### PR TITLE
[BE] CI 버그 수정 & application-secret.properties 폐기

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,65 +10,47 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: CI Build
+  integration-test:
     runs-on: ubuntu-latest
 
+    defaults:
+          run:
+            working-directory: backend
+            
     services:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
-          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
-          MYSQL_USER: ${{ secrets.MYSQL_USER }}
-          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
-          TZ: Asia/Seoul
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: hearit_db
         ports:
-          - "13307:3306"
+          - 13307:3306
         options: >-
-          --health-cmd="mysqladmin ping --silent"
+          --health-cmd="mysqladmin ping -uroot -proot"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
 
-    defaults:
-      run:
-        working-directory: backend
+    env:
+      MYSQL_ROOT_PASSWORD: root
+      TEST_MYSQL_PORT: 13307
+      db.mysql.host: localhost:13307
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          distribution: temurin
+          java-version: 21
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          gradle-version: current
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
 
-      - name: Generate application-secret.properties
-        run: |
-          mkdir -p src/main/resources
-          cat <<EOF > src/main/resources/application-secret.properties
-          mysql.root.password=${{ secrets.MYSQL_ROOT_PASSWORD }}
-          jwt.secret=${{ secrets.JWT_SECRET }}
-          jwt.expiration=${{ secrets.JWT_EXPIRATION }}
-          server.port=${{ secrets.SERVER_PORT }}
-          amazon.s3.bucket.url=${{ secrets.AMAZON_S3_BUCKET_URL }}
-          EOF
-
-      - name: Wait for MySQL to be ready
-        run: |
-          for i in {1..10}; do
-            nc -zv 127.0.0.1 13307 && echo "MySQL is up!" && break
-            echo "Waiting for MySQL..." && sleep 5
-          done
-
-      - name: Run Tests
+      - name: Run tests
         run: ./gradlew test
-
+      
       - name: Build with Gradle
         run: ./gradlew build -x test

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,4 +38,3 @@ out/
 
 .DS_store
 .env
-application-secret.properties

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "${TEST_MYSQL_PORT}:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -1,10 +1,10 @@
 # secret import
-spring.config.import=application-secret.properties
+spring.config.import=optional:file:.env[.properties]
 
 # Dev-DataSource
 spring.datasource.url=jdbc:mysql://localhost:13306/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=${mysql.root.password}
+spring.datasource.password=${MYSQL_ROOT_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA
@@ -15,5 +15,8 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
+# Server Port
+server.port=80
+
 # S3 public URL
-amazon.s3.bucket=${amazon.s3.bucket.url}
+amazon.s3.bucket=${AMAZON_S3_BUCKET_URL}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=hEARit
-#spring.profiles.active=dev
-spring.config.import=application-secret.properties
+
+spring.profiles.active=dev
+
 # JPA Auditing
 spring.jpa.properties.hibernate.jdbc.time_zone=Asia/Seoul

--- a/backend/src/test/resources/application-integration-test.properties
+++ b/backend/src/test/resources/application-integration-test.properties
@@ -1,10 +1,7 @@
-# secret import
-spring.config.import=application-secret.properties
-
 # Dev-DataSource
-spring.datasource.url=jdbc:mysql://${db.mysql.host}/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.url=jdbc:mysql://localhost:13307/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=${mysql.root.password}
+spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

더이상 보안 정보를 secret.properties에 담지 않습니다.
.env로 변수 주입을 통합합니다.

아래 코드를 통해 application.properties 등에서도 .env를 로컬환경에서 직접 주입할 수 있습니다.
`spring.config.import=optional:file:.env[.properties]`

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
Action에서 확인
.env 노션에서 업데이트할것

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#71 