### PR TITLE
[BE] refactor: 히어릿 검색 및 카테고리 조회 응답을 PagedResponse로 리팩터링 #141

### DIFF
--- a/backend/src/main/java/com/onair/hearit/application/CategoryService.java
+++ b/backend/src/main/java/com/onair/hearit/application/CategoryService.java
@@ -5,6 +5,7 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.CategoryResponse;
 import com.onair.hearit.dto.response.HearitSearchResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.CategoryRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
 import java.util.List;
@@ -29,11 +30,10 @@ public class CategoryService {
                 .toList();
     }
 
-    public List<HearitSearchResponse> findHearitsByCategory(Long categoryId, PagingRequest pagingRequest) {
+    public PagedResponse<HearitSearchResponse> findHearitsByCategory(Long categoryId, PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> result = hearitRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
-        return result.stream()
-                .map(HearitSearchResponse::from)
-                .toList();
+        Page<HearitSearchResponse> response = result.map(HearitSearchResponse::from);
+        return PagedResponse.from(response);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitSearchService.java
@@ -3,8 +3,8 @@ package com.onair.hearit.application;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.HearitSearchResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,16 +15,13 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class HearitSearchService {
 
-    private static final String LIKE_PATTERN_TEMPLATE = "%%%s%%";
-
     private final HearitRepository hearitRepository;
 
-    public List<HearitSearchResponse> search(String searchTerm, PagingRequest pagingRequest) {
+    public PagedResponse<HearitSearchResponse> search(String searchTerm, PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> hearits = hearitRepository.searchByTerm(searchTerm, pageable);
-        return hearits.stream()
-                .map(HearitSearchResponse::from)
-                .toList();
+        Page<HearitSearchResponse> response = hearits.map(HearitSearchResponse::from);
+        return PagedResponse.from(response);
     }
 }
 

--- a/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
@@ -17,8 +17,8 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
     @Query(value = """
             SELECT DISTINCT h.*
             FROM hearit h
-            LEFT JOIN hearit_keyword hk ON h.id = hk.hearit_id
-            LEFT JOIN keyword k ON hk.keyword_id = k.id
+            JOIN hearit_keyword hk ON h.id = hk.hearit_id
+            JOIN keyword k ON hk.keyword_id = k.id
             WHERE
                 LOWER(h.title) LIKE LOWER(CONCAT('%', :searchTerm, '%'))
                 OR LOWER(k.name) LIKE LOWER(CONCAT('%', :searchTerm, '%'))

--- a/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
@@ -4,6 +4,7 @@ import com.onair.hearit.application.CategoryService;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.CategoryResponse;
 import com.onair.hearit.dto.response.HearitSearchResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -35,12 +36,12 @@ public class CategoryController {
 
     @Operation(summary = "카테고리 id로 히어릿 카테고리로 조회", description = "히어릿의 카테고리 id, page 정보를 입력해 히어릿을 조회합니다. ")
     @GetMapping("/{categoryId}/hearits")
-    public ResponseEntity<List<HearitSearchResponse>> searchHearitsByCategory(
+    public ResponseEntity<PagedResponse<HearitSearchResponse>> searchHearitsByCategory(
             @PathVariable Long categoryId,
             @RequestParam(name = "page", defaultValue = "0") Integer page,
             @RequestParam(name = "size", defaultValue = "20") Integer size) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        List<HearitSearchResponse> response = categoryService.findHearitsByCategory(categoryId, pagingRequest);
+        PagedResponse<HearitSearchResponse> response = categoryService.findHearitsByCategory(categoryId, pagingRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -6,6 +6,7 @@ import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.HearitDetailResponse;
 import com.onair.hearit.dto.response.HearitSearchResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.dto.response.RandomHearitResponse;
 import com.onair.hearit.dto.response.RecommendHearitResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -67,12 +68,12 @@ public class HearitController {
 
     @Operation(summary = "검색어를 입력해 히어릿을 검색", description = "검색어를 포함하는 제목 또는 키워드를 가진 히어릿을 검색합니다. ")
     @GetMapping("/search")
-    public ResponseEntity<List<HearitSearchResponse>> searchHearitsByTitle(
+    public ResponseEntity<PagedResponse<HearitSearchResponse>> searchHearitsByTitle(
             @RequestParam(name = "searchTerm") String searchTerm,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        List<HearitSearchResponse> response = hearitSearchService.search(searchTerm, pagingRequest);
+        PagedResponse<HearitSearchResponse> response = hearitSearchService.search(searchTerm, pagingRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
@@ -9,6 +9,7 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.CategoryResponse;
 import com.onair.hearit.dto.response.HearitSearchResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.CategoryRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
 import java.time.LocalDateTime;
@@ -79,12 +80,12 @@ class CategoryServiceTest {
         PagingRequest request = new PagingRequest(0, 10);
 
         // when
-        List<HearitSearchResponse> result = categoryService.findHearitsByCategory(category1.getId(), request);
+        PagedResponse<HearitSearchResponse> result = categoryService.findHearitsByCategory(category1.getId(), request);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(2),
-                () -> assertThat(result).extracting(HearitSearchResponse::id)
+                () -> assertThat(result.content()).hasSize(2),
+                () -> assertThat(result.content()).extracting(HearitSearchResponse::id)
                         .containsExactlyInAnyOrder(hearit2.getId(), hearit1.getId())
         );
     }
@@ -100,12 +101,12 @@ class CategoryServiceTest {
         PagingRequest request = new PagingRequest(1, 2);
 
         // when
-        List<HearitSearchResponse> result = categoryService.findHearitsByCategory(category.getId(), request);
+        PagedResponse<HearitSearchResponse> result = categoryService.findHearitsByCategory(category.getId(), request);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(1),
-                () -> assertThat(result.get(0).id()).isEqualTo(hearit1.getId())
+                () -> assertThat(result.content()).hasSize(1),
+                () -> assertThat(result.content().get(0).id()).isEqualTo(hearit1.getId())
         );
     }
 

--- a/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
@@ -10,9 +10,9 @@ import com.onair.hearit.domain.HearitKeyword;
 import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.HearitSearchResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.HearitRepository;
 import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,17 +49,17 @@ class HearitSearchServiceTest {
         Hearit hearit2 = saveHearitWithTitleAndKeyword("wwSpring1ww", saveKeyword("keyword2"));      // 제목에 검색어 포함됨
         Hearit hearit3 = saveHearitWithTitleAndKeyword("noSpring", saveKeyword("Spring"));           // 제목에 검색어 포함됨
         Hearit hearit4 = saveHearitWithTitleAndKeyword("pring", saveKeyword("sring"));               // 검색어서 제외됨
-        Hearit hearit5 = saveHearitWithTitleAndKeyword("notitle", saveKeyword("noKeyword"));         // 검색에서 제외됨
+        saveHearitWithTitleAndKeyword("notitle", saveKeyword("noKeyword"));         // 검색에서 제외됨
 
         // when
-        List<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(4),
-                () -> assertThat(result).extracting(HearitSearchResponse::id)
+                () -> assertThat(result.content()).hasSize(4),
+                () -> assertThat(result.content()).extracting(HearitSearchResponse::id)
                         .containsExactlyInAnyOrder(hearit.getId(), hearit1.getId(), hearit2.getId(), hearit3.getId()),
-                () -> assertThat(result).extracting(HearitSearchResponse::id).doesNotContain(hearit4.getId())
+                () -> assertThat(result.content()).extracting(HearitSearchResponse::id).doesNotContain(hearit4.getId())
         );
     }
 
@@ -75,14 +75,14 @@ class HearitSearchServiceTest {
         Hearit hearit4 = saveHearitWithTitleAndKeyword("noTitle", saveKeyword("noKeyword"));   // 검색에서 제외됨
 
         // when
-        List<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(3),
-                () -> assertThat(result).extracting(HearitSearchResponse::id)
+                () -> assertThat(result.content()).hasSize(3),
+                () -> assertThat(result.content()).extracting(HearitSearchResponse::id)
                         .containsExactlyInAnyOrder(hearit.getId(), hearit1.getId(), hearit2.getId()),
-                () -> assertThat(result).extracting(HearitSearchResponse::id)
+                () -> assertThat(result.content()).extracting(HearitSearchResponse::id)
                         .doesNotContain(hearit3.getId(), hearit4.getId())
         );
     }
@@ -99,18 +99,17 @@ class HearitSearchServiceTest {
         Hearit neither = saveHearitWithTitleAndKeyword("notitle", saveKeyword("nokeyword")); // 둘 다 매칭 안 됨
 
         // when
-        List<HearitSearchResponse> result = hearitSearchService.search("spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("spring", request);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(3),
-                () -> assertThat(result).extracting(HearitSearchResponse::id)
+                () -> assertThat(result.content()).hasSize(3),
+                () -> assertThat(result.content()).extracting(HearitSearchResponse::id)
                         .containsExactlyInAnyOrder(titleOnly.getId(), keywordOnly.getId(), bothMatch.getId()),
-                () -> assertThat(result).extracting(HearitSearchResponse::id)
+                () -> assertThat(result.content()).extracting(HearitSearchResponse::id)
                         .doesNotContain(neither.getId())
         );
     }
-
 
     @Test
     @DisplayName("히어릿 목록을 검색으로 조회 시 최신순으로 정렬되어 반환된다.")
@@ -122,17 +121,16 @@ class HearitSearchServiceTest {
         Hearit hearit3 = saveHearitWithTitleAndKeyword("notitle", saveKeyword("springKeyword"));   // latest
 
         // when
-        List<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(3),
-                () -> assertThat(result.get(0).id()).isEqualTo(hearit3.getId()),
-                () -> assertThat(result.get(1).id()).isEqualTo(hearit2.getId()),
-                () -> assertThat(result.get(2).id()).isEqualTo(hearit1.getId())
+                () -> assertThat(result.content()).hasSize(3),
+                () -> assertThat(result.content().get(0).id()).isEqualTo(hearit3.getId()),
+                () -> assertThat(result.content().get(1).id()).isEqualTo(hearit2.getId()),
+                () -> assertThat(result.content().get(2).id()).isEqualTo(hearit1.getId())
         );
     }
-
 
     @Test
     @DisplayName("히어릿 목록을 검색으로 조회 시 페이지네이션이 적용되어 반환된다.")
@@ -144,12 +142,12 @@ class HearitSearchServiceTest {
         Hearit hearit3 = saveHearitWithTitleAndKeyword("otherTitle", saveKeyword("Spring"));
 
         // when
-        List<HearitSearchResponse> result = hearitSearchService.search("spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("spring", request);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(1),
-                () -> assertThat(result.get(0).id()).isEqualTo(hearit1.getId())
+                () -> assertThat(result.content()).hasSize(1),
+                () -> assertThat(result.content().get(0).id()).isEqualTo(hearit1.getId())
         );
     }
 

--- a/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
@@ -68,8 +68,8 @@ class HearitRepositoryTest {
     @DisplayName("제목 또는 키워드에 검색어가 포함된 히어릿을 반환한다.")
     void searchByTerm_filterByTitleOrKeyword() {
         // given
-        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("SpringKeyword"));
-        Keyword keyword2 = dbHelper.insertKeyword(new Keyword("NotMatched"));
+        Keyword keyword1 = saveKeyword("Springboot");
+        Keyword keyword2 = saveKeyword("NotMatched");
 
         Hearit titleMatched = saveHearitWithTitleAndKeyword("SpringBoot is great", keyword2); // 제목만 매칭
         Hearit keywordMatched = saveHearitWithTitleAndKeyword("No match in title", keyword1); // 키워드만 매칭
@@ -78,7 +78,7 @@ class HearitRepositoryTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        Page<Hearit> result = hearitRepository.searchByTerm("%spring%", pageable);
+        Page<Hearit> result = hearitRepository.searchByTerm("spring", pageable);
 
         // then
         assertAll(
@@ -101,7 +101,7 @@ class HearitRepositoryTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
-        Page<Hearit> result = hearitRepository.searchByTerm("%spring%", pageable);
+        Page<Hearit> result = hearitRepository.searchByTerm("spring", pageable);
 
         // then
         assertAll(
@@ -127,22 +127,6 @@ class HearitRepositoryTest {
         return dbHelper.insertHearit(hearit);
     }
 
-    private Hearit saveHearitByTitle(String title) {
-        Category category = new Category("category", "#123");
-        dbHelper.insertCategory(category);
-        Hearit hearit = new Hearit(
-                title,
-                "summary",
-                1,
-                "originalAudioUrl",
-                "shortAudioUrl",
-                "scriptUrl",
-                "source",
-                LocalDateTime.now(),
-                category);
-        return dbHelper.insertHearit(hearit);
-    }
-
     private Category saveCategory(String name, String colorCode) {
         Category category = new Category(name, colorCode);
         return dbHelper.insertCategory(category);
@@ -156,4 +140,9 @@ class HearitRepositoryTest {
         dbHelper.insertHearitKeyword(new HearitKeyword(savedHearit, keyword));
         return savedHearit;
     }
+
+    private Keyword saveKeyword(String name) {
+        return dbHelper.insertKeyword(new Keyword(name));
+    }
+
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
@@ -7,7 +7,9 @@ import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.CategoryResponse;
 import com.onair.hearit.dto.response.HearitSearchResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -57,11 +59,10 @@ class CategoryControllerTest extends IntegrationTest {
 
         Hearit hearit1 = saveHearitWithCategory(category1);
         Hearit hearit2 = saveHearitWithCategory(category1);
-
-        saveHearitWithCategory(category2);
+        saveHearitWithCategory(category2); // 다른 카테고리
 
         // when
-        List<HearitSearchResponse> responses = RestAssured
+        PagedResponse<HearitSearchResponse> pagedResponse = RestAssured
                 .given()
                 .pathParam("categoryId", category1.getId())
                 .queryParam("page", 0)
@@ -71,8 +72,9 @@ class CategoryControllerTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .jsonPath()
-                .getList(".", HearitSearchResponse.class);
+                .as(new TypeRef<>() {
+                });
+        List<HearitSearchResponse> responses = pagedResponse.content();
 
         // then
         assertAll(
@@ -81,6 +83,7 @@ class CategoryControllerTest extends IntegrationTest {
                 () -> assertThat(responses.get(1).id()).isEqualTo(hearit1.getId())
         );
     }
+
 
     private Category saveCategory(String name, String color) {
         return dbHelper.insertCategory(new Category(name, color));


### PR DESCRIPTION
## 📌 변경 내용 & 이유
- 기존에 `List<HearitSearchResponse>` 형태로 반환되던 히어릿 검색 및 카테고리 기반 조회 API 응답을 `PagedResponse<HearitSearchResponse>`로 감싸는 형태로 수정
- Repository 쿼리 중 불필요한 `LEFT JOIN`을 `INNER JOIN`으로 변경하여 성능 최적화 및 중복 제거

## 📸 스크린샷 (선택)

## 🧪 테스트 방법
- `CategoryServiceTest`, `HearitSearchServiceTest`, `HearitControllerTest`, `CategoryControllerTest`에 포함된 기존 테스트들이 모두 `PagedResponse`를 기준으로 수정
- RestAssured 기반 테스트에서 `.jsonPath().getList()` → `.as(new TypeRef<>())` 로 타입 추출 방식 변경

## 📢 논의하고 싶은 내용

## 🧩 관련 이슈
- close #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results for Hearits (by title, keyword, or category) now provide paginated responses, including pagination metadata for easier navigation through large result sets.

* **Bug Fixes**
  * Improved search accuracy by only returning Hearits that have associated keywords.

* **Tests**
  * Updated all relevant tests to handle paginated responses and reflect the expanded search matching criteria for both titles and keywords.
  * Refactored test setup for improved code reuse and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->