### PR TITLE
[BE] 히어릿 리스트 조회 API (탐색 탭) #27

### DIFF
--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -1,0 +1,26 @@
+package com.onair.hearit.application;
+
+import com.onair.hearit.dto.response.HearitExploreResponse;
+import com.onair.hearit.infrastructure.HearitRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HearitService {
+
+    private static final int MAX_EXPLORE_COUNT = 5;
+
+    private final HearitRepository hearitRepository;
+
+    public List<HearitExploreResponse> getExploredHearits() {
+        Pageable pageable = PageRequest.of(0, MAX_EXPLORE_COUNT);
+
+        return hearitRepository.findRandom(pageable).stream()
+                .map(HearitExploreResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/domain/Category.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Category.java
@@ -22,4 +22,8 @@ public class Category {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    public Category(String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Hearit.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Hearit.java
@@ -37,11 +37,17 @@ public class Hearit {
     @Column(name = "play_time", nullable = false)
     private Integer playTime;
 
-    @Column(name = "audio_url", nullable = false)
-    private String audioUrl;
+    @Column(name = "original_audio_url", nullable = false)
+    private String originalAudioUrl;
+
+    @Column(name = "short_audio_url", nullable = false)
+    private String shortAudioUrl;
 
     @Column(name = "script_url", nullable = false)
     private String scriptUrl;
+
+    @Column(name = "source")
+    private String source;
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -50,4 +56,17 @@ public class Hearit {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
+
+    public Hearit(String title, String summary, Integer playTime, String originalAudioUrl, String shortAudioUrl,
+                  String scriptUrl, String source, LocalDateTime createdAt, Category category) {
+        this.title = title;
+        this.summary = summary;
+        this.playTime = playTime;
+        this.originalAudioUrl = originalAudioUrl;
+        this.shortAudioUrl = shortAudioUrl;
+        this.scriptUrl = scriptUrl;
+        this.source = source;
+        this.createdAt = createdAt;
+        this.category = category;
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/dto/response/HearitExploreResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/HearitExploreResponse.java
@@ -1,0 +1,15 @@
+package com.onair.hearit.dto.response;
+
+import com.onair.hearit.domain.Hearit;
+
+public record HearitExploreResponse(
+        String title,
+        String summary) {
+
+    public static HearitExploreResponse from(Hearit hearit) {
+        return new HearitExploreResponse(
+                hearit.getTitle(),
+                hearit.getSummary()
+        );
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
@@ -1,7 +1,13 @@
 package com.onair.hearit.infrastructure;
 
 import com.onair.hearit.domain.Hearit;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface HearitRepository extends JpaRepository<Hearit, Long> {
+
+    @Query("SELECT h FROM Hearit h ORDER BY function('RAND')")
+    List<Hearit> findRandom(Pageable pageable);
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -1,0 +1,23 @@
+package com.onair.hearit.presentation;
+
+import com.onair.hearit.application.HearitService;
+import com.onair.hearit.dto.response.HearitExploreResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/hearit")
+public class HearitController {
+
+    private final HearitService hearitService;
+
+    @GetMapping("/random")
+    public ResponseEntity<List<HearitExploreResponse>> readExploredHearits() {
+        return ResponseEntity.ok(hearitService.getExploredHearits());
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -1,0 +1,57 @@
+package com.onair.hearit.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.dto.response.HearitExploreResponse;
+import com.onair.hearit.infrastructure.CategoryRepository;
+import com.onair.hearit.infrastructure.HearitRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class HearitServiceTest {
+
+    @Autowired
+    private HearitRepository hearitRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private HearitService hearitService;
+
+    @BeforeEach
+    void setUp() {
+        hearitService = new HearitService(hearitRepository);
+    }
+
+    @Test
+    @DisplayName("최대 탐색 개수인 5개의 랜덤 히어릿을 조회할 수 있다.")
+    void findByMemberId() {
+        // given
+        for (int i = 1; i <= 6; i++) {
+            saveHearit(i);
+        }
+
+        // when
+        List<HearitExploreResponse> hearits = hearitService.getExploredHearits();
+
+        // then
+        assertThat(hearits).hasSize(5);
+    }
+
+    private Hearit saveHearit(int num) {
+        Category category = new Category("name" + num);
+        categoryRepository.save(category);
+
+        Hearit hearit = new Hearit("title" + num, "summary" + num, num, "originalAudioUrl" + num, "shortAudioUrl" + num,
+                "scriptUrl" + num, "source" + num, LocalDateTime.now(), category);
+        return hearitRepository.save(hearit);
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.onair.hearit.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+class HearitRepositoryTest {
+
+    @Autowired
+    private HearitRepository hearitRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Test
+    @DisplayName("원하는 개수만큼 랜덤 히어릿을 조회할 수 있다.")
+    void findByMemberId() {
+        // given
+        saveHearit(1);
+        saveHearit(2);
+
+        Pageable pageable = PageRequest.of(0, 1);
+
+        // when
+        List<Hearit> hearits = hearitRepository.findRandom(pageable);
+
+        // then
+        assertAll(() -> {
+            assertThat(hearits).hasSize(1);
+            assertThat(hearitRepository.findAll()).hasSize(2);
+        });
+    }
+
+    private Hearit saveHearit(int num) {
+        Category category = new Category("name" + num);
+        categoryRepository.save(category);
+
+        Hearit hearit = new Hearit("title" + num, "summary" + num, num, "originalAudioUrl" + num, "shortAudioUrl" + num,
+                "scriptUrl" + num, "source" + num, LocalDateTime.now(), category);
+        return hearitRepository.save(hearit);
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -5,4 +5,5 @@ spring.datasource.password=
 
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 히어릿 리스트 조회 API (탐색 탭)을 위해 랜덤 히어릿을 MAX 개수만큼 조회합니다.

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
쿼리만 추가해서 Repository와 Service 테스트만 간단히 진행했습니다.

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #27
