### PR TITLE
[BE] CI 테스트용 DB 포트 하드코딩 처리

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,7 +24,7 @@ jobs:
           MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
           TZ: Asia/Seoul
         ports:
-          - "${{ secrets.TEST_MYSQL_PORT }}:3306"
+          - "13307:3306"
         options: >-
           --health-cmd="mysqladmin ping --silent"
           --health-interval=10s
@@ -63,7 +63,7 @@ jobs:
       - name: Wait for MySQL to be ready
         run: |
           for i in {1..10}; do
-            nc -zv 127.0.0.1 ${{ secrets.TEST_MYSQL_PORT }} && echo "MySQL is up!" && break
+            nc -zv 127.0.0.1 13307 && echo "MySQL is up!" && break
             echo "Waiting for MySQL..." && sleep 5
           done
 


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- GitHub Actions CI에서 테스트 실행 시 사용할 MySQL 컨테이너의 포트를 `${{ secrets.TEST_MYSQL_PORT }}`로 설정하려 했으나,
  `services.ports` 섹션에서는 secrets 변수 사용이 불가능하여 워크플로우 실행 오류 발생
- 이에 따라 포트 번호 `13307`을 하드코딩하여 직접 명시
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #58 