### PR TITLE
[BE] feat: 카테고리 및 키워드 기반 히어릿 검색 기능 구현

### DIFF
--- a/backend/src/main/java/com/onair/hearit/application/CategoryService.java
+++ b/backend/src/main/java/com/onair/hearit/application/CategoryService.java
@@ -1,5 +1,6 @@
 package com.onair.hearit.application;
 
+import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.dto.response.CategoryResponse;
 import com.onair.hearit.infrastructure.CategoryRepository;
@@ -16,7 +17,17 @@ public class CategoryService {
     public List<CategoryResponse> getCategories() {
         List<Category> categories = categoryRepository.findAll();
         return categories.stream()
-                .map(category -> CategoryResponse.from(category))
+                .map(CategoryResponse::from)
                 .toList();
+    }
+
+    public CategoryResponse getCategory(final Long id) {
+        Category category = findCategory(id);
+        return CategoryResponse.from(category);
+    }
+
+    private Category findCategory(final Long id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("hearitId", String.valueOf(id)));
     }
 }

--- a/backend/src/main/java/com/onair/hearit/application/CategoryService.java
+++ b/backend/src/main/java/com/onair/hearit/application/CategoryService.java
@@ -1,0 +1,22 @@
+package com.onair.hearit.application;
+
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.dto.response.CategoryResponse;
+import com.onair.hearit.infrastructure.CategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public List<CategoryResponse> getCategories() {
+        List<Category> categories = categoryRepository.findAll();
+        return categories.stream()
+                .map(category -> CategoryResponse.from(category))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/application/CategoryService.java
+++ b/backend/src/main/java/com/onair/hearit/application/CategoryService.java
@@ -28,6 +28,6 @@ public class CategoryService {
 
     private Category findCategory(final Long id) {
         return categoryRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("hearitId", String.valueOf(id)));
+                .orElseThrow(() -> new NotFoundException("categoryId", String.valueOf(id)));
     }
 }

--- a/backend/src/main/java/com/onair/hearit/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitSearchService.java
@@ -2,6 +2,7 @@ package com.onair.hearit.application;
 
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.request.CategorySearchCondition;
+import com.onair.hearit.dto.request.KeywordSearchCondition;
 import com.onair.hearit.dto.request.TitleSearchCondition;
 import com.onair.hearit.dto.response.HearitSearchResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
@@ -31,6 +32,14 @@ public class HearitSearchService {
     public List<HearitSearchResponse> searchByCategory(CategorySearchCondition condition) {
         Pageable pageable = PageRequest.of(condition.page(), condition.size());
         Page<Hearit> result = hearitRepository.findByCategoryIdOrderByCreatedAtDesc(condition.categoryId(), pageable);
+        return result.stream()
+                .map(HearitSearchResponse::from)
+                .toList();
+    }
+
+    public List<HearitSearchResponse> searchByKeyword(KeywordSearchCondition condition) {
+        Pageable pageable = PageRequest.of(condition.page(), condition.size());
+        Page<Hearit> result = hearitRepository.findByKeywordIdOrderByCreatedAtDesc(condition.keywordId(), pageable);
         return result.stream()
                 .map(HearitSearchResponse::from)
                 .toList();

--- a/backend/src/main/java/com/onair/hearit/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitSearchService.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.application;
 
 import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.dto.request.CategorySearchCondition;
 import com.onair.hearit.dto.request.TitleSearchCondition;
 import com.onair.hearit.dto.response.HearitSearchResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
@@ -22,6 +23,14 @@ public class HearitSearchService {
     public List<HearitSearchResponse> searchByTitle(TitleSearchCondition condition) {
         Pageable pageable = PageRequest.of(condition.page(), condition.size());
         Page<Hearit> result = hearitRepository.findByTitleOrderByCreatedAtDesc(condition.searchTerm(), pageable);
+        return result.stream()
+                .map(HearitSearchResponse::from)
+                .toList();
+    }
+
+    public List<HearitSearchResponse> searchByCategory(CategorySearchCondition condition) {
+        Pageable pageable = PageRequest.of(condition.page(), condition.size());
+        Page<Hearit> result = hearitRepository.findByCategoryIdOrderByCreatedAtDesc(condition.categoryId(), pageable);
         return result.stream()
                 .map(HearitSearchResponse::from)
                 .toList();

--- a/backend/src/main/java/com/onair/hearit/application/KeywordService.java
+++ b/backend/src/main/java/com/onair/hearit/application/KeywordService.java
@@ -1,0 +1,40 @@
+package com.onair.hearit.application;
+
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.domain.Keyword;
+import com.onair.hearit.dto.response.KeywordResponse;
+import com.onair.hearit.infrastructure.KeywordRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordService {
+
+    private final KeywordRepository keywordRepository;
+
+    public List<KeywordResponse> getKeywords() {
+        List<Keyword> keywords = keywordRepository.findAll();
+        return keywords.stream()
+                .map(KeywordResponse::from)
+                .toList();
+    }
+
+    public KeywordResponse getKeyword(final Long id) {
+        Keyword keyword = findKeyword(id);
+        return KeywordResponse.from(keyword);
+    }
+
+    private Keyword findKeyword(final Long id) {
+        return keywordRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("keywordId", String.valueOf(id)));
+    }
+
+    public List<KeywordResponse> getRecommendedKeyword(long seed, int size) {
+        List<Keyword> keywords = keywordRepository.findRandomWithSeed(seed, size);
+        return keywords.stream()
+                .map(KeywordResponse::from)
+                .toList();
+    }
+} 

--- a/backend/src/main/java/com/onair/hearit/application/KeywordService.java
+++ b/backend/src/main/java/com/onair/hearit/application/KeywordService.java
@@ -4,7 +4,9 @@ import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.dto.response.KeywordResponse;
 import com.onair.hearit.infrastructure.KeywordRepository;
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -32,9 +34,17 @@ public class KeywordService {
     }
 
     public List<KeywordResponse> getRecommendedKeyword(long seed, int size) {
-        List<Keyword> keywords = keywordRepository.findRandomWithSeed(seed, size);
+        List<Long> allIds = keywordRepository.findAllIds();
+        List<Long> selectedIds = pickRandomIds(allIds, seed, size);
+        List<Keyword> keywords = keywordRepository.findAllByIdIn(selectedIds);
         return keywords.stream()
                 .map(KeywordResponse::from)
                 .toList();
+    }
+
+    private List<Long> pickRandomIds(List<Long> allIds, long seed, int size) {
+        int fetchSize = Math.min(size, allIds.size());
+        Collections.shuffle(allIds, new Random(seed));
+        return allIds.subList(0, fetchSize);
     }
 } 

--- a/backend/src/main/java/com/onair/hearit/domain/Category.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Category.java
@@ -23,6 +23,9 @@ public class Category {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Column(name = "color_code", nullable = false)
+    private String colorCode;
+
     public Category(String name) {
         this.name = name;
     }

--- a/backend/src/main/java/com/onair/hearit/domain/HearitKeyword.java
+++ b/backend/src/main/java/com/onair/hearit/domain/HearitKeyword.java
@@ -29,4 +29,9 @@ public class HearitKeyword {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "keyword_id")
     private Keyword keyword;
+
+    public HearitKeyword(final Hearit hearit, final Keyword keyword) {
+        this.hearit = hearit;
+        this.keyword = keyword;
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Keyword.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Keyword.java
@@ -22,4 +22,8 @@ public class Keyword {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    public Keyword(final String name) {
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/dto/request/CategorySearchCondition.java
+++ b/backend/src/main/java/com/onair/hearit/dto/request/CategorySearchCondition.java
@@ -1,0 +1,21 @@
+package com.onair.hearit.dto.request;
+
+import com.onair.hearit.common.exception.custom.InvalidInputException;
+
+public record CategorySearchCondition(
+        Long categoryId,
+        Integer page,
+        Integer size
+) {
+    public CategorySearchCondition {
+        if (categoryId == null) {
+            throw new InvalidInputException("검색어는 20자를 이하어야 합니다.");
+        }
+        if (page == null || page < 0) {
+            throw new InvalidInputException("page는 0 이상의 값이어야 합니다.");
+        }
+        if (size == null || size < 0 || size > 50) {
+            throw new InvalidInputException("size는 0 이상 50 이하의 값이어야 합니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/dto/request/KeywordSearchCondition.java
+++ b/backend/src/main/java/com/onair/hearit/dto/request/KeywordSearchCondition.java
@@ -1,0 +1,18 @@
+package com.onair.hearit.dto.request;
+
+import com.onair.hearit.common.exception.custom.InvalidInputException;
+
+public record KeywordSearchCondition(
+        long keywordId,
+        int page,
+        int size
+) {
+    public KeywordSearchCondition {
+        if (page < 0) {
+            throw new InvalidInputException("page는 0 이상의 값이어야 합니다.");
+        }
+        if (size < 0 || size > 50) {
+            throw new InvalidInputException("size는 0 이상 50 이하의 값이어야 합니다.");
+        }
+    }
+} 

--- a/backend/src/main/java/com/onair/hearit/dto/response/CategoryResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/CategoryResponse.java
@@ -1,0 +1,17 @@
+package com.onair.hearit.dto.response;
+
+import com.onair.hearit.domain.Category;
+
+public record CategoryResponse(
+        Long id,
+        String name,
+        String colorCode
+) {
+
+    public static CategoryResponse from(final Category category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getColorCode());
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/dto/response/KeywordResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/KeywordResponse.java
@@ -1,0 +1,15 @@
+package com.onair.hearit.dto.response;
+
+import com.onair.hearit.domain.Keyword;
+
+public record KeywordResponse(
+        Long id,
+        String name
+) {
+    public static KeywordResponse from(final Keyword keyword) {
+        return new KeywordResponse(
+                keyword.getId(),
+                keyword.getName()
+        );
+    }
+} 

--- a/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
@@ -22,4 +22,13 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
     Page<Hearit> findByTitleOrderByCreatedAtDesc(@Param("searchTerm") String searchTerm, Pageable pageable);
 
     Page<Hearit> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
+
+    @Query("""
+            SELECT h
+            FROM Hearit h
+            JOIN HearitKeyword hk ON hk.hearit = h
+            WHERE hk.keyword.id = :keywordId
+            ORDER BY h.createdAt DESC
+            """)
+    Page<Hearit> findByKeywordIdOrderByCreatedAtDesc(@Param("keywordId") Long keywordId, Pageable pageable);
 }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
@@ -20,4 +20,6 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
             ORDER BY h.createdAt DESC
             """)
     Page<Hearit> findByTitleOrderByCreatedAtDesc(@Param("searchTerm") String searchTerm, Pageable pageable);
+
+    Page<Hearit> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
 }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/KeywordRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/KeywordRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
 
-    @Query(
-            value = "SELECT * FROM keyword ORDER BY RAND(:seed) LIMIT :size",
-            nativeQuery = true
-    )
-    List<Keyword> findRandomWithSeed(@Param("seed") long seed, @Param("size") int size);
+    @Query("SELECT k.id FROM Keyword k")
+    List<Long> findAllIds();
+
+    @Query("SELECT k FROM Keyword k WHERE k.id IN :ids")
+    List<Keyword> findAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/KeywordRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/KeywordRepository.java
@@ -1,7 +1,16 @@
 package com.onair.hearit.infrastructure;
 
 import com.onair.hearit.domain.Keyword;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+    @Query(
+            value = "SELECT * FROM keyword ORDER BY RAND(:seed) LIMIT :size",
+            nativeQuery = true
+    )
+    List<Keyword> findRandomWithSeed(@Param("seed") long seed, @Param("size") int size);
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
@@ -1,0 +1,36 @@
+package com.onair.hearit.presentation;
+
+import com.onair.hearit.application.CategoryService;
+import com.onair.hearit.dto.response.CategoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/category")
+@Tag(name = "Category", description = "카테고리")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @Operation(summary = "전체 카테고리 목록 조회", description = "전체 카테고리 목록들을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<CategoryResponse>> readCategories(@PathVariable Long hearitId) {
+        List<CategoryResponse> responses = categoryService.getCategories();
+        return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "단일 카테고리 조회", description = "전체 카테고리 목록들을 조회합니다.")
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<CategoryResponse> readCategory(@PathVariable Long categoryId) {
+        CategoryResponse response = categoryService.getCategory(categoryId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -3,9 +3,10 @@ package com.onair.hearit.presentation;
 import com.onair.hearit.application.HearitSearchService;
 import com.onair.hearit.application.HearitService;
 import com.onair.hearit.auth.dto.CurrentMember;
-import com.onair.hearit.dto.response.HearitListResponse;
+import com.onair.hearit.dto.request.CategorySearchCondition;
 import com.onair.hearit.dto.request.TitleSearchCondition;
 import com.onair.hearit.dto.response.HearitDetailResponse;
+import com.onair.hearit.dto.response.HearitListResponse;
 import com.onair.hearit.dto.response.HearitSearchResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -56,7 +57,8 @@ public class HearitController {
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/search")
+    @Operation(summary = "히어릿 제목명으로 검색", description = "히어릿의 제목명, page 정보를 입력해 히어릿을 검색합니다. ")
+    @GetMapping("/search/title")
     public ResponseEntity<List<HearitSearchResponse>> searchHearitsByTitle(
             @RequestParam(name = "searchTerm") String searchTerm,
             @RequestParam(name = "page", defaultValue = "0") Integer page,
@@ -64,6 +66,18 @@ public class HearitController {
     ) {
         TitleSearchCondition condition = new TitleSearchCondition(searchTerm, page, size);
         List<HearitSearchResponse> response = hearitSearchService.searchByTitle(condition);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "히어릿 카테고리명으로 검색", description = "히어릿의 카테고리명, page 정보를 입력해 히어릿을 검색합니다. ")
+    @GetMapping("/search/category")
+    public ResponseEntity<List<HearitSearchResponse>> searchHearitsByCategory(
+            @RequestParam(name = "categoryId") Long categoryId,
+            @RequestParam(name = "page", defaultValue = "0") Integer page,
+            @RequestParam(name = "size", defaultValue = "20") Integer size
+    ) {
+        CategorySearchCondition condition = new CategorySearchCondition(categoryId, page, size);
+        List<HearitSearchResponse> response = hearitSearchService.searchByCategory(condition);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -4,6 +4,7 @@ import com.onair.hearit.application.HearitSearchService;
 import com.onair.hearit.application.HearitService;
 import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.dto.request.CategorySearchCondition;
+import com.onair.hearit.dto.request.KeywordSearchCondition;
 import com.onair.hearit.dto.request.TitleSearchCondition;
 import com.onair.hearit.dto.response.HearitDetailResponse;
 import com.onair.hearit.dto.response.HearitListResponse;
@@ -78,6 +79,18 @@ public class HearitController {
     ) {
         CategorySearchCondition condition = new CategorySearchCondition(categoryId, page, size);
         List<HearitSearchResponse> response = hearitSearchService.searchByCategory(condition);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "히어릿 키워드로 검색", description = "히어릿의 키워드, page 정보를 입력해 히어릿을 검색합니다. ")
+    @GetMapping("/search/keyword")
+    public ResponseEntity<List<HearitSearchResponse>> searchHearitsByKeyword(
+            @RequestParam(name = "keywordId") Long keywordId,
+            @RequestParam(name = "page", defaultValue = "0") Integer page,
+            @RequestParam(name = "size", defaultValue = "20") Integer size
+    ) {
+        KeywordSearchCondition condition = new KeywordSearchCondition(keywordId, page, size);
+        List<HearitSearchResponse> response = hearitSearchService.searchByKeyword(condition);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/KeywordController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/KeywordController.java
@@ -1,0 +1,46 @@
+package com.onair.hearit.presentation;
+
+import com.onair.hearit.application.KeywordService;
+import com.onair.hearit.dto.response.KeywordResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/keyword")
+@Tag(name = "Keyword", description = "키워드")
+public class KeywordController {
+
+    private final KeywordService keywordService;
+
+    @Operation(summary = "전체 키워드 목록 조회", description = "전체 키워드 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<KeywordResponse>> readKeywords() {
+        List<KeywordResponse> responses = keywordService.getKeywords();
+        return ResponseEntity.ok(responses);
+    }
+
+    @Operation(summary = "단일 키워드 조회", description = "단일 키워드를 조회합니다.")
+    @GetMapping("/{keywordId}")
+    public ResponseEntity<KeywordResponse> readKeyword(@PathVariable Long keywordId) {
+        KeywordResponse response = keywordService.getKeyword(keywordId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "오늘의 추천 키워드 조회", description = "오늘의 추천 키워드를 조회합니다.")
+    @GetMapping("/recommend")
+    public ResponseEntity<List<KeywordResponse>> readRecommendedKeywords(@RequestParam(defaultValue = "9") int size) {
+        long todaySeed = LocalDate.now().toEpochDay();
+        List<KeywordResponse> responses = keywordService.getRecommendedKeyword(todaySeed, size);
+        return ResponseEntity.ok(responses);
+    }
+} 

--- a/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
@@ -1,0 +1,89 @@
+package com.onair.hearit.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.DbHelper;
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.dto.response.CategoryResponse;
+import com.onair.hearit.infrastructure.CategoryRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(DbHelper.class)
+@ActiveProfiles("fake-test")
+class CategoryServiceTest {
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private CategoryService categoryService;
+
+    @BeforeEach
+    void setup() {
+        categoryService = new CategoryService(categoryRepository);
+    }
+
+    @Test
+    @DisplayName("전체 카테고리를 조회할 수 있다.")
+    void getAllCategories() {
+        // given
+        Category category1 = saveCategory("category1", "#111");
+        Category category2 = saveCategory("category2", "#222");
+        Category category3 = saveCategory("category3", "#333");
+
+        // when
+        List<CategoryResponse> result = categoryService.getCategories();
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(3),
+                () -> assertThat(result).extracting(CategoryResponse::id)
+                        .contains(category1.getId(), category2.getId(), category3.getId())
+        );
+    }
+
+
+    @Test
+    @DisplayName("단일 카테고리를 조회할 수 있다.")
+    void getCategoryById() {
+        // given
+        Category category = saveCategory("category", "#abc");
+
+        // when
+        CategoryResponse result = categoryService.getCategory(category.getId());
+
+        // then
+        assertThat(result.id()).isEqualTo(category.getId());
+        assertThat(result.name()).isEqualTo(category.getName());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리를 조회하면 NotFoundException이 발생한다.")
+    void getCategory_notFound() {
+        // given
+        Long notExistId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> categoryService.getCategory(notExistId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("categoryId");
+    }
+
+    private Category saveCategory(String name, String color) {
+        Category category = new Category(name, color);
+        return dbHelper.insertCategory(category);
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
@@ -6,7 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.onair.hearit.DbHelper;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.HearitKeyword;
+import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.dto.request.CategorySearchCondition;
+import com.onair.hearit.dto.request.KeywordSearchCondition;
 import com.onair.hearit.dto.request.TitleSearchCondition;
 import com.onair.hearit.dto.response.HearitSearchResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
@@ -39,7 +42,7 @@ class HearitSearchServiceTest {
     }
 
     @Test
-    @DisplayName("히어릿 목록을 조회 시 제목이 포함된 히어릿만 반환한다.")
+    @DisplayName("히어릿 목록을 검색으로 조회 시 제목이 포함된 히어릿만 반환한다.")
     void searchHearitsByTitle_onlyTitleMatch() {
         // given
         saveHearitByTitle("exampletitle1");
@@ -60,7 +63,7 @@ class HearitSearchServiceTest {
     }
 
     @Test
-    @DisplayName("히어릿 목록을 조회 시 최신순으로 정렬되어 반환된다.")
+    @DisplayName("히어릿 목록을 검색으로 조회 시 최신순으로 정렬되어 반환된다.")
     void searchHearitsByTitle_sortedByCreatedAtDesc() {
         // given
         Hearit hearit1 = saveHearitByTitle("title1");
@@ -79,7 +82,7 @@ class HearitSearchServiceTest {
     }
 
     @Test
-    @DisplayName("히어릿 목록을 조회 시 페이지네이션이 적용되어 반환된다.")
+    @DisplayName("히어릿 목록을 검색으로 조회 시 페이지네이션이 적용되어 반환된다.")
     void searchHearitsByTitle_pagination() {
         // given
         Hearit hearit1 = saveHearitByTitle("title1");
@@ -98,7 +101,7 @@ class HearitSearchServiceTest {
     }
 
     @Test
-    @DisplayName("히어릿 목록을 조회 시 카테고리에 해당하는 히어릿만 반환한다.")
+    @DisplayName("히어릿 목록을 카테고리 조회 시 카테고리에 해당하는 히어릿만 반환한다.")
     void searchHearitsByCategory_onlyMatchingCategory() {
         // given
         Category category1 = saveCategory("Spring", "#001");
@@ -120,7 +123,7 @@ class HearitSearchServiceTest {
     }
 
     @Test
-    @DisplayName("히어릿 목록을 조회 시 최신순으로 페이지네이션이 적용된다.")
+    @DisplayName("히어릿 목록을 카테고리 조회 시 최신순으로 페이지네이션이 적용된다.")
     void searchHearitsByCategory_pagination() {
         // given
         Category category = saveCategory("Spring", "#001");
@@ -131,6 +134,51 @@ class HearitSearchServiceTest {
 
         // when
         List<HearitSearchResponse> result = hearitSearchService.searchByCategory(condition);
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(1),
+                () -> assertThat(result.get(0).id()).isEqualTo(hearit1.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("히어릿 목록을 키워드로 조회 시 해당 키워드가 포함된 히어릿만 반환한다.")
+    void searchHearitsByKeyword_onlyMatchingKeyword() {
+        // given
+        Keyword keyword1 = saveKeyword("keyword1");
+        Keyword keyword2 = saveKeyword("keyword2");
+
+        Hearit hearit1 = saveHearitWithKeyword(keyword1);
+        Hearit hearit2 = saveHearitWithKeyword(keyword1);
+        saveHearitWithKeyword(keyword2);
+
+        KeywordSearchCondition condition = new KeywordSearchCondition(keyword1.getId(), 0, 10);
+
+        // when
+        List<HearitSearchResponse> result = hearitSearchService.searchByKeyword(condition);
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(2),
+                () -> assertThat(result).extracting(HearitSearchResponse::id)
+                        .containsOnly(hearit2.getId(), hearit1.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("히어릿 목록을 키워드로 조회 시 최신순으로 페이지네이션이 적용된다.")
+    void searchHearitsByKeyword_pagination() {
+        // given
+        Keyword keyword = saveKeyword("keyword");
+        Hearit hearit1 = saveHearitWithKeyword(keyword);
+        Hearit hearit2 = saveHearitWithKeyword(keyword);
+        Hearit hearit3 = saveHearitWithKeyword(keyword);
+
+        KeywordSearchCondition condition = new KeywordSearchCondition(keyword.getId(), 1, 2); // page 1, size 2
+
+        // when
+        List<HearitSearchResponse> result = hearitSearchService.searchByKeyword(condition);
 
         // then
         assertAll(
@@ -174,4 +222,27 @@ class HearitSearchServiceTest {
         return dbHelper.insertHearit(hearit);
     }
 
+    private Keyword saveKeyword(String name) {
+        return dbHelper.insertKeyword(new Keyword(name));
+    }
+
+    private Hearit saveHearitWithKeyword(Keyword keyword) {
+        Category category = saveCategory("category", "#abc");
+
+        Hearit hearit = new Hearit(
+                "title",
+                "summary",
+                1,
+                "originalAudioUrl",
+                "shortAudioUrl",
+                "scriptUrl",
+                "source",
+                LocalDateTime.now(),
+                category
+        );
+
+        Hearit savedHearit = dbHelper.insertHearit(hearit);
+        dbHelper.insertHearitKeyword(new HearitKeyword(savedHearit, keyword));
+        return savedHearit;
+    }
 }

--- a/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
@@ -103,11 +103,9 @@ class HearitSearchServiceTest {
         // given
         Category category1 = saveCategory("Spring", "#001");
         Category category2 = saveCategory("Java", "#002");
-
         Hearit hearit1 = saveHearitWithCategory(category1);
         Hearit hearit2 = saveHearitWithCategory(category1);
         saveHearitWithCategory(category2);
-
         CategorySearchCondition condition = new CategorySearchCondition(category1.getId(), 0, 10);
 
         // when
@@ -126,11 +124,9 @@ class HearitSearchServiceTest {
     void searchHearitsByCategory_pagination() {
         // given
         Category category = saveCategory("Spring", "#001");
-
         Hearit hearit1 = saveHearitWithCategory(category);
         Hearit hearit2 = saveHearitWithCategory(category);
         Hearit hearit3 = saveHearitWithCategory(category);
-
         CategorySearchCondition condition = new CategorySearchCondition(category.getId(), 1, 2);
 
         // when
@@ -147,7 +143,14 @@ class HearitSearchServiceTest {
     private Hearit saveHearitByTitle(String title) {
         Category category = new Category("category", "#123");
         dbHelper.insertCategory(category);
-        Hearit hearit = new Hearit(title, "summary", 1, "originalAudioUrl", "shortAudioUrl", "scriptUrl", "source",
+        Hearit hearit = new Hearit(
+                title,
+                "summary",
+                1,
+                "originalAudioUrl",
+                "shortAudioUrl",
+                "scriptUrl",
+                "source",
                 LocalDateTime.now(), category);
         return dbHelper.insertHearit(hearit);
     }
@@ -158,8 +161,16 @@ class HearitSearchServiceTest {
     }
 
     private Hearit saveHearitWithCategory(Category category) {
-        Hearit hearit = new Hearit("title", "summary", 1, "originalAudioUrl", "shortAudioUrl", "scriptUrl", "source",
-                LocalDateTime.now(), category);
+        Hearit hearit = new Hearit(
+                "title",
+                "summary",
+                1,
+                "originalAudioUrl",
+                "shortAudioUrl",
+                "scriptUrl",
+                "source",
+                LocalDateTime.now(),
+                category);
         return dbHelper.insertHearit(hearit);
     }
 

--- a/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
@@ -1,0 +1,142 @@
+package com.onair.hearit.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.DbHelper;
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.domain.Keyword;
+import com.onair.hearit.dto.response.KeywordResponse;
+import com.onair.hearit.infrastructure.KeywordRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(DbHelper.class)
+@ActiveProfiles("fake-test")
+class KeywordServiceTest {
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Autowired
+    private KeywordRepository keywordRepository;
+    private KeywordService keywordService;
+
+    @BeforeEach
+    void setup() {
+        keywordService = new KeywordService(keywordRepository);
+    }
+
+    @Test
+    @DisplayName("전체 키워드를 조회할 수 있다.")
+    void getAllKeywords() {
+        // given
+        Keyword keyword1 = saveKeyword("keyword1");
+        Keyword keyword2 = saveKeyword("keyword2");
+        Keyword keyword3 = saveKeyword("keyword3");
+
+        // when
+        List<KeywordResponse> result = keywordService.getKeywords();
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(3),
+                () -> assertThat(result).extracting(KeywordResponse::id)
+                        .contains(keyword1.getId(), keyword2.getId(), keyword3.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("단일 키워드를 조회할 수 있다.")
+    void getKeywordById() {
+        // given
+        Keyword keyword = saveKeyword("keyword");
+
+        // when
+        KeywordResponse result = keywordService.getKeyword(keyword.getId());
+
+        // then
+        assertThat(result.id()).isEqualTo(keyword.getId());
+        assertThat(result.name()).isEqualTo(keyword.getName());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 키워드를 조회하면 NotFoundException이 발생한다.")
+    void getKeyword_notFound() {
+        // given
+        Long notExistId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> keywordService.getKeyword(notExistId))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("keywordId");
+    }
+
+    @Test
+    @DisplayName("오늘의 추천 키워드를 지정한 개수만큼 조회할 수 있다.")
+    void getRecommendedKeywords() {
+        // given
+        Keyword keyword1 = saveKeyword("keyword1");
+        Keyword keyword2 = saveKeyword("keyword2");
+        Keyword keyword3 = saveKeyword("keyword3");
+        Keyword keyword4 = saveKeyword("keyword4");
+        Keyword keyword5 = saveKeyword("keyword5");
+
+        int size = 3;
+
+        // when
+        List<KeywordResponse> result = keywordService.getRecommendedKeyword(1, size);
+
+        // then
+        assertThat(result).hasSize(size);
+        assertThat(result).extracting(KeywordResponse::id)
+                .allMatch(id -> List.of(
+                        keyword1.getId(), keyword2.getId(), keyword3.getId(),
+                        keyword4.getId(), keyword5.getId()
+                ).contains(id));
+    }
+
+    @Test
+    @DisplayName("같은 시드값으로 호출하면 추천 키워드 결과는 항상 동일하다.")
+    void getRecommendedKeywords_shouldBeDeterministicForSameSeed() {
+        // given
+        Keyword keyword1 = saveKeyword("keyword1");
+        Keyword keyword2 = saveKeyword("keyword2");
+        Keyword keyword3 = saveKeyword("keyword3");
+        Keyword keyword4 = saveKeyword("keyword4");
+        Keyword keyword5 = saveKeyword("keyword5");
+
+        int size = 3;
+        long fixedSeed = 20250722L;  // 시드 고정
+
+        // when
+        List<KeywordResponse> firstResponse = keywordService.getRecommendedKeyword(fixedSeed, size);
+        List<KeywordResponse> secondResponse = keywordService.getRecommendedKeyword(fixedSeed, size);
+
+        // then
+        assertThat(firstResponse).hasSize(size);
+        assertThat(secondResponse).hasSize(size);
+
+        assertThat(firstResponse)
+                .extracting(KeywordResponse::id)
+                .containsExactlyElementsOf(
+                        secondResponse.stream()
+                                .map(KeywordResponse::id)
+                                .toList()
+                );
+    }
+
+
+    private Keyword saveKeyword(String name) {
+        Keyword keyword = new Keyword(name);
+        return dbHelper.insertKeyword(keyword);
+    }
+} 

--- a/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
@@ -99,7 +99,6 @@ class KeywordServiceTest {
         assertThat(result).hasSize(size);
     }
 
-
     @Test
     @DisplayName("같은 시드값으로 호출하면 추천 키워드 결과는 항상 동일하다.")
     void getRecommendedKeywords_shouldBeDeterministicForSameSeed() {
@@ -122,7 +121,6 @@ class KeywordServiceTest {
                         second.stream().map(KeywordResponse::id).toList()
                 );
     }
-
 
     private Keyword saveKeyword(String name) {
         Keyword keyword = new Keyword(name);

--- a/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
@@ -84,53 +84,42 @@ class KeywordServiceTest {
     @DisplayName("오늘의 추천 키워드를 지정한 개수만큼 조회할 수 있다.")
     void getRecommendedKeywords() {
         // given
-        Keyword keyword1 = saveKeyword("keyword1");
-        Keyword keyword2 = saveKeyword("keyword2");
-        Keyword keyword3 = saveKeyword("keyword3");
-        Keyword keyword4 = saveKeyword("keyword4");
-        Keyword keyword5 = saveKeyword("keyword5");
+        saveKeyword("keyword1");
+        saveKeyword("keyword2");
+        saveKeyword("keyword3");
+        saveKeyword("keyword4");
+        saveKeyword("keyword5");
 
         int size = 3;
 
         // when
-        List<KeywordResponse> result = keywordService.getRecommendedKeyword(1, size);
+        List<KeywordResponse> result = keywordService.getRecommendedKeyword(1L, size);
 
         // then
         assertThat(result).hasSize(size);
-        assertThat(result).extracting(KeywordResponse::id)
-                .allMatch(id -> List.of(
-                        keyword1.getId(), keyword2.getId(), keyword3.getId(),
-                        keyword4.getId(), keyword5.getId()
-                ).contains(id));
     }
+
 
     @Test
     @DisplayName("같은 시드값으로 호출하면 추천 키워드 결과는 항상 동일하다.")
     void getRecommendedKeywords_shouldBeDeterministicForSameSeed() {
         // given
-        Keyword keyword1 = saveKeyword("keyword1");
-        Keyword keyword2 = saveKeyword("keyword2");
-        Keyword keyword3 = saveKeyword("keyword3");
-        Keyword keyword4 = saveKeyword("keyword4");
-        Keyword keyword5 = saveKeyword("keyword5");
-
+        saveKeyword("keyword1");
+        saveKeyword("keyword2");
+        saveKeyword("keyword3");
+        saveKeyword("keyword4");
+        saveKeyword("keyword5");
         int size = 3;
-        long fixedSeed = 20250722L;  // 시드 고정
+        long fixedSeed = 20250722L;
 
         // when
-        List<KeywordResponse> firstResponse = keywordService.getRecommendedKeyword(fixedSeed, size);
-        List<KeywordResponse> secondResponse = keywordService.getRecommendedKeyword(fixedSeed, size);
+        List<KeywordResponse> first = keywordService.getRecommendedKeyword(fixedSeed, size);
+        List<KeywordResponse> second = keywordService.getRecommendedKeyword(fixedSeed, size);
 
         // then
-        assertThat(firstResponse).hasSize(size);
-        assertThat(secondResponse).hasSize(size);
-
-        assertThat(firstResponse)
-                .extracting(KeywordResponse::id)
+        assertThat(first).extracting(KeywordResponse::id)
                 .containsExactlyElementsOf(
-                        secondResponse.stream()
-                                .map(KeywordResponse::id)
-                                .toList()
+                        second.stream().map(KeywordResponse::id).toList()
                 );
     }
 

--- a/backend/src/test/java/com/onair/hearit/infrastructure/KeywordRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/KeywordRepositoryTest.java
@@ -24,40 +24,36 @@ class KeywordRepositoryTest {
     private DbHelper dbHelper;
 
     @Test
-    @DisplayName("지정한 개수만큼 랜덤 키워드를 조회할 수 있다.")
-    void findRandomWithSeed_returnsSpecifiedSize() {
+    @DisplayName("저장된 키워드들의 ID 목록을 조회할 수 있다.")
+    void findAllIds_returnsAllKeywordIds() {
         // given
-        saveKeyword("keyword1");
-        saveKeyword("keyword2");
-        saveKeyword("keyword3");
-        saveKeyword("keyword4");
-        saveKeyword("keyword5");
-
-        int size = 3;
-        long seed = 12345L;
+        Keyword keyword1 = saveKeyword("keyword1");
+        Keyword keyword2 = saveKeyword("keyword2");
+        Keyword keyword3 = saveKeyword("keyword3");
 
         // when
-        List<Keyword> result = keywordRepository.findRandomWithSeed(seed, size);
+        List<Long> ids = keywordRepository.findAllIds();
 
         // then
-        assertThat(result).hasSize(size);
+        assertThat(ids).containsExactlyInAnyOrder(keyword1.getId(), keyword2.getId(), keyword3.getId());
     }
 
     @Test
-    @DisplayName("전체 키워드 수보다 더 많은 개수를 요청하면 모든 키워드를 반환한다.")
-    void findRandomWithSeed_whenSizeExceedsTotal_returnsAll() {
+    @DisplayName("ID 목록으로 키워드를 조회할 수 있다.")
+    void findAllByIdIn_returnsMatchingKeywords() {
         // given
-        saveKeyword("keyword1");
-        saveKeyword("keyword2");
+        Keyword keyword1 = saveKeyword("keyword1");
+        Keyword keyword2 = saveKeyword("keyword2");
+        saveKeyword("keyword3");
 
-        int requestedSize = 5;
-        long seed = 999L;
+        List<Long> selectedIds = List.of(keyword1.getId(), keyword2.getId());
 
         // when
-        List<Keyword> result = keywordRepository.findRandomWithSeed(seed, requestedSize);
+        List<Keyword> result = keywordRepository.findAllByIdIn(selectedIds);
 
         // then
-        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Keyword::getId)
+                .containsExactlyInAnyOrderElementsOf(selectedIds);
     }
 
     private Keyword saveKeyword(String name) {

--- a/backend/src/test/java/com/onair/hearit/infrastructure/KeywordRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/KeywordRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.onair.hearit.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.onair.hearit.DbHelper;
+import com.onair.hearit.domain.Keyword;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import(DbHelper.class)
+@ActiveProfiles("fake-test")
+class KeywordRepositoryTest {
+
+    @Autowired
+    private KeywordRepository keywordRepository;
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Test
+    @DisplayName("지정한 개수만큼 랜덤 키워드를 조회할 수 있다.")
+    void findRandomWithSeed_returnsSpecifiedSize() {
+        // given
+        saveKeyword("keyword1");
+        saveKeyword("keyword2");
+        saveKeyword("keyword3");
+        saveKeyword("keyword4");
+        saveKeyword("keyword5");
+
+        int size = 3;
+        long seed = 12345L;
+
+        // when
+        List<Keyword> result = keywordRepository.findRandomWithSeed(seed, size);
+
+        // then
+        assertThat(result).hasSize(size);
+    }
+
+    @Test
+    @DisplayName("전체 키워드 수보다 더 많은 개수를 요청하면 모든 키워드를 반환한다.")
+    void findRandomWithSeed_whenSizeExceedsTotal_returnsAll() {
+        // given
+        saveKeyword("keyword1");
+        saveKeyword("keyword2");
+
+        int requestedSize = 5;
+        long seed = 999L;
+
+        // when
+        List<Keyword> result = keywordRepository.findRandomWithSeed(seed, requestedSize);
+
+        // then
+        assertThat(result).hasSize(2);
+    }
+
+    private Keyword saveKeyword(String name) {
+        return dbHelper.insertKeyword(new Keyword(name));
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -256,8 +256,6 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("유효하지 않은 page 또는 size 값이 주어지면 400 BAD_REQUEST를 반환한다.")
     void searchHearitsByKeywordWithInvalidParams() {
         Keyword keyword = saveKeyword("DevOps");
-
-        // page 음수
         RestAssured.given()
                 .queryParam("keywordId", keyword.getId())
                 .queryParam("page", -1)

--- a/backend/src/test/java/com/onair/hearit/presentation/KeywordControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/KeywordControllerTest.java
@@ -1,0 +1,95 @@
+package com.onair.hearit.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.onair.hearit.domain.Keyword;
+import io.restassured.RestAssured;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class KeywordControllerTest extends IntegrationTest {
+
+    @Test
+    @DisplayName("전체 키워드를 조회 시 200 OK 및 모든 키워드 목록을 반환한다.")
+    void readAllKeywords() {
+        // given
+        saveKeyword("keyword1");
+        saveKeyword("keyword2");
+        saveKeyword("keyword3");
+
+        // when
+        List<Keyword> result = RestAssured.given()
+                .when()
+                .get("/api/v1/keyword")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList(".", Keyword.class);
+
+        // then
+        assertThat(result).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("단일 키워드 조회 시 200 OK 및 해당 키워드 정보를 반환한다.")
+    void readSingleKeyword() {
+        // given
+        Keyword keyword = saveKeyword("keyword");
+
+        // when
+        Keyword result = RestAssured.given()
+                .when()
+                .get("/api/v1/keyword/" + keyword.getId())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(Keyword.class);
+
+        // then
+        assertThat(result.getId()).isEqualTo(keyword.getId());
+        assertThat(result.getName()).isEqualTo(keyword.getName());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 키워드를 조회 시 404 NOT_FOUND를 반환한다.")
+    void readNotFoundKeyword() {
+        // when & then
+        RestAssured.given()
+                .when()
+                .get("/api/v1/keyword/999")
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("추천 키워드 조회 시 200 OK 및 요청 개수만큼의 키워드를 반환한다.")
+    void readRecommendedKeywords() {
+        // given
+        saveKeyword("keyword1");
+        saveKeyword("keyword2");
+        saveKeyword("keyword3");
+
+        int size = 2;
+
+        // when
+        List<Keyword> result = RestAssured.given()
+                .param("size", size)
+                .when()
+                .get("/api/v1/keyword/recommend")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList(".", Keyword.class);
+
+        // then
+        assertThat(result).hasSize(size);
+    }
+
+    private Keyword saveKeyword(String name) {
+        return dbHelper.insertKeyword(new Keyword(name));
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 카테고리 및 키워드 기반 히어릿 검색 API 구현 (/search/category, /search/keyword)
- 카테고리 및 키워드 조회 기능 추가 (전체 조회, 단일 조회, 추천 키워드)
- 랜덤 키워드 추천 로직 추가 (GET /keyword/recommend)

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #83 