### PR TITLE
[BE] 북마크 생성 시 response 추가 및 응답 형식 변경

### DIFF
--- a/backend/src/main/java/com/onair/hearit/admin/application/AdminHearitService.java
+++ b/backend/src/main/java/com/onair/hearit/admin/application/AdminHearitService.java
@@ -43,8 +43,8 @@ public class AdminHearitService {
         List<HearitKeyword> hearitKeywords = hearitKeywordRepository.findByHearitIdIn(hearitIds);
         Map<Long, List<KeywordInHearit>> keywordMap = mapKeywordsByHearitId(hearitKeywords);
 
-        Page<HearitAdminResponse> dtoPage = hearits.map(h -> HearitAdminResponse.from(h, keywordMap));
-        return PagedResponse.from(dtoPage);
+        Page<HearitAdminResponse> hearitDtos = hearits.map(h -> HearitAdminResponse.from(h, keywordMap));
+        return PagedResponse.from(hearitDtos);
     }
 
     private List<Long> extractHearitIds(Page<Hearit> hearits) {

--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -8,6 +8,7 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.BookmarkRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
@@ -37,14 +38,15 @@ public class BookmarkService {
     }
 
     @Transactional
-    public void addBookmark(Long hearitId, Long memberId) {
+    public BookmarkInfoResponse addBookmark(Long hearitId, Long memberId) {
         if (bookmarkRepository.existsByHearitIdAndMemberId(hearitId, memberId)) {
             throw new AlreadyExistException("이미 북마크된 히어릿입니다.");
         }
         Hearit hearit = getHearitById(hearitId);
         Member member = getMemberById(memberId);
         Bookmark bookmark = new Bookmark(member, hearit);
-        bookmarkRepository.save(bookmark);
+        Bookmark saved = bookmarkRepository.save(bookmark);
+        return BookmarkInfoResponse.from(saved);
     }
 
     @Transactional

--- a/backend/src/main/java/com/onair/hearit/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitSearchService.java
@@ -20,8 +20,7 @@ public class HearitSearchService {
     public PagedResponse<HearitSearchResponse> search(String searchTerm, PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> hearits = hearitRepository.searchByTerm(searchTerm, pageable);
-        Page<HearitSearchResponse> response = hearits.map(HearitSearchResponse::from);
-        return PagedResponse.from(response);
+        Page<HearitSearchResponse> hearitDtos = hearits.map(HearitSearchResponse::from);
+        return PagedResponse.from(hearitDtos);
     }
 }
-

--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -5,6 +5,7 @@ import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.HearitDetailResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.dto.response.RandomHearitResponse;
 import com.onair.hearit.dto.response.RecommendHearitResponse;
 import com.onair.hearit.infrastructure.BookmarkRepository;
@@ -40,12 +41,11 @@ public class HearitService {
                 .orElseThrow(() -> new NotFoundException("hearitId", hearitId.toString()));
     }
 
-    public List<RandomHearitResponse> getRandomHearits(Long memberId, PagingRequest pagingRequest) {
+    public PagedResponse<RandomHearitResponse> getRandomHearits(Long memberId, PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> hearits = hearitRepository.findRandom(pageable);
-        return hearits.stream()
-                .map(hearit -> toRandomHearitResponse(hearit, memberId))
-                .toList();
+        Page<RandomHearitResponse> hearitDtos = hearits.map(hearit -> toRandomHearitResponse(hearit, memberId));
+        return PagedResponse.from(hearitDtos);
     }
 
     private RandomHearitResponse toRandomHearitResponse(Hearit hearit, Long memberId) {

--- a/backend/src/main/java/com/onair/hearit/dto/response/BookmarkInfoResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/BookmarkInfoResponse.java
@@ -1,0 +1,12 @@
+package com.onair.hearit.dto.response;
+
+import com.onair.hearit.domain.Bookmark;
+
+public record BookmarkInfoResponse(
+        Long id
+) {
+
+    public static BookmarkInfoResponse from(Bookmark bookmark) {
+        return new BookmarkInfoResponse(bookmark.getId());
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -4,6 +4,7 @@ import com.onair.hearit.application.BookmarkService;
 import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.dto.response.PagedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -50,11 +51,11 @@ public class BookmarkController {
                             content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
             })
     @PostMapping("/{hearitId}/bookmarks")
-    public ResponseEntity<Void> createBookmark(
+    public ResponseEntity<BookmarkInfoResponse> createBookmark(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal CurrentMember member) {
-        bookmarkService.addBookmark(hearitId, member.memberId());
-        return ResponseEntity.created(URI.create("/api/v1/hearits/" + hearitId)).build();
+        BookmarkInfoResponse response = bookmarkService.addBookmark(hearitId, member.memberId());
+        return ResponseEntity.created(URI.create("/api/v1/hearits/" + hearitId)).body(response);
     }
 
     @Operation(summary = "북마크 삭제", description = "로그인한 히어릿 ID와 북마크 ID로 북마크를 삭제합니다.")

--- a/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
@@ -24,7 +24,7 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
-    @Operation(summary = "전체 카테고리 목록 조회", description = "전체 카테고리 목록들을 조회합니다.")
+    @Operation(summary = "전체 카테고리 목록을 조회", description = "전체 카테고리 목록들을 조회합니다.")
     @GetMapping
     public ResponseEntity<List<CategoryResponse>> readCategories(
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -42,13 +42,13 @@ public class HearitController {
 
     @Operation(summary = "랜덤 히어릿 조회", description = "랜덤 히어릿을 page, size로 목록을 조회합니다.")
     @GetMapping("/random")
-    public ResponseEntity<List<RandomHearitResponse>> readRandomHearits(
+    public ResponseEntity<PagedResponse<RandomHearitResponse>> readRandomHearits(
             @AuthenticationPrincipal CurrentMember member,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "10") int size) {
         Long memberId = extractMemberId(member);
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        List<RandomHearitResponse> responses = hearitService.getRandomHearits(memberId, pagingRequest);
+        PagedResponse<RandomHearitResponse> responses = hearitService.getRandomHearits(memberId, pagingRequest);
         return ResponseEntity.ok(responses);
     }
 

--- a/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
@@ -2,6 +2,7 @@ package com.onair.hearit.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.TestFixture;
 import com.onair.hearit.DbHelper;
@@ -13,6 +14,7 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.infrastructure.BookmarkRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
 import com.onair.hearit.infrastructure.MemberRepository;
@@ -75,11 +77,14 @@ class BookmarkServiceTest {
         int previousBookmarkCount = bookmarkRepository.findAll().size();
 
         // when
-        bookmarkService.addBookmark(hearit.getId(), member.getId());
+        BookmarkInfoResponse response = bookmarkService.addBookmark(hearit.getId(), member.getId());
 
         // then
         int currentBookmarkCount = bookmarkRepository.findAll().size();
-        assertThat(previousBookmarkCount + 1).isEqualTo(currentBookmarkCount);
+        assertAll(() -> {
+            assertThat(previousBookmarkCount + 1).isEqualTo(currentBookmarkCount);
+            assertThat(response.id()).isNotNull();
+        });
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -13,6 +13,7 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.HearitDetailResponse;
+import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.dto.response.RandomHearitResponse;
 import com.onair.hearit.dto.response.RecommendHearitResponse;
 import com.onair.hearit.infrastructure.BookmarkRepository;
@@ -95,10 +96,10 @@ class HearitServiceTest {
         PagingRequest pagingRequest = new PagingRequest(0, 10);
 
         // when
-        List<RandomHearitResponse> hearits = hearitService.getRandomHearits(member.getId(), pagingRequest);
+        PagedResponse<RandomHearitResponse> hearits = hearitService.getRandomHearits(member.getId(), pagingRequest);
 
         // then
-        assertThat(hearits).hasSize(10);
+        assertThat(hearits.content()).hasSize(10);
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -1,5 +1,6 @@
 package com.onair.hearit.presentation;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import com.onair.TestFixture;
@@ -8,6 +9,7 @@ import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.Member;
+import com.onair.hearit.dto.response.BookmarkInfoResponse;
 import io.restassured.RestAssured;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -97,12 +99,15 @@ class BookmarkControllerTest extends IntegrationTest {
         Hearit hearit = saveHearitWithSuffix(1);
 
         // when & then
-        RestAssured.given()
+        BookmarkInfoResponse response = RestAssured.given()
                 .header("Authorization", "Bearer " + token)
                 .when()
                 .post("/api/v1/hearits/" + hearit.getId() + "/bookmarks")
                 .then()
-                .statusCode(HttpStatus.CREATED.value());
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().as(BookmarkInfoResponse.class);
+
+        assertThat(response.id()).isNotNull();
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -95,17 +95,17 @@ class HearitControllerTest extends IntegrationTest {
         saveHearitWithSuffix(3);
 
         // when
-        List<RandomHearitResponse> responses = RestAssured.given()
+        PagedResponse<RandomHearitResponse> responses = RestAssured.given()
                 .when()
                 .get("/api/v1/hearits/random")
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .jsonPath()
-                .getList(".", RandomHearitResponse.class);
+                .as(new TypeRef<>() {
+                });
 
         // then
-        assertThat(responses).hasSize(3);
+        assertThat(responses.content()).hasSize(3);
     }
 
     @Test


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 북마크 삭제 시 북마크 id 필요
- 페이징 시 PagedResponse 로의 통일된 결과 반환

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a comprehensive backend API for managing hearits, categories, keywords, bookmarks, and user authentication.
  * Added admin web interfaces for managing hearits, categories, and keywords with full CRUD capabilities and pagination.
  * Implemented user authentication with local and Kakao social login, JWT-based security, and member profile management.
  * Enabled bookmark functionality for hearits, including add, remove, and paginated retrieval.
  * Provided endpoints for searching hearits, retrieving random/recommended hearits, and accessing associated audio/script files.
  * Added robust error handling and standardized API documentation with Swagger UI.

* **Bug Fixes**
  * Not applicable (initial implementation).

* **Documentation**
  * Added Swagger/OpenAPI documentation for all public endpoints.
  * Included detailed API descriptions and response schemas.

* **Style**
  * Not applicable.

* **Tests**
  * Added extensive unit and integration tests for services and controllers, covering core functionalities and error scenarios.

* **Chores**
  * Configured CI/CD pipelines, database containers, and environment-specific settings for streamlined development and deployment.

* **Refactor**
  * Not applicable.

* **Revert**
  * Not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->