### PR TITLE
[BE] MySQL 도커 컨테이너 미실행으로 인한 CI 테스트 실패 문제 수정

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -68,7 +68,7 @@ jobs:
           done
 
       - name: Run Tests
-        run: ./gradlew test -Dspring.profiles.active=dev
+        run: ./gradlew test
 
       - name: Build with Gradle
         run: ./gradlew build -x test

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,7 +24,7 @@ jobs:
           MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
           TZ: Asia/Seoul
         ports:
-          - "${{ secrets.MYSQL_PORT }}:3306"
+          - "${{ secrets.TEST_MYSQL_PORT }}:3306"
         options: >-
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
@@ -63,7 +63,7 @@ jobs:
       - name: Wait for MySQL to be ready
         run: |
           for i in {1..10}; do
-            nc -zv 127.0.0.1 ${{ secrets.MYSQL_PORT }} && echo "MySQL is up!" && break
+            nc -zv 127.0.0.1 ${{ secrets.TEST_MYSQL_PORT }} && echo "MySQL is up!" && break
             echo "Waiting for MySQL..." && sleep 5
           done
 

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -14,6 +14,23 @@ jobs:
     name: CI Build
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+          MYSQL_USER: ${{ secrets.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          TZ: Asia/Seoul
+        ports:
+          - "${{ secrets.MYSQL_PORT }}:3306"
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     defaults:
       run:
         working-directory: backend
@@ -43,8 +60,15 @@ jobs:
           amazon.s3.bucket.url=${{ secrets.AMAZON_S3_BUCKET_URL }}
           EOF
 
+      - name: Wait for MySQL to be ready
+        run: |
+          for i in {1..10}; do
+            nc -zv 127.0.0.1 ${{ secrets.MYSQL_PORT }} && echo "MySQL is up!" && break
+            echo "Waiting for MySQL..." && sleep 5
+          done
+
       - name: Run Tests
-        run: ./gradlew test
+        run: ./gradlew test -Dspring.profiles.active=dev
 
       - name: Build with Gradle
         run: ./gradlew build -x test


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- CI 환경에서 `./gradlew test` 실행 시 MySQL 연결 오류 발생했다.
- 이를 해결하기 위해 `services.mysql` 설정을 추가하여 CI 단계에서 MySQL 도커 컨테이너가 함께 실행되도록 설정했다.
- `주요 DB 환경 변수는 GitHub Secrets로 관리한다.
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #52 