### PR TITLE
[BE] 북마크 API 구현

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   hearit-prod-db:
     image: mysql:8.0

--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -2,12 +2,14 @@ package com.onair.hearit.application;
 
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
 import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.infrastructure.BookmarkRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
 import com.onair.hearit.infrastructure.MemberRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,22 +21,38 @@ public class BookmarkService {
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
 
+    @Transactional
     public void addBookmark(Long hearitId, Long memberId) {
-        if(bookmarkRepository.existsByHearitIdAndMemberId(hearitId, memberId)) {
+        if (bookmarkRepository.existsByHearitIdAndMemberId(hearitId, memberId)) {
             throw new AlreadyExistException("이미 북마크가 존재합니다.");
         }
-        Hearit hearit = findHearitById(hearitId);
-        Member member = findMemberById(memberId);
+        Hearit hearit = getHearitById(hearitId);
+        Member member = getMemberById(memberId);
         Bookmark bookmark = new Bookmark(member, hearit);
         bookmarkRepository.save(bookmark);
     }
 
-    private Hearit findHearitById(Long hearitId) {
+    @Transactional
+    public void deleteBookmark(Long bookmarkId, Long memberId) {
+        Bookmark bookmark = getBookmarkById(bookmarkId);
+        Member member = getMemberById(memberId);
+        if (bookmark.isCreatedBy(member)) {
+            bookmarkRepository.delete(bookmark);
+        }
+        throw new UnauthorizedException("북마크를 삭제할 권한이 없습니다.");
+    }
+
+    private Bookmark getBookmarkById(Long bookmarkId) {
+        return bookmarkRepository.findById(bookmarkId)
+                .orElseThrow(() -> new NotFoundException("bookmarkId", bookmarkId.toString()));
+    }
+
+    private Hearit getHearitById(Long hearitId) {
         return hearitRepository.findById(hearitId)
                 .orElseThrow(() -> new NotFoundException("hearitId", hearitId.toString()));
     }
 
-    private Member findMemberById(Long memberId) {
+    private Member getMemberById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
     }

--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -48,6 +48,7 @@ public class BookmarkService {
         Member member = getMemberById(memberId);
         if (bookmark.isCreatedBy(member)) {
             bookmarkRepository.delete(bookmark);
+            return;
         }
         throw new UnauthorizedException("북마크를 삭제할 권한이 없습니다.");
     }

--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -1,0 +1,41 @@
+package com.onair.hearit.application;
+
+import com.onair.hearit.common.exception.custom.AlreadyExistException;
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.domain.Bookmark;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.infrastructure.BookmarkRepository;
+import com.onair.hearit.infrastructure.HearitRepository;
+import com.onair.hearit.infrastructure.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final HearitRepository hearitRepository;
+    private final MemberRepository memberRepository;
+    private final BookmarkRepository bookmarkRepository;
+
+    public void addBookmark(Long hearitId, Long memberId) {
+        if(bookmarkRepository.existsByHearitIdAndMemberId(hearitId, memberId)) {
+            throw new AlreadyExistException("이미 북마크가 존재합니다.");
+        }
+        Hearit hearit = findHearitById(hearitId);
+        Member member = findMemberById(memberId);
+        Bookmark bookmark = new Bookmark(member, hearit);
+        bookmarkRepository.save(bookmark);
+    }
+
+    private Hearit findHearitById(Long hearitId) {
+        return hearitRepository.findById(hearitId)
+                .orElseThrow(() -> new NotFoundException("hearitId", hearitId.toString()));
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -13,6 +13,8 @@ import com.onair.hearit.infrastructure.MemberRepository;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,9 +25,10 @@ public class BookmarkService {
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public List<BookmarkHearitResponse> getBookmarkHearits(Long memberId) {
+    public List<BookmarkHearitResponse> getBookmarkHearits(Long memberId, int page, int size) {
         Member member = getMemberById(memberId);
-        List<Bookmark> bookmarks = bookmarkRepository.findAllByMember(member);
+        Pageable pageable = PageRequest.of(page, size);
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByCreatedAtDesc(member, pageable);
         return bookmarks.stream()
                 .map(BookmarkHearitResponse::from)
                 .toList();

--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -6,10 +6,12 @@ import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.Member;
+import com.onair.hearit.dto.response.BookmarkHearitResponse;
 import com.onair.hearit.infrastructure.BookmarkRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
 import com.onair.hearit.infrastructure.MemberRepository;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +22,14 @@ public class BookmarkService {
     private final HearitRepository hearitRepository;
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
+
+    public List<BookmarkHearitResponse> getBookmarkHearits(Long memberId) {
+        Member member = getMemberById(memberId);
+        List<Bookmark> bookmarks = bookmarkRepository.findAllByMember(member);
+        return bookmarks.stream()
+                .map(BookmarkHearitResponse::from)
+                .toList();
+    }
 
     @Transactional
     public void addBookmark(Long hearitId, Long memberId) {
@@ -42,6 +52,11 @@ public class BookmarkService {
         throw new UnauthorizedException("북마크를 삭제할 권한이 없습니다.");
     }
 
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
+    }
+
     private Bookmark getBookmarkById(Long bookmarkId) {
         return bookmarkRepository.findById(bookmarkId)
                 .orElseThrow(() -> new NotFoundException("bookmarkId", bookmarkId.toString()));
@@ -50,10 +65,5 @@ public class BookmarkService {
     private Hearit getHearitById(Long hearitId) {
         return hearitRepository.findById(hearitId)
                 .orElseThrow(() -> new NotFoundException("hearitId", hearitId.toString()));
-    }
-
-    private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
     }
 }

--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -3,6 +3,8 @@ package com.onair.hearit.application;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.HearitDetailResponse;
+import com.onair.hearit.dto.response.HearitPersonalDetailResponse;
+import com.onair.hearit.infrastructure.BookmarkRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,10 +14,17 @@ import org.springframework.stereotype.Service;
 public class HearitService {
 
     private final HearitRepository hearitRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     public HearitDetailResponse getHearitDetail(Long hearitId) {
         Hearit hearit = getHearitById(hearitId);
         return HearitDetailResponse.from(hearit);
+    }
+
+    public HearitPersonalDetailResponse getHearitPersonalDetail(Long hearitId, Long memberId) {
+        Hearit hearit = getHearitById(hearitId);
+        Boolean isBookmarked = bookmarkRepository.existsByHearitIdAndMemberId(hearitId, memberId);
+        return HearitPersonalDetailResponse.of(hearit, isBookmarked);
     }
 
     private Hearit getHearitById(Long hearitId) {

--- a/backend/src/main/java/com/onair/hearit/auth/Infrastructure/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/onair/hearit/auth/Infrastructure/jwt/JwtTokenProvider.java
@@ -37,7 +37,7 @@ public class JwtTokenProvider {
     }
 
     public boolean validateToken(String token) {
-        if(token == null || token.isBlank()) {
+        if (token == null || token.isBlank()) {
             return false;
         }
 

--- a/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
+++ b/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
@@ -36,7 +36,7 @@ public class AuthService {
     }
 
     private void validatePassword(LoginRequest request, Member member) {
-        if(!passwordEncoder.matches(request.password(), member.getPassword())) {
+        if (!passwordEncoder.matches(request.password(), member.getPassword())) {
             throw new UnauthorizedException("아이디나 비밀번호가 일치하지 않습니다.");
         }
     }

--- a/backend/src/main/java/com/onair/hearit/auth/dto/response/KakaoUserInfoResponse.java
+++ b/backend/src/main/java/com/onair/hearit/auth/dto/response/KakaoUserInfoResponse.java
@@ -4,12 +4,12 @@ public record KakaoUserInfoResponse(
         String id,
         Properties properties
 ) {
+    public String nickname() {
+        return this.properties().nickname();
+    }
+
     public record Properties(
             String nickname
     ) {
-    }
-
-    public String nickname() {
-        return this.properties().nickname();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/auth/exception/KakaoExceptionHandler.java
+++ b/backend/src/main/java/com/onair/hearit/auth/exception/KakaoExceptionHandler.java
@@ -19,8 +19,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class KakaoExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(KakaoClientException.class)
-    public ResponseEntity<Object> handleBadRequestException(final KakaoClientException e, final WebRequest request)
-    {
+    public ResponseEntity<Object> handleBadRequestException(final KakaoClientException e, final WebRequest request) {
         log.error(e.getMessage(), e);
         return buildResponseEntity(e, e.getStatusCode(), e.getMessage(), request);
     }

--- a/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
+    ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정보를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다.");
 

--- a/backend/src/main/java/com/onair/hearit/common/exception/custom/AlreadyExistException.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/custom/AlreadyExistException.java
@@ -1,0 +1,10 @@
+package com.onair.hearit.common.exception.custom;
+
+import com.onair.hearit.common.exception.ErrorCode;
+
+public class AlreadyExistException extends HearitException {
+
+    public AlreadyExistException(String detail) {
+        super(ErrorCode.INVALID_INPUT, detail);
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/domain/Bookmark.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Bookmark.java
@@ -43,4 +43,8 @@ public class Bookmark {
         this.member = member;
         this.hearit = hearit;
     }
+
+    public boolean isCreatedBy(Member member) {
+        return this.member.equals(member);
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Bookmark.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Bookmark.java
@@ -36,6 +36,11 @@ public class Bookmark {
     private Hearit hearit;
 
     @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
+
+    public Bookmark(Member member, Hearit hearit) {
+        this.member = member;
+        this.hearit = hearit;
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Member.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Member.java
@@ -25,17 +25,23 @@ public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(name = "local_id")
     private String localId; // 자체 회원용
+
     @Column(name = "password")
     private String password; // 자체 회원용
+
     @Column(name = "social_id")
     private String socialId;
+
     @Column(name = "nickname", nullable = false)
     private String nickname;
+
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 

--- a/backend/src/main/java/com/onair/hearit/domain/Member.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Member.java
@@ -22,6 +22,23 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "local_id")
+    private String localId; // 자체 회원용
+    @Column(name = "password")
+    private String password; // 자체 회원용
+    @Column(name = "social_id")
+    private String socialId;
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public Member(String localId, String password, String socialId, String nickname) {
         this.localId = localId;
         this.password = password;
@@ -33,32 +50,9 @@ public class Member {
         return new Member(memberId, password, null, nickname);
     }
 
-    public static Member createSocialUser(String socialId,  String nickname) {
+    public static Member createSocialUser(String socialId, String nickname) {
         return new Member(null, null, socialId, nickname);
     }
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(name = "local_id")
-    private String localId; // 자체 회원용
-
-    @Column(name = "password")
-    private String password; // 자체 회원용
-
-    @Column(name = "social_id")
-    private String socialId;
-
-    @Column(name = "nickname", nullable = false)
-    private String nickname;
-
-    @CreatedDate
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
-
-    @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
 
     @Override
     public boolean equals(Object o) {

--- a/backend/src/main/java/com/onair/hearit/domain/Member.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Member.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -40,4 +41,20 @@ public class Member {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Member member)) {
+            return false;
+        }
+        return Objects.equals(id, member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/dto/response/BookmarkHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/BookmarkHearitResponse.java
@@ -1,0 +1,23 @@
+package com.onair.hearit.dto.response;
+
+import com.onair.hearit.domain.Bookmark;
+import com.onair.hearit.domain.Hearit;
+
+public record BookmarkHearitResponse(
+        Long hearitId,
+        Long bookmarkId,
+        String title,
+        String summary,
+        Integer playTime
+) {
+
+    public static BookmarkHearitResponse from(Bookmark bookmark) {
+        Hearit hearit = bookmark.getHearit();
+        return new BookmarkHearitResponse(
+                hearit.getId(),
+                bookmark.getId(),
+                hearit.getTitle(),
+                hearit.getSummary(),
+                hearit.getPlayTime());
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/dto/response/HearitPersonalDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/HearitPersonalDetailResponse.java
@@ -1,0 +1,26 @@
+package com.onair.hearit.dto.response;
+
+import com.onair.hearit.domain.Hearit;
+import java.time.LocalDateTime;
+
+public record HearitPersonalDetailResponse(
+        Long id,
+        String title,
+        String summary,
+        String source,
+        Integer playTime,
+        LocalDateTime createdAt,
+        Boolean isBookmarked
+) {
+
+    public static HearitPersonalDetailResponse of(Hearit hearit, Boolean isBookmarked) {
+        return new HearitPersonalDetailResponse(
+                hearit.getId(),
+                hearit.getTitle(),
+                hearit.getSummary(),
+                hearit.getSource(),
+                hearit.getPlayTime(),
+                hearit.getCreatedAt(),
+                isBookmarked);
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/infrastructure/BookmarkRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/BookmarkRepository.java
@@ -4,4 +4,6 @@ import com.onair.hearit.domain.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    boolean existsByHearitIdAndMemberId(Long hearitId, Long memberId);
 }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/BookmarkRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/BookmarkRepository.java
@@ -3,11 +3,12 @@ package com.onair.hearit.infrastructure;
 import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Member;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByHearitIdAndMemberId(Long hearitId, Long memberId);
 
-    List<Bookmark> findAllByMember(Member member);
+    List<Bookmark> findAllByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
 }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/BookmarkRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/BookmarkRepository.java
@@ -1,9 +1,13 @@
 package com.onair.hearit.infrastructure;
 
 import com.onair.hearit.domain.Bookmark;
+import com.onair.hearit.domain.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByHearitIdAndMemberId(Long hearitId, Long memberId);
+
+    List<Bookmark> findAllByMember(Member member);
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -31,7 +31,7 @@ public class BookmarkController {
     public ResponseEntity<List<BookmarkHearitResponse>> readBookmarkHearits(
             @AuthenticationPrincipal CurrentMember member,
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "10") int size) {
+            @RequestParam(name = "size", defaultValue = "20") int size) {
         List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.memberId(), page, size);
         return ResponseEntity.ok(responses);
     }

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -1,10 +1,16 @@
 package com.onair.hearit.presentation;
 
 import com.onair.hearit.application.BookmarkService;
+import com.onair.hearit.auth.dto.CurrentMember;
+import com.onair.hearit.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.dto.response.HearitDetailResponse;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,18 +23,21 @@ public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
-    //TODO 로그인한 사용자 아이디로 수정
-    @PostMapping("/{hearitId}/bookmarks")
-    public ResponseEntity<Void> createBookmark(@PathVariable Long hearitId, Long memberId) {
-        bookmarkService.addBookmark(hearitId, memberId);
-        //TODO 단건조회 API 넘기는데 이게 맞음?
-        return ResponseEntity.created(URI.create("/api/v1/hearits/{id}")).build();
+    @GetMapping("/bookmarks")
+    public ResponseEntity<List<BookmarkHearitResponse>> readBookmarkHearits(@AuthenticationPrincipal CurrentMember member) {
+        List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.memberId());
+        return ResponseEntity.ok(responses);
     }
 
-    //TODO 로그인한 사용자 아이디로 수정
+    @PostMapping("/{hearitId}/bookmarks")
+    public ResponseEntity<Void> createBookmark(@PathVariable Long hearitId, @AuthenticationPrincipal CurrentMember member) {
+        bookmarkService.addBookmark(hearitId, member.memberId());
+        return ResponseEntity.created(URI.create("/api/v1/hearits/" + hearitId)).build();
+    }
+
     @DeleteMapping("/{hearitId}/bookmarks/{bookmarkId}")
-    public ResponseEntity<Void> deleteBookmark(@PathVariable Long hearitId, @PathVariable Long bookmarkId, Long memberId) {
-        bookmarkService.deleteBookmark(bookmarkId, memberId);
+    public ResponseEntity<Void> deleteBookmark(@PathVariable Long bookmarkId, @AuthenticationPrincipal CurrentMember member) {
+        bookmarkService.deleteBookmark(bookmarkId, member.memberId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -3,7 +3,6 @@ package com.onair.hearit.presentation;
 import com.onair.hearit.application.BookmarkService;
 import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.dto.response.BookmarkHearitResponse;
-import com.onair.hearit.dto.response.HearitDetailResponse;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +23,8 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
 
     @GetMapping("/bookmarks")
-    public ResponseEntity<List<BookmarkHearitResponse>> readBookmarkHearits(@AuthenticationPrincipal CurrentMember member) {
+    public ResponseEntity<List<BookmarkHearitResponse>> readBookmarkHearits(
+            @AuthenticationPrincipal CurrentMember member) {
         List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.memberId());
         return ResponseEntity.ok(responses);
     }

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -4,6 +4,7 @@ import com.onair.hearit.application.BookmarkService;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,10 +18,17 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
 
     //TODO 로그인한 사용자 아이디로 수정
-    @PostMapping("/{id}/bookmarks")
-    public ResponseEntity<Void> createBookmark(@PathVariable(name = "id") Long hearitId, Long memberId) {
+    @PostMapping("/{hearitId}/bookmarks")
+    public ResponseEntity<Void> createBookmark(@PathVariable Long hearitId, Long memberId) {
         bookmarkService.addBookmark(hearitId, memberId);
         //TODO 단건조회 API 넘기는데 이게 맞음?
         return ResponseEntity.created(URI.create("/api/v1/hearits/{id}")).build();
+    }
+
+    //TODO 로그인한 사용자 아이디로 수정
+    @DeleteMapping("/{hearitId}/bookmarks/{bookmarkId}")
+    public ResponseEntity<Void> deleteBookmark(@PathVariable Long hearitId, @PathVariable Long bookmarkId, Long memberId) {
+        bookmarkService.deleteBookmark(bookmarkId, memberId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -30,13 +30,15 @@ public class BookmarkController {
     }
 
     @PostMapping("/{hearitId}/bookmarks")
-    public ResponseEntity<Void> createBookmark(@PathVariable Long hearitId, @AuthenticationPrincipal CurrentMember member) {
+    public ResponseEntity<Void> createBookmark(@PathVariable Long hearitId,
+                                               @AuthenticationPrincipal CurrentMember member) {
         bookmarkService.addBookmark(hearitId, member.memberId());
         return ResponseEntity.created(URI.create("/api/v1/hearits/" + hearitId)).build();
     }
 
     @DeleteMapping("/{hearitId}/bookmarks/{bookmarkId}")
-    public ResponseEntity<Void> deleteBookmark(@PathVariable Long bookmarkId, @AuthenticationPrincipal CurrentMember member) {
+    public ResponseEntity<Void> deleteBookmark(@PathVariable Long bookmarkId,
+                                               @AuthenticationPrincipal CurrentMember member) {
         bookmarkService.deleteBookmark(bookmarkId, member.memberId());
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,8 +25,10 @@ public class BookmarkController {
 
     @GetMapping("/bookmarks")
     public ResponseEntity<List<BookmarkHearitResponse>> readBookmarkHearits(
-            @AuthenticationPrincipal CurrentMember member) {
-        List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.memberId());
+            @AuthenticationPrincipal CurrentMember member,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+        List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.memberId(), page, size);
         return ResponseEntity.ok(responses);
     }
 

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -3,6 +3,8 @@ package com.onair.hearit.presentation;
 import com.onair.hearit.application.BookmarkService;
 import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.dto.response.BookmarkHearitResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/hearits/")
+@Tag(name = "Bookmark", description = "북마크 및 북마크 재생목록")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
+    @Operation(summary = "북마크 재생목록 조회", description = "로그인한 회원이 page, size로 재생목록을 조회합니다.")
     @GetMapping("/bookmarks")
     public ResponseEntity<List<BookmarkHearitResponse>> readBookmarkHearits(
             @AuthenticationPrincipal CurrentMember member,
@@ -32,6 +36,7 @@ public class BookmarkController {
         return ResponseEntity.ok(responses);
     }
 
+    @Operation(summary = "북마크 생성", description = "로그인한 회원이 히어릿 ID로 북마크를 생성합니다.")
     @PostMapping("/{hearitId}/bookmarks")
     public ResponseEntity<Void> createBookmark(@PathVariable Long hearitId,
                                                @AuthenticationPrincipal CurrentMember member) {
@@ -39,6 +44,7 @@ public class BookmarkController {
         return ResponseEntity.created(URI.create("/api/v1/hearits/" + hearitId)).build();
     }
 
+    @Operation(summary = "북마크 삭제", description = "로그인한 히어릿 ID와 북마크 ID로 북마크를 삭제합니다.")
     @DeleteMapping("/{hearitId}/bookmarks/{bookmarkId}")
     public ResponseEntity<Void> deleteBookmark(@PathVariable Long bookmarkId,
                                                @AuthenticationPrincipal CurrentMember member) {

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -1,0 +1,26 @@
+package com.onair.hearit.presentation;
+
+import com.onair.hearit.application.BookmarkService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/hearits/")
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    //TODO 로그인한 사용자 아이디로 수정
+    @PostMapping("/{id}/bookmarks")
+    public ResponseEntity<Void> createBookmark(@PathVariable(name = "id") Long hearitId, Long memberId) {
+        bookmarkService.addBookmark(hearitId, memberId);
+        //TODO 단건조회 API 넘기는데 이게 맞음?
+        return ResponseEntity.created(URI.create("/api/v1/hearits/{id}")).build();
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -1,10 +1,11 @@
 package com.onair.hearit.presentation;
 
 import com.onair.hearit.application.HearitService;
-import com.onair.hearit.dto.response.HearitDetailResponse;
+import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.dto.response.HearitPersonalDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,10 +18,10 @@ public class HearitController {
 
     private final HearitService hearitService;
 
-    //TODO 실제 멤버로 변경
     @GetMapping("/{hearitId}")
-    public ResponseEntity<HearitPersonalDetailResponse> readHearit(@PathVariable Long hearitId, Long memberId) {
-        HearitPersonalDetailResponse response = hearitService.getHearitPersonalDetail(hearitId, memberId);
+    public ResponseEntity<HearitPersonalDetailResponse> readHearit(@PathVariable Long hearitId,
+                                                                   @AuthenticationPrincipal CurrentMember member) {
+        HearitPersonalDetailResponse response = hearitService.getHearitPersonalDetail(hearitId, member.memberId());
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -1,12 +1,12 @@
 package com.onair.hearit.presentation;
 
 import com.onair.hearit.application.HearitService;
+import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.dto.response.HearitDetailResponse;
-import java.util.List;
+import com.onair.hearit.dto.response.HearitPersonalDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import com.onair.hearit.auth.dto.CurrentMember;
-import com.onair.hearit.dto.response.HearitPersonalDetailResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -2,6 +2,7 @@ package com.onair.hearit.presentation;
 
 import com.onair.hearit.application.HearitService;
 import com.onair.hearit.dto.response.HearitDetailResponse;
+import com.onair.hearit.dto.response.HearitPersonalDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,9 +17,10 @@ public class HearitController {
 
     private final HearitService hearitService;
 
+    //TODO 실제 멤버로 변경
     @GetMapping("/{hearitId}")
-    public ResponseEntity<HearitDetailResponse> readHearit(@PathVariable Long hearitId) {
-        HearitDetailResponse response = hearitService.getHearitDetail(hearitId);
+    public ResponseEntity<HearitPersonalDetailResponse> readHearit(@PathVariable Long hearitId, Long memberId) {
+        HearitPersonalDetailResponse response = hearitService.getHearitPersonalDetail(hearitId, memberId);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
@@ -49,7 +49,7 @@ class BookmarkServiceTest {
     }
 
     @Test
-    @DisplayName("멤버 아이디에 따라 북마크한 히어릿 목록을 조회한다.")
+    @DisplayName("멤버 아이디에 따라 북마크한 히어릿 목록을 페이지에 따라 조회한다.")
     void getBookmarkHearitsTest() {
         // given
         Member member = saveMember();
@@ -59,7 +59,7 @@ class BookmarkServiceTest {
         }
 
         // when
-        List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.getId());
+        List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.getId(), 0, 5);
 
         // then
         assertThat(responses).hasSize(5);
@@ -71,13 +71,13 @@ class BookmarkServiceTest {
         // given
         Member member = saveMember();
         Hearit hearit = saveHearitWithSuffix(1);
-        int previousBookmarkCount = bookmarkService.getBookmarkHearits(member.getId()).size();
+        int previousBookmarkCount = bookmarkService.getBookmarkHearits(member.getId(), 0, 10).size();
 
         // when
         bookmarkService.addBookmark(hearit.getId(), member.getId());
 
         // then
-        int currentBookmarkCount = bookmarkService.getBookmarkHearits(member.getId()).size();
+        int currentBookmarkCount = bookmarkService.getBookmarkHearits(member.getId(), 0, 10).size();
         assertThat(previousBookmarkCount + 1).isEqualTo(currentBookmarkCount);
     }
 

--- a/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
@@ -1,0 +1,147 @@
+package com.onair.hearit.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.onair.hearit.DbHelper;
+import com.onair.hearit.common.exception.custom.AlreadyExistException;
+import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.domain.Bookmark;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.infrastructure.BookmarkRepository;
+import com.onair.hearit.infrastructure.HearitRepository;
+import com.onair.hearit.infrastructure.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(DbHelper.class)
+@ActiveProfiles("fake-test")
+class BookmarkServiceTest {
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Autowired
+    private HearitRepository hearitRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
+    private BookmarkService bookmarkService;
+
+    @BeforeEach
+    void setup() {
+        bookmarkService = new BookmarkService(hearitRepository, memberRepository, bookmarkRepository);
+    }
+
+    @Test
+    @DisplayName("멤버 아이디에 따라 북마크한 히어릿 목록을 조회한다.")
+    void getBookmarkHearitsTest() {
+        // given
+        Member member = saveMember();
+        for (int i = 0; i < 5; i++) {
+            Hearit hearit = saveHearitWithSuffix(i);
+            dbHelper.insertBookmark(new Bookmark(member, hearit));
+        }
+
+        // when
+        List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.getId());
+
+        // then
+        assertThat(responses).hasSize(5);
+    }
+
+    @Test
+    @DisplayName("멤버 아이디와 히어릿 아이디로 북마크를 추가한다.")
+    void addBookmarkTest() {
+        // given
+        Member member = saveMember();
+        Hearit hearit = saveHearitWithSuffix(1);
+        int previousBookmarkCount = bookmarkService.getBookmarkHearits(member.getId()).size();
+
+        // when
+        bookmarkService.addBookmark(hearit.getId(), member.getId());
+
+        // then
+        int currentBookmarkCount = bookmarkService.getBookmarkHearits(member.getId()).size();
+        assertThat(previousBookmarkCount + 1).isEqualTo(currentBookmarkCount);
+    }
+
+    @Test
+    @DisplayName("북마크 추가 시, 이미 북마크가 존재한다면 AlreadyExistException을 던진다.")
+    void addBookmarkTest_AlreadyExistTest() {
+        // given
+        Member member = saveMember();
+        Hearit hearit = saveHearitWithSuffix(1);
+        dbHelper.insertBookmark(new Bookmark(member, hearit));
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.addBookmark(hearit.getId(), member.getId()))
+                .isInstanceOf(AlreadyExistException.class)
+                .hasMessageContaining("이미 북마크가 존재합니다.");
+    }
+
+    @Test
+    @DisplayName("북마크 아이디와 멤버 아이디로 북마크를 삭제한다.")
+    void deleteBookmarkTest() {
+        // given
+        Member member = saveMember();
+        Hearit hearit = saveHearitWithSuffix(1);
+        Bookmark bookmark = dbHelper.insertBookmark(new Bookmark(member, hearit));
+
+        // when
+        bookmarkService.deleteBookmark(bookmark.getId(), member.getId());
+
+        // then
+        assertThat(bookmarkRepository.findById(bookmark.getId())).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("북마크 삭제 시, 북마크를 한 멤버가 아니라면 UnauthorizedException을 던진다.")
+    void deleteBookmark_UnauthorizedTest() {
+        // given
+        Member bookmarkMember = saveMember();
+        Member notBookmarkMember = saveMember();
+        Hearit hearit = saveHearitWithSuffix(1);
+        Bookmark bookmark = dbHelper.insertBookmark(new Bookmark(bookmarkMember, hearit));
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.deleteBookmark(bookmark.getId(), notBookmarkMember.getId()))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessageContaining("북마크를 삭제할 권한이 없습니다.");
+    }
+
+    private Member saveMember() {
+        return dbHelper.insertMember(new Member("testId", "test1234!", null, "testMember"));
+    }
+
+    private Hearit saveHearitWithSuffix(int suffix) {
+        Category category = new Category("name" + suffix);
+        dbHelper.insertCategory(category);
+
+        Hearit hearit = new Hearit(
+                "title" + suffix,
+                "summary" + suffix, suffix,
+                "originalAudioUrl" + suffix,
+                "shortAudioUrl" + suffix,
+                "scriptUrl" + suffix,
+                "source" + suffix,
+                LocalDateTime.now(),
+                category);
+        return dbHelper.insertHearit(hearit);
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -9,6 +9,7 @@ import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.HearitDetailResponse;
+import com.onair.hearit.infrastructure.BookmarkRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,11 +31,14 @@ class HearitServiceTest {
     @Autowired
     private HearitRepository hearitRepository;
 
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
     private HearitService hearitService;
 
     @BeforeEach
     void setup() {
-        hearitService = new HearitService(hearitRepository);
+        hearitService = new HearitService(hearitRepository, bookmarkRepository);
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
@@ -30,21 +30,16 @@ class AuthServiceTest {
 
     @MockitoBean
     KakaoUserInfoClient kakaoUserInfoClient;
-
-    @Autowired
-    private AuthService authService;
-
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
-
     @Autowired
     MemberRepository memberRepository;
-
     @Autowired
     DbHelper dbHelper;
+    @Autowired
+    private AuthService authService;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Test
     @DisplayName("아이디와 비밀번호로 회원가입할 수 있다")

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -33,7 +33,7 @@ class BookmarkControllerTest extends IntegrationTest {
 
         // when & then
         int size = 5;
-        for (int i = 0; i < bookmarkCount / size ; i++) {
+        for (int i = 0; i < bookmarkCount / size; i++) {
             RestAssured.given()
                     .header("Authorization", "Bearer " + token)
                     .param("page", i)

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -20,25 +20,30 @@ class BookmarkControllerTest extends IntegrationTest {
     private JwtTokenProvider jwtTokenProvider;
 
     @Test
-    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 북마크 목록을 반환한다.")
+    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
     void readBookmarkHearitsTest() {
         // given
         Member member = saveMember();
         String token = generateToken(member);
-        int bookmarkCount = 5;
+        int bookmarkCount = 30;
         for (int i = 0; i < bookmarkCount; i++) {
             Hearit hearit = saveHearitWithSuffix(i);
             dbHelper.insertBookmark(new Bookmark(member, hearit));
         }
 
         // when & then
-        RestAssured.given()
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .get("/api/v1/hearits/bookmarks")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .body("size()", equalTo(5));
+        int size = 5;
+        for (int i = 0; i < bookmarkCount / size ; i++) {
+            RestAssured.given()
+                    .header("Authorization", "Bearer " + token)
+                    .param("page", i)
+                    .param("size", size)
+                    .when()
+                    .get("/api/v1/hearits/bookmarks")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .body("size()", equalTo(5));
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -2,29 +2,39 @@ package com.onair.hearit.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.onair.hearit.auth.Infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
-import com.onair.hearit.dto.response.HearitDetailResponse;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.dto.response.HearitPersonalDetailResponse;
 import io.restassured.RestAssured;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 class HearitControllerTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
 
     @Test
     @DisplayName("히어릿 단일 조회 시, 200 OK 및 히어릿 정보를 제공한다.")
     void readHearitWithSuccess() {
         // given
+        Member member = saveTestMember();
+        String token = generateToken(member);
         Hearit hearit = saveHearitWithSuffix(1);
 
         // when & then
-        HearitDetailResponse response = RestAssured.when()
+        HearitPersonalDetailResponse response = RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .when()
                 .get("/api/v1/hearits/" + hearit.getId())
                 .then()
                 .statusCode(HttpStatus.OK.value())
-                .extract().as(HearitDetailResponse.class);
+                .extract().as(HearitPersonalDetailResponse.class);
 
         assertThat(response.id()).isEqualTo(hearit.getId());
     }
@@ -33,13 +43,25 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("히어릿 단일 조회 시, 존재하지 않는 아이디인 경우 404 NOT_FOUND를 반환한다.")
     void readHearitWithNotFound() {
         // given
+        Member member = saveTestMember();
+        String token = generateToken(member);
         Long notFoundHearitId = 1L;
 
         // when & then
-        RestAssured.when()
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .when()
                 .get("/api/v1/hearits/" + notFoundHearitId)
                 .then()
                 .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    private Member saveTestMember() {
+        return dbHelper.insertMember(new Member("testId", "test1234!", null, "testMember"));
+    }
+
+    private String generateToken(Member member) {
+        return jwtTokenProvider.createToken(member.getId());
     }
 
     private Hearit saveHearitWithSuffix(int suffix) {


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

1. 로그인한 사용자만 북마크를 할 수 있다.
로그인하지 않은 사용자가 요청 시 401 Anauthorized 예외를 응답한다.
2. 북마크를 추가할 수 있다.
POST /api/v1/hearits/{hearitId}/bookmarks

3. 북마크를 삭제할 수 있다.
DELETE /api/v1/hearits/{hearitid}/bookmarks/{bookmarkid}

4. 사용자의 북마크한 재생목록을 조회할 수 있다.
최근에 추가한 순서대로 조회한다.
요청한 수만큼 조회한다.
GET /api/v1/hearits/bookmarks

{[
{
	"hearitId" : 1,
        "bookmarkId" : 1,
	"title" : "테스트 히어릿",
	"summary" : "테스트 히어릿 설명 요약입니다. 테스트 히어릿 설명 요약입니다.",
	"playTime" : 185
},
{
	"hearitId" : 2,
        "bookmarkId" : 2,
	"title" : "테스트 히어릿",
	"summary" : "테스트 히어릿 설명 요약입니다. 테스트 히어릿 설명 요약입니다.",
	"playTime" : 185
}
...
]}

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
통합테스트 : BookmarkControllerTest
서비스 레이어 테스트 : BookmarkServiceTest

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

### 1. 커스텀 예외 AlreadyExist 추가

unique해야하는 값을 또 넣어야하는 경우에 대한 커스텀 예외 추가했습니다.
Conflict status를 반환합니다.

### 2. 히어릿 관련 response 네이밍
현재 히어릿 재생목록에서 제공하는 resposne : HearitPersonalDetailResponse 
히어릿 탐색 리스트, 히어릿 홈화면 리스트 response : HearitDetailResponse
히어릿 검색 리스트 : HearitSimpleResponse ( 이부분은 아직 벡터의 코드와 병합안됨 [코드](https://github.com/woowacourse-teams/2025-hEARit/pull/82/files#diff-d9c3a500179558e0615e3fc6773eee337e1efab1d38b50a32c41f045744559ac))

등으로 다양한데 네이밍으로 이 response가 어떤 곳에 사용되는지 파악하기 어려운 것 같아서 이 부분에 대해함 함께 협의가 필요한 것 같습니다.

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->

close #49 