### PR TITLE
[BE] fix: 개발서버 스웨거 문서에서의 CORS 문제 해결 및 문서 업데이트

### DIFF
--- a/backend/src/main/java/com/onair/hearit/auth/config/CorsConfig.java
+++ b/backend/src/main/java/com/onair/hearit/auth/config/CorsConfig.java
@@ -1,0 +1,26 @@
+package com.onair.hearit.auth.config;
+
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOriginPatterns(List.of("http://localhost:80"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/onair/hearit/auth/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.onair.hearit.auth.config;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 import com.onair.hearit.auth.infrastructure.jwt.JwtAuthenticationFilter;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
+                .cors(withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth

--- a/backend/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
@@ -6,6 +6,7 @@ import com.onair.hearit.auth.dto.request.LoginRequest;
 import com.onair.hearit.auth.dto.request.SignupRequest;
 import com.onair.hearit.auth.dto.response.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +38,11 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "회원가입", description = "새로운 계정을 생성합니다.")
+    @Operation(summary = "회원가입", description = "새로운 계정을 생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+                    @ApiResponse(responseCode = "400", description = "중복된 이메일")
+            })
     @PostMapping("/signup")
     public ResponseEntity<Void> signup(@RequestBody SignupRequest request) {
         authService.signup(request);

--- a/backend/src/main/java/com/onair/hearit/common/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/onair/hearit/common/config/SwaggerConfig.java
@@ -29,7 +29,7 @@ public class SwaggerConfig {
                         .description("히어릿 백엔드 API 문서")
                         .version("v1"))
                 .servers(List.of(
-                        new Server().url("http://localhost:8080").description("로컬 서버"),
+                        new Server().url("http://localhost:80").description("로컬 서버"),
                         new Server().url("http://hearit.o-r.kr").description("운영 서버")
                 ));
     }

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -5,6 +5,7 @@ import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.dto.request.BookmarkListCondition;
 import com.onair.hearit.dto.response.BookmarkHearitResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.net.URI;
 import java.util.List;
@@ -38,7 +39,11 @@ public class BookmarkController {
         return ResponseEntity.ok(responses);
     }
 
-    @Operation(summary = "북마크 생성", description = "로그인한 회원이 히어릿 ID로 북마크를 생성합니다.")
+    @Operation(summary = "북마크 생성", description = "로그인한 회원이 히어릿 ID로 북마크를 생성합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "북마크 성공"),
+                    @ApiResponse(responseCode = "400", description = "이미 북마크된 히어릿")
+            })
     @PostMapping("/{hearitId}/bookmarks")
     public ResponseEntity<Void> createBookmark(
             @PathVariable Long hearitId,


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 로컬 스웨거 문서(localhost:80) -> 배포서버([http://hearit.o-r.kr)로](http://hearit.o-r.xn--kr)-ky7m/) 요청을 보낼 시 CORS 발생
- 해당 문제 해결을 위해 CorsConfig 설정, 개발서버에서 보내는 POST, GET, PUT, DELETE 요청은 허용하도록 함

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
1. 스웨거 문서 접속(localhost/docs)
2. 개발서버(localhost:80) 선택
3. 아무 api 실험
4. CORS가 안 터지는 것을 확인한 후 웃음짓기

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->
swagger 진짜 구린거같아요
response를 직접 지정해줘야되다니
200인지 201인지에 따라서 클라이언트는 어떻게 처리해야될지 다를수도있는디
얼른 restdocs 기반 + swagger를 적용해보도록해용

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #119 