### PR TITLE
[BE] Swagger UI 설정 및 문서 기본 설명 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api'
 
     // Test
-    testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner:4.2.1'
+    testImplementation 'org.springframework.cloud:spring-cloud-starter-contract-stub-runner'
     testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -49,6 +49,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    //Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/onair/hearit/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/onair/hearit/auth/config/SecurityConfig.java
@@ -34,9 +34,13 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         //TODO: 추후 허용되는 api만 여는 화이트리스트 방식으로 변경해야됨 지금은 다 열어둠
                         .requestMatchers("/api/v1/**").permitAll()
+                        .requestMatchers("/docs").permitAll()
+                        .requestMatchers("/swagger-ui/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
@@ -5,6 +5,8 @@ import com.onair.hearit.auth.dto.request.KakaoLoginRequest;
 import com.onair.hearit.auth.dto.request.LoginRequest;
 import com.onair.hearit.auth.dto.request.SignupRequest;
 import com.onair.hearit.auth.dto.response.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,22 +17,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
+@Tag(name = "Auth", description = "사용자 인증")
 public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "일반 로그인", description = "아이디/비밀번호로 로그인하여 토큰을 발급받습니다.")
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
         TokenResponse response = authService.login(request);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "카카오 로그인", description = "카카오 액세스토큰으로 로그인 시 토큰을 발급받습니다.")
     @PostMapping("/kakao-login")
     public ResponseEntity<TokenResponse> loginWithKakao(@RequestBody KakaoLoginRequest request) {
         TokenResponse response = authService.loginWithKakao(request);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "회원가입", description = "새로운 계정을 생성합니다.")
     @PostMapping("/signup")
     public ResponseEntity<Void> signup(@RequestBody SignupRequest request) {
         authService.signup(request);

--- a/backend/src/main/java/com/onair/hearit/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/onair/hearit/common/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package com.onair.hearit.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                        )
+                )
+                .info(new Info()
+                        .title("Hearit API")
+                        .description("히어잇 백엔드 API 문서")
+                        .version("v1"));
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/onair/hearit/common/config/SwaggerConfig.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -23,6 +25,10 @@ public class SwaggerConfig {
                 .info(new Info()
                         .title("Hearit API")
                         .description("히어잇 백엔드 API 문서")
-                        .version("v1"));
+                        .version("v1"))
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("로컬 서버"),
+                        new Server().url("http://hearit.o-r.kr").description("운영 서버")
+                ));
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/FileSourceController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/FileSourceController.java
@@ -4,6 +4,8 @@ import com.onair.hearit.application.FileSourceService;
 import com.onair.hearit.dto.response.OriginalAudioResponse;
 import com.onair.hearit.dto.response.ScriptResponse;
 import com.onair.hearit.dto.response.ShortAudioResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,22 +16,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/hearits")
+@Tag(name = "FileSource", description = "오디오 및 스크립트 파일")
 public class FileSourceController {
 
     private final FileSourceService fileSourceService;
 
+    @Operation(summary = "원본 오디오 파일 조회", description = "히어릿ID룰 통해 원본 오디오 파일을 조회합니다.")
     @GetMapping("/{hearitId}/original-audio-url")
     public ResponseEntity<OriginalAudioResponse> readOriginalAudioUrl(@PathVariable Long hearitId) {
         OriginalAudioResponse response = fileSourceService.getOriginalAudio(hearitId);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "1분 미리보기 오디오 파일 조회", description = "히어릿ID룰 통해 1분 미리보기 오디오 파일을 조회합니다.")
     @GetMapping("/{hearitId}/short-audio-url")
     public ResponseEntity<ShortAudioResponse> readShortAudioUrl(@PathVariable Long hearitId) {
         ShortAudioResponse response = fileSourceService.getShortAudio(hearitId);
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "스크립트 파일 조회", description = "히어릿ID룰 통해 스크립트 파일을 조회합니다.")
     @GetMapping("/{hearitId}/script-url")
     public ResponseEntity<ScriptResponse> readScriptUrl(@PathVariable Long hearitId) {
         ScriptResponse response = fileSourceService.getScript(hearitId);

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -2,6 +2,8 @@ package com.onair.hearit.presentation;
 
 import com.onair.hearit.application.HearitService;
 import com.onair.hearit.dto.response.HearitDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,10 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/hearits")
+@Tag(name = "Hearit", description = "히어릿")
 public class HearitController {
 
     private final HearitService hearitService;
 
+    @Operation(summary = "단일 히어릿 상세 조회", description = "히어릿ID룰 통해 하나의 히어릿 상세 정보를 조회합니다.")
     @GetMapping("/{hearitId}")
     public ResponseEntity<HearitDetailResponse> readHearit(@PathVariable Long hearitId) {
         HearitDetailResponse response = hearitService.getHearitDetail(hearitId);

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -9,7 +9,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.defer-datasource-initialization=true
@@ -27,3 +27,10 @@ jwt.expiration=${JWT_EXPIRATION}
 
 # kakao base-url
 kakao.user-info.base-url=https://kapi.kakao.com
+
+# Swagger
+springdoc.default-produces-media-type=application/json
+springdoc.swagger-ui.path=/docs
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.display-request-duration=true


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

- Swagger UI를 통한 API 문서화
- application-dev.properteis의 ddl-auto 설정 create로 변경
    - Entity 변경 시 create 되어야하므로

## 📸 스크린샷 (선택)

<img width="1379" height="775" alt="image" src="https://github.com/user-attachments/assets/6fb14402-3f15-4e1a-bb0a-1029a637211d" />

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

- Application 로컬에서 돌린 후 /docs 혹은 /swagger-ui/index.html 로 접근하면 확인 가능

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->
없습니다

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #78