### PR TITLE
[BE] refactor: 카테고리 조회 API 반환 타입 통일

### DIFF
--- a/backend/src/main/java/com/onair/hearit/admin/application/AdminCategoryService.java
+++ b/backend/src/main/java/com/onair/hearit/admin/application/AdminCategoryService.java
@@ -28,17 +28,17 @@ public class AdminCategoryService {
         return PagedResponse.from(dtoPage);
     }
 
-    @Transactional
-    public CategoryInfoResponse addCategory(CategoryCreateRequest request) {
-        Category category = new Category(request.name(), request.colorCode());
-        Category saved = categoryRepository.save(category);
-        return CategoryInfoResponse.from(saved);
-    }
-
     public List<CategoryInfoResponse> getAllCategories() {
         List<Category> allCategories = categoryRepository.findAll();
         return allCategories.stream()
                 .map(CategoryInfoResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public CategoryInfoResponse addCategory(CategoryCreateRequest request) {
+        Category category = new Category(request.name(), request.colorCode());
+        Category saved = categoryRepository.save(category);
+        return CategoryInfoResponse.from(saved);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/admin/application/AdminKeywordService.java
+++ b/backend/src/main/java/com/onair/hearit/admin/application/AdminKeywordService.java
@@ -28,17 +28,17 @@ public class AdminKeywordService {
         return PagedResponse.from(dtoPage);
     }
 
-    @Transactional
-    public KeywordInfoResponse addKeyword(KeywordCreateRequest request) {
-        Keyword keyword = new Keyword(request.name());
-        Keyword saved = keywordRepository.save(keyword);
-        return KeywordInfoResponse.from(saved);
-    }
-
     public List<KeywordInfoResponse> getAllKeywords() {
         List<Keyword> allKeywords = keywordRepository.findAll();
         return allKeywords.stream()
                 .map(KeywordInfoResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public KeywordInfoResponse addKeyword(KeywordCreateRequest request) {
+        Keyword keyword = new Keyword(request.name());
+        Keyword saved = keywordRepository.save(keyword);
+        return KeywordInfoResponse.from(saved);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/admin/dto/response/HearitAdminResponse.java
+++ b/backend/src/main/java/com/onair/hearit/admin/dto/response/HearitAdminResponse.java
@@ -18,7 +18,6 @@ public record HearitAdminResponse(
         CategoryInfoResponse category,
         List<KeywordInHearit> keywords
 ) {
-
     public static HearitAdminResponse from(Hearit hearit, Map<Long, List<KeywordInHearit>> keywordMap) {
         return new HearitAdminResponse(
                 hearit.getId(),

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminViewController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminViewController.java
@@ -12,6 +12,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/admin")
 public class AdminViewController {
 
+    @GetMapping
+    public String adminHome() {
+        return "admin/home";
+    }
+
     @GetMapping("/hearits")
     public String hearitListPage() {
         return "admin/hearit-list";
@@ -25,10 +30,5 @@ public class AdminViewController {
     @GetMapping("/keywords")
     public String keywordListPage() {
         return "admin/keyword-list";
-    }
-
-    @GetMapping
-    public String adminHome() {
-        return "admin/home";
     }
 }

--- a/backend/src/main/java/com/onair/hearit/application/CategoryService.java
+++ b/backend/src/main/java/com/onair/hearit/application/CategoryService.java
@@ -8,7 +8,6 @@ import com.onair.hearit.dto.response.HearitSearchResponse;
 import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.CategoryRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -22,18 +21,17 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
     private final HearitRepository hearitRepository;
 
-    public List<CategoryResponse> getCategories(PagingRequest pagingRequest) {
+    public PagedResponse<CategoryResponse> getCategories(PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Category> categories = categoryRepository.findAll(pageable);
-        return categories.stream()
-                .map(CategoryResponse::from)
-                .toList();
+        Page<CategoryResponse> categoryDtos = categories.map(CategoryResponse::from);
+        return PagedResponse.from(categoryDtos);
     }
 
-    public PagedResponse<HearitSearchResponse> findHearitsByCategory(Long categoryId, PagingRequest pagingRequest) {
+    public PagedResponse<HearitSearchResponse> getHearitsByCategory(Long categoryId, PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
-        Page<Hearit> result = hearitRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
-        Page<HearitSearchResponse> response = result.map(HearitSearchResponse::from);
-        return PagedResponse.from(response);
+        Page<Hearit> hearits = hearitRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
+        Page<HearitSearchResponse> hearitDtos = hearits.map(HearitSearchResponse::from);
+        return PagedResponse.from(hearitDtos);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/application/FileSourceService.java
+++ b/backend/src/main/java/com/onair/hearit/application/FileSourceService.java
@@ -21,21 +21,21 @@ public class FileSourceService {
     }
 
     public OriginalAudioResponse getOriginalAudio(Long hearitId) {
-        Hearit hearit = findHearit(hearitId);
+        Hearit hearit = getHearitById(hearitId);
         return new OriginalAudioResponse(hearit.getId(), createFullUrl(hearit.getOriginalAudioUrl()));
     }
 
     public ShortAudioResponse getShortAudio(Long id) {
-        Hearit hearit = findHearit(id);
+        Hearit hearit = getHearitById(id);
         return new ShortAudioResponse(hearit.getId(), createFullUrl(hearit.getShortAudioUrl()));
     }
 
     public ScriptResponse getScript(Long id) {
-        Hearit hearit = findHearit(id);
+        Hearit hearit = getHearitById(id);
         return new ScriptResponse(hearit.getId(), createFullUrl(hearit.getScriptUrl()));
     }
 
-    private Hearit findHearit(Long id) {
+    private Hearit getHearitById(Long id) {
         return hearitRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("hearitId", String.valueOf(id)));
     }

--- a/backend/src/main/java/com/onair/hearit/application/KeywordService.java
+++ b/backend/src/main/java/com/onair/hearit/application/KeywordService.java
@@ -29,7 +29,7 @@ public class KeywordService {
                 .toList();
     }
 
-    public List<KeywordResponse> getRecommendedKeyword(int size) {
+    public List<KeywordResponse> getRecommendedKeywords(int size) {
         long seed = LocalDate.now().toEpochDay();
         List<Long> allIds = keywordRepository.findAllIds();
         List<Long> selectedIds = pickRandomIds(allIds, seed, size);
@@ -46,11 +46,11 @@ public class KeywordService {
     }
 
     public KeywordResponse getKeyword(final Long id) {
-        Keyword keyword = findKeywordById(id);
+        Keyword keyword = getKeywordById(id);
         return KeywordResponse.from(keyword);
     }
 
-    private Keyword findKeywordById(Long id) {
+    private Keyword getKeywordById(Long id) {
         return keywordRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException("keywordId", String.valueOf(id)));
     }

--- a/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
+++ b/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
@@ -57,7 +57,7 @@ public class AuthService {
         }
     }
 
-    // 소셜 로그인의 경우 회원가입이 따로 없으며 로그인 시 자동으로 회원가입되도록 구현함
+    // 소셜 로그인의 경우 회원가입이 따로 없으며 로그인 시 자동으로 회원가입되도록 구현
     public TokenResponse loginWithKakao(KakaoLoginRequest request) {
         KakaoUserInfoResponse kakaoUser = kakaoUserInfoClient.getUserInfo(request.accessToken());
 

--- a/backend/src/main/java/com/onair/hearit/auth/exception/KakaoErrorHandler.java
+++ b/backend/src/main/java/com/onair/hearit/auth/exception/KakaoErrorHandler.java
@@ -21,9 +21,7 @@ public class KakaoErrorHandler implements ErrorHandler {
     @Override
     public void handle(HttpRequest request, ClientHttpResponse response) throws IOException {
         KakaoErrorResponse kakaoErrorResponse = extractResponseFrom(response.getBody());
-
-        throw new KakaoClientException(
-                response.getStatusCode(), kakaoErrorResponse.msg());
+        throw new KakaoClientException(response.getStatusCode(), kakaoErrorResponse.msg());
     }
 
     private KakaoErrorResponse extractResponseFrom(InputStream errorStream) {

--- a/backend/src/main/java/com/onair/hearit/auth/exception/KakaoExceptionHandler.java
+++ b/backend/src/main/java/com/onair/hearit/auth/exception/KakaoExceptionHandler.java
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class KakaoExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(KakaoClientException.class)
-    public ResponseEntity<Object> handleBadRequestException(final KakaoClientException e, final WebRequest request) {
+    public ResponseEntity<Object> handleBadRequestException(KakaoClientException e, WebRequest request) {
         log.error(e.getMessage(), e);
         return buildResponseEntity(e, e.getStatusCode(), e.getMessage(), request);
     }
@@ -28,8 +28,7 @@ public class KakaoExceptionHandler extends ResponseEntityExceptionHandler {
             final Exception e,
             final HttpStatusCode status,
             final String message,
-            final WebRequest request
-    ) {
+            final WebRequest request) {
         final String path = ((ServletWebRequest) request).getRequest().getRequestURI();
         final ProblemDetail body = super.createProblemDetail(e, status, message, path, null, request);
         return super.handleExceptionInternal(e, body, new HttpHeaders(), status, request);

--- a/backend/src/main/java/com/onair/hearit/dto/request/PagingRequest.java
+++ b/backend/src/main/java/com/onair/hearit/dto/request/PagingRequest.java
@@ -6,7 +6,6 @@ public record PagingRequest(
         int page,
         int size
 ) {
-
     public PagingRequest {
         if (page < 0) {
             throw new InvalidInputException("page는 0 이상이어야합니다.");

--- a/backend/src/main/java/com/onair/hearit/dto/response/BookmarkHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/BookmarkHearitResponse.java
@@ -10,7 +10,6 @@ public record BookmarkHearitResponse(
         String summary,
         Integer playTime
 ) {
-
     public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit) {
         return new BookmarkHearitResponse(
                 hearit.getId(),

--- a/backend/src/main/java/com/onair/hearit/dto/response/BookmarkInfoResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/BookmarkInfoResponse.java
@@ -5,7 +5,6 @@ import com.onair.hearit.domain.Bookmark;
 public record BookmarkInfoResponse(
         Long id
 ) {
-
     public static BookmarkInfoResponse from(Bookmark bookmark) {
         return new BookmarkInfoResponse(bookmark.getId());
     }

--- a/backend/src/main/java/com/onair/hearit/dto/response/CategoryResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/CategoryResponse.java
@@ -7,7 +7,6 @@ public record CategoryResponse(
         String name,
         String colorCode
 ) {
-
     public static CategoryResponse from(Category category) {
         return new CategoryResponse(
                 category.getId(),

--- a/backend/src/main/java/com/onair/hearit/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/HearitDetailResponse.java
@@ -14,7 +14,6 @@ public record HearitDetailResponse(
         Boolean isBookmarked,
         Long bookmarkId
 ) {
-
     public static HearitDetailResponse from(Hearit hearit) {
         return new HearitDetailResponse(
                 hearit.getId(),

--- a/backend/src/main/java/com/onair/hearit/dto/response/HearitSearchResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/HearitSearchResponse.java
@@ -8,7 +8,6 @@ public record HearitSearchResponse(
         String summary,
         Integer playTime
 ) {
-
     public static HearitSearchResponse from(Hearit hearit) {
         return new HearitSearchResponse(
                 hearit.getId(),

--- a/backend/src/main/java/com/onair/hearit/dto/response/KeywordResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/KeywordResponse.java
@@ -6,7 +6,6 @@ public record KeywordResponse(
         Long id,
         String name
 ) {
-
     public static KeywordResponse from(Keyword keyword) {
         return new KeywordResponse(
                 keyword.getId(),

--- a/backend/src/main/java/com/onair/hearit/dto/response/MemberInfoResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/MemberInfoResponse.java
@@ -7,7 +7,6 @@ public record MemberInfoResponse(
         String nickname,
         String profileImage
 ) {
-
     public static MemberInfoResponse from(Member member) {
         return new MemberInfoResponse(member.getId(), member.getNickname(), member.getProfileImage());
     }

--- a/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
@@ -14,7 +14,6 @@ public record RandomHearitResponse(
         Boolean isBookmarked,
         Long bookmarkId
 ) {
-
     public static RandomHearitResponse from(Hearit hearit) {
         return new RandomHearitResponse(
                 hearit.getId(),

--- a/backend/src/main/java/com/onair/hearit/dto/response/RecommendHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/RecommendHearitResponse.java
@@ -11,7 +11,6 @@ public record RecommendHearitResponse(
         Integer playTime,
         LocalDateTime createdAt
 ) {
-
     public static RecommendHearitResponse from(Hearit hearit) {
         return new RecommendHearitResponse(
                 hearit.getId(),

--- a/backend/src/main/java/com/onair/hearit/infrastructure/HearitKeywordRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/HearitKeywordRepository.java
@@ -15,5 +15,4 @@ public interface HearitKeywordRepository extends JpaRepository<HearitKeyword, Lo
                 WHERE hk.hearit.id IN :hearitIds
             """)
     List<HearitKeyword> findByHearitIdIn(@Param("hearitIds") List<Long> hearitIds);
-
 }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
@@ -25,5 +25,4 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
             ORDER BY h.created_at DESC
             """, nativeQuery = true)
     Page<Hearit> searchByTerm(@Param("searchTerm") String searchTerm, Pageable pageable);
-
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
@@ -26,11 +26,11 @@ public class CategoryController {
 
     @Operation(summary = "전체 카테고리 목록을 조회", description = "전체 카테고리 목록들을 조회합니다.")
     @GetMapping
-    public ResponseEntity<List<CategoryResponse>> readCategories(
+    public ResponseEntity<PagedResponse<CategoryResponse>> readCategories(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        List<CategoryResponse> responses = categoryService.getCategories(pagingRequest);
+        PagedResponse<CategoryResponse> responses = categoryService.getCategories(pagingRequest);
         return ResponseEntity.ok(responses);
     }
 
@@ -41,7 +41,7 @@ public class CategoryController {
             @RequestParam(name = "page", defaultValue = "0") Integer page,
             @RequestParam(name = "size", defaultValue = "20") Integer size) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        PagedResponse<HearitSearchResponse> response = categoryService.findHearitsByCategory(categoryId, pagingRequest);
+        PagedResponse<HearitSearchResponse> response = categoryService.getHearitsByCategory(categoryId, pagingRequest);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/CategoryController.java
@@ -7,7 +7,6 @@ import com.onair.hearit.dto.response.HearitSearchResponse;
 import com.onair.hearit.dto.response.PagedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/onair/hearit/presentation/KeywordController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/KeywordController.java
@@ -43,7 +43,7 @@ public class KeywordController {
     @GetMapping("/recommend")
     public ResponseEntity<List<KeywordResponse>> readRecommendedKeywords(
             @RequestParam(name = "size", defaultValue = "9") int size) {
-        List<KeywordResponse> responses = keywordService.getRecommendedKeyword(size);
+        List<KeywordResponse> responses = keywordService.getRecommendedKeywords(size);
         return ResponseEntity.ok(responses);
     }
 }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -10,7 +10,6 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # Dev-JPA
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always

--- a/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
@@ -56,14 +56,14 @@ class CategoryServiceTest {
         PagingRequest pagingRequest = new PagingRequest(1, 2);// page 1 (두 번째 페이지), size 2
 
         // when
-        List<CategoryResponse> result = categoryService.getCategories(pagingRequest);
+        PagedResponse<CategoryResponse> result = categoryService.getCategories(pagingRequest);
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(2),
-                () -> assertThat(result).extracting(CategoryResponse::name)
+                () -> assertThat(result.content()).hasSize(2),
+                () -> assertThat(result.content()).extracting(CategoryResponse::name)
                         .containsExactly("category3", "category4"),
-                () -> assertThat(result).extracting(CategoryResponse::colorCode)
+                () -> assertThat(result.content()).extracting(CategoryResponse::colorCode)
                         .containsExactly("#333", "#444")
         );
     }
@@ -80,7 +80,7 @@ class CategoryServiceTest {
         PagingRequest request = new PagingRequest(0, 10);
 
         // when
-        PagedResponse<HearitSearchResponse> result = categoryService.findHearitsByCategory(category1.getId(), request);
+        PagedResponse<HearitSearchResponse> result = categoryService.getHearitsByCategory(category1.getId(), request);
 
         // then
         assertAll(
@@ -101,7 +101,7 @@ class CategoryServiceTest {
         PagingRequest request = new PagingRequest(1, 2);
 
         // when
-        PagedResponse<HearitSearchResponse> result = categoryService.findHearitsByCategory(category.getId(), request);
+        PagedResponse<HearitSearchResponse> result = categoryService.getHearitsByCategory(category.getId(), request);
 
         // then
         assertAll(

--- a/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
@@ -98,7 +98,7 @@ class KeywordServiceTest {
         int size = 3;
 
         // when
-        List<KeywordResponse> result = keywordService.getRecommendedKeyword(size);
+        List<KeywordResponse> result = keywordService.getRecommendedKeywords(size);
 
         // then
         assertThat(result).hasSize(size);
@@ -116,8 +116,8 @@ class KeywordServiceTest {
         int size = 3;
 
         // when
-        List<KeywordResponse> first = keywordService.getRecommendedKeyword(size);
-        List<KeywordResponse> second = keywordService.getRecommendedKeyword(size);
+        List<KeywordResponse> first = keywordService.getRecommendedKeywords(size);
+        List<KeywordResponse> second = keywordService.getRecommendedKeywords(size);
 
         // then
         assertThat(first).extracting(KeywordResponse::id)

--- a/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
@@ -29,7 +29,7 @@ class CategoryControllerTest extends IntegrationTest {
         Category category5 = saveCategory("category5", "#555");
 
         // when
-        List<CategoryResponse> result = RestAssured.given()
+        PagedResponse<CategoryResponse> result = RestAssured.given()
                 .param("page", 1)
                 .param("size", 2)
                 .when()
@@ -37,15 +37,15 @@ class CategoryControllerTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .jsonPath()
-                .getList(".", CategoryResponse.class);
+                .as(new TypeRef<>() {
+                });
 
         // then
         assertAll(
-                () -> assertThat(result).hasSize(2),
-                () -> assertThat(result).extracting(CategoryResponse::id)
+                () -> assertThat(result.content()).hasSize(2),
+                () -> assertThat(result.content()).extracting(CategoryResponse::id)
                         .containsExactly(category3.getId(), category4.getId()),
-                () -> assertThat(result).extracting(CategoryResponse::colorCode)
+                () -> assertThat(result.content()).extracting(CategoryResponse::colorCode)
                         .containsExactly("#333", "#444")
         );
     }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 카테고리 조회 API 반환 타입 통일
- show sql 설정 제거

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #145 
