### PR TITLE
[BE] 랜덤/추천 히어릿 리스트 조회 API

### DIFF
--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -4,7 +4,6 @@ import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.HearitDetailResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -16,8 +15,7 @@ import org.springframework.stereotype.Service;
 public class HearitService {
 
     private static final int MAX_EXPLORE_COUNT = 10;
-    private static final int MAX_TODAY_HEARIT_COUNT = 4;
-    private static final long TODAY_RECOMMEND_HEARIT = 1L;
+    private static final int MAX_RECOMMEND_HEARIT_COUNT = 5;
 
     private final HearitRepository hearitRepository;
 
@@ -26,7 +24,7 @@ public class HearitService {
         return HearitDetailResponse.from(hearit);
     }
 
-    public List<HearitDetailResponse> getExploredHearits() {
+    public List<HearitDetailResponse> getRandomHearits() {
         Pageable pageable = PageRequest.of(0, MAX_EXPLORE_COUNT);
 
         return hearitRepository.findRandom(pageable).stream()
@@ -34,14 +32,10 @@ public class HearitService {
                 .toList();
     }
 
-    public List<HearitDetailResponse> getTodayHearits() {
-        Pageable pageable = PageRequest.of(0, MAX_TODAY_HEARIT_COUNT);
+    public List<HearitDetailResponse> getRecommendedHearits() {
+        Pageable pageable = PageRequest.of(0, MAX_RECOMMEND_HEARIT_COUNT);
 
-        List<Hearit> hearits = new ArrayList<>();
-        hearits.add(getHearitById(TODAY_RECOMMEND_HEARIT));
-        hearits.addAll(hearitRepository.findRandom(pageable));
-
-        return hearits.stream()
+        return hearitRepository.findRandom(pageable).stream()
                 .map(HearitDetailResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -4,18 +4,31 @@ import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.HearitDetailResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class HearitService {
 
+    private static final int MAX_EXPLORE_COUNT = 10;
+
     private final HearitRepository hearitRepository;
 
     public HearitDetailResponse getHearitDetail(Long hearitId) {
         Hearit hearit = getHearitById(hearitId);
         return HearitDetailResponse.from(hearit);
+    }
+
+    public List<HearitDetailResponse> getExploredHearits() {
+        Pageable pageable = PageRequest.of(0, MAX_EXPLORE_COUNT);
+
+        return hearitRepository.findRandom(pageable).stream()
+                .map(HearitDetailResponse::from)
+                .toList();
     }
 
     private Hearit getHearitById(Long hearitId) {

--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -4,6 +4,7 @@ import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.HearitDetailResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -15,6 +16,8 @@ import org.springframework.stereotype.Service;
 public class HearitService {
 
     private static final int MAX_EXPLORE_COUNT = 10;
+    private static final int MAX_TODAY_HEARIT_COUNT = 4;
+    private static final long TODAY_RECOMMEND_HEARIT = 1L;
 
     private final HearitRepository hearitRepository;
 
@@ -27,6 +30,18 @@ public class HearitService {
         Pageable pageable = PageRequest.of(0, MAX_EXPLORE_COUNT);
 
         return hearitRepository.findRandom(pageable).stream()
+                .map(HearitDetailResponse::from)
+                .toList();
+    }
+
+    public List<HearitDetailResponse> getTodayHearits() {
+        Pageable pageable = PageRequest.of(0, MAX_TODAY_HEARIT_COUNT);
+
+        List<Hearit> hearits = new ArrayList<>();
+        hearits.add(getHearitById(TODAY_RECOMMEND_HEARIT));
+        hearits.addAll(hearitRepository.findRandom(pageable));
+
+        return hearits.stream()
                 .map(HearitDetailResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
@@ -1,7 +1,13 @@
 package com.onair.hearit.infrastructure;
 
 import com.onair.hearit.domain.Hearit;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface HearitRepository extends JpaRepository<Hearit, Long> {
+
+    @Query("SELECT h FROM Hearit h ORDER BY function('RAND')")
+    List<Hearit> findRandom(Pageable pageable);
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -2,6 +2,7 @@ package com.onair.hearit.presentation;
 
 import com.onair.hearit.application.HearitService;
 import com.onair.hearit.dto.response.HearitDetailResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,5 +21,11 @@ public class HearitController {
     public ResponseEntity<HearitDetailResponse> readHearit(@PathVariable Long hearitId) {
         HearitDetailResponse response = hearitService.getHearitDetail(hearitId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/random")
+    public ResponseEntity<List<HearitDetailResponse>> readExploredHearits() {
+        List<HearitDetailResponse> responses = hearitService.getExploredHearits();
+        return ResponseEntity.ok(responses);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -24,8 +24,14 @@ public class HearitController {
     }
 
     @GetMapping("/random")
-    public ResponseEntity<List<HearitDetailResponse>> readExploredHearits() {
-        List<HearitDetailResponse> responses = hearitService.getExploredHearits();
+    public ResponseEntity<List<HearitDetailResponse>> readRandomHearits() {
+        List<HearitDetailResponse> responses = hearitService.getRandomHearits();
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/recommend")
+    public ResponseEntity<List<HearitDetailResponse>> readRecommendedHearits() {
+        List<HearitDetailResponse> responses = hearitService.getRecommendedHearits();
         return ResponseEntity.ok(responses);
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -69,7 +69,7 @@ class HearitServiceTest {
     }
 
     @Test
-    @DisplayName("최대 10개의  랜덤 히어릿을 조회할 수 있다.")
+    @DisplayName("최대 10개의 랜덤 히어릿을 조회할 수 있다.")
     void getRandomHearits() {
         // given
         IntStream.rangeClosed(1, 11)

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -11,6 +11,8 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.HearitDetailResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -64,6 +66,20 @@ class HearitServiceTest {
         assertThatThrownBy(() -> hearitService.getHearitDetail(notExistHearitId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("hearitId");
+    }
+
+    @Test
+    @DisplayName("최대 탐색 개수인 10개의 랜덤 히어릿을 조회할 수 있다.")
+    void findByMemberId() {
+        // given
+        IntStream.rangeClosed(1, 11)
+                .forEach(this::saveHearitWithSuffix);
+
+        // when
+        List<HearitDetailResponse> hearits = hearitService.getExploredHearits();
+
+        // then
+        assertThat(hearits).hasSize(10);
     }
 
     private Hearit saveHearitWithSuffix(int suffix) {

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -69,28 +69,28 @@ class HearitServiceTest {
     }
 
     @Test
-    @DisplayName("최대 탐색 개수인 10개의 랜덤 히어릿을 조회할 수 있다.")
-    void getExploredHearits() {
+    @DisplayName("최대 10개의  랜덤 히어릿을 조회할 수 있다.")
+    void getRandomHearits() {
         // given
         IntStream.rangeClosed(1, 11)
                 .forEach(this::saveHearitWithSuffix);
 
         // when
-        List<HearitDetailResponse> hearits = hearitService.getExploredHearits();
+        List<HearitDetailResponse> hearits = hearitService.getRandomHearits();
 
         // then
         assertThat(hearits).hasSize(10);
     }
 
     @Test
-    @DisplayName("최대 탐색 개수인 5개의 오늘의 히어릿을 조회할 수 있다.")
-    void getTodayHearits() {
+    @DisplayName("최대 5개의 추천 히어릿을 조회할 수 있다.")
+    void getRecommendedHearits() {
         // given
         IntStream.rangeClosed(1, 6)
                 .forEach(this::saveHearitWithSuffix);
 
         // when
-        List<HearitDetailResponse> hearits = hearitService.getTodayHearits();
+        List<HearitDetailResponse> hearits = hearitService.getRecommendedHearits();
 
         // then
         assertThat(hearits).hasSize(5);

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -70,7 +70,7 @@ class HearitServiceTest {
 
     @Test
     @DisplayName("최대 탐색 개수인 10개의 랜덤 히어릿을 조회할 수 있다.")
-    void findByMemberId() {
+    void getExploredHearits() {
         // given
         IntStream.rangeClosed(1, 11)
                 .forEach(this::saveHearitWithSuffix);
@@ -80,6 +80,20 @@ class HearitServiceTest {
 
         // then
         assertThat(hearits).hasSize(10);
+    }
+
+    @Test
+    @DisplayName("최대 탐색 개수인 5개의 오늘의 히어릿을 조회할 수 있다.")
+    void getTodayHearits() {
+        // given
+        IntStream.rangeClosed(1, 6)
+                .forEach(this::saveHearitWithSuffix);
+
+        // when
+        List<HearitDetailResponse> hearits = hearitService.getTodayHearits();
+
+        // then
+        assertThat(hearits).hasSize(5);
     }
 
     private Hearit saveHearitWithSuffix(int suffix) {

--- a/backend/src/test/java/com/onair/hearit/auth/Infrastructure/client/KakaoUserInfoClientTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/Infrastructure/client/KakaoUserInfoClientTest.java
@@ -16,7 +16,7 @@ class KakaoUserInfoClientTest extends IntegrationTest {
     @Disabled("실제 카카오 외부 API를 호출하는 테스트-필요시 활성화")
     @Test
     @DisplayName("실제 카카오 API를 호출하여 사용자정보를 가져온다.")
-    void 실제_카카오_API_호출하여_사용자정보를_가져온다() {
+    void fetchUserInfo_usingRealKakaoApi() {
         String kakaoAccessToken = "yC5CmZ1kj1jHcCICRBWX_dvbXIMqfn8rAAAAAQoXBi4AAAGYE03XhpQkbXeV0h_w";
 
         KakaoUserInfoResponse response = kakaoUserInfoClient.getUserInfo(kakaoAccessToken);

--- a/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
@@ -20,7 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 @DataJpaTest
 @Import(DbHelper.class)
 @ActiveProfiles("fake-test")
-public class HearitRepositoryTest {
+class HearitRepositoryTest {
 
     @Autowired
     private DbHelper dbHelper;

--- a/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.onair.hearit.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.DbHelper;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(DbHelper.class)
+@ActiveProfiles("fake-test")
+public class HearitRepositoryTest {
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Autowired
+    private HearitRepository hearitRepository;
+
+    @Test
+    @DisplayName("원하는 개수만큼 랜덤 히어릿을 조회할 수 있다.")
+    void findRandom() {
+        // given
+        saveHearitWithSuffix(1);
+        saveHearitWithSuffix(2);
+
+        Pageable pageable = PageRequest.of(0, 1);
+
+        // when
+        List<Hearit> hearits = hearitRepository.findRandom(pageable);
+
+        // then
+        assertAll(() -> {
+            assertThat(hearits).hasSize(1);
+            assertThat(hearitRepository.findAll()).hasSize(2);
+        });
+    }
+
+    @Test
+    @DisplayName("전체 히어릿 개수 < 원하는 개수면 전체 히어릿을 모두 조회할 수 있다.")
+    void findRandomWithAllHearits() {
+        // given
+        saveHearitWithSuffix(1);
+
+        Pageable pageable = PageRequest.of(0, 2);
+
+        // when
+        List<Hearit> hearits = hearitRepository.findRandom(pageable);
+
+        // then
+        assertThat(hearits.size()).isEqualTo(hearitRepository.findAll().size());
+    }
+
+    private Hearit saveHearitWithSuffix(int suffix) {
+        Category category = new Category("name" + suffix);
+        dbHelper.insertCategory(category);
+
+        Hearit hearit = new Hearit(
+                "title" + suffix,
+                "summary" + suffix, suffix,
+                "originalAudioUrl" + suffix,
+                "shortAudioUrl" + suffix,
+                "scriptUrl" + suffix,
+                "source" + suffix,
+                LocalDateTime.now(),
+                category);
+        return dbHelper.insertHearit(hearit);
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -44,7 +44,7 @@ class HearitControllerTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("랜덤 히어릿을 조회 시, 200 OK 및 히어릿 정보 목록을 제공한다.")
+    @DisplayName("랜덤 히어릿을 조회 시, 200 OK 및 최대 10개 히어릿 정보 목록을 제공한다.")
     void readRandomHearits() {
         // given
         saveHearitWithSuffix(1);
@@ -66,8 +66,8 @@ class HearitControllerTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("추천 히어릿을 조회 시, 200 OK 및 히어릿 정보 목록을 제공한다.")
-    void readTodayHearits() {
+    @DisplayName("추천 히어릿을 조회 시, 200 OK 및 최대 5개 히어릿 정보 목록을 제공한다.")
+    void readRecommendedHearits() {
         // given
         saveHearitWithSuffix(1);
         saveHearitWithSuffix(2);

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -7,6 +7,7 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.HearitDetailResponse;
 import io.restassured.RestAssured;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -40,6 +41,28 @@ class HearitControllerTest extends IntegrationTest {
                 .get("/api/v1/hearits/" + notFoundHearitId)
                 .then()
                 .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("랜덤 히어릿을 조회 시, 200 OK 및 히어릿 정보 목록을 제공한다.")
+    void readExploredHearits() {
+        // given
+        saveHearitWithSuffix(1);
+        saveHearitWithSuffix(2);
+        saveHearitWithSuffix(3);
+
+        // when
+        List<HearitDetailResponse> responses = RestAssured.given()
+                .when()
+                .get("/api/v1/hearits/random")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList(".", HearitDetailResponse.class);
+
+        // then
+        assertThat(responses).hasSize(3);
     }
 
     private Hearit saveHearitWithSuffix(int suffix) {

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -45,7 +45,7 @@ class HearitControllerTest extends IntegrationTest {
 
     @Test
     @DisplayName("랜덤 히어릿을 조회 시, 200 OK 및 히어릿 정보 목록을 제공한다.")
-    void readExploredHearits() {
+    void readRandomHearits() {
         // given
         saveHearitWithSuffix(1);
         saveHearitWithSuffix(2);
@@ -55,6 +55,28 @@ class HearitControllerTest extends IntegrationTest {
         List<HearitDetailResponse> responses = RestAssured.given()
                 .when()
                 .get("/api/v1/hearits/random")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList(".", HearitDetailResponse.class);
+
+        // then
+        assertThat(responses).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("추천 히어릿을 조회 시, 200 OK 및 히어릿 정보 목록을 제공한다.")
+    void readTodayHearits() {
+        // given
+        saveHearitWithSuffix(1);
+        saveHearitWithSuffix(2);
+        saveHearitWithSuffix(3);
+
+        // when
+        List<HearitDetailResponse> responses = RestAssured.given()
+                .when()
+                .get("/api/v1/hearits/recommend")
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract()


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 랜덤 히어릿 10개 조회 API 추가
- 추천 히어릿 5개 조회 API 추가

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->
추천 히어릿에서 인덱스 고정 방식 구현이, 기본 데이터가 없어서 구현하지 못했습니다.
추후 기획 논의 후, 추천 방식에 대해 고민하면 좋을 것 같습니다.

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #44 
