### PR TITLE
[AN] refactor: 카테고리 전체 조회 API 페이지네이션 적용

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "com.onair.hearit"
         minSdk = 29
         targetSdk = 35
-        versionCode = 1002
-        versionName = "1.0.02"
+        versionCode = 1003
+        versionName = "1.0.03"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android/app/src/main/java/com/onair/hearit/data/CategoryMapper.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/CategoryMapper.kt
@@ -2,10 +2,25 @@ package com.onair.hearit.data
 
 import com.onair.hearit.data.dto.CategoryResponse
 import com.onair.hearit.domain.model.Category
+import com.onair.hearit.domain.model.PageResult
+import com.onair.hearit.domain.model.Paging
 
-fun CategoryResponse.toDomain(): Category =
+fun CategoryResponse.Content.toDomain(): Category =
     Category(
         id = this.id,
         colorCode = this.colorCode,
         name = this.name,
+    )
+
+fun CategoryResponse.toDomain(): PageResult<Category> =
+    PageResult(
+        items = content.map { it.toDomain() },
+        paging =
+            Paging(
+                page = page,
+                size = size,
+                totalPages = totalPages,
+                isFirst = isFirst,
+                isLast = isLast,
+            ),
     )

--- a/android/app/src/main/java/com/onair/hearit/data/api/CategoryService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/CategoryService.kt
@@ -3,8 +3,12 @@ package com.onair.hearit.data.api
 import com.onair.hearit.data.dto.CategoryResponse
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface CategoryService {
     @GET("categories")
-    suspend fun getCategories(): Response<List<CategoryResponse>>
+    suspend fun getCategories(
+        @Query("page") page: Int?,
+        @Query("size") size: Int?,
+    ): Response<CategoryResponse>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/CategoryRemoteDataSource.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/CategoryRemoteDataSource.kt
@@ -3,5 +3,8 @@ package com.onair.hearit.data.datasource
 import com.onair.hearit.data.dto.CategoryResponse
 
 interface CategoryRemoteDataSource {
-    suspend fun getCategories(): Result<List<CategoryResponse>>
+    suspend fun getCategories(
+        page: Int?,
+        size: Int?,
+    ): Result<CategoryResponse>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/CategoryRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/CategoryRemoteDataSourceImpl.kt
@@ -6,10 +6,13 @@ import com.onair.hearit.data.dto.CategoryResponse
 class CategoryRemoteDataSourceImpl(
     private val categoryService: CategoryService,
 ) : CategoryRemoteDataSource {
-    override suspend fun getCategories(): Result<List<CategoryResponse>> =
+    override suspend fun getCategories(
+        page: Int?,
+        size: Int?,
+    ): Result<CategoryResponse> =
         handleApiCall(
             errorMessage = "카테고리 조회 실패",
-            apiCall = { categoryService.getCategories() },
+            apiCall = { categoryService.getCategories(page, size) },
             transform = { response ->
                 response.body() ?: throw IllegalStateException("응답 바디가 null입니다.")
             },

--- a/android/app/src/main/java/com/onair/hearit/data/dto/CategoryResponse.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/dto/CategoryResponse.kt
@@ -5,10 +5,28 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CategoryResponse(
-    @SerialName("colorCode")
-    val colorCode: String,
-    @SerialName("id")
-    val id: Long,
-    @SerialName("name")
-    val name: String,
-)
+    @SerialName("content")
+    val content: List<Content>,
+    @SerialName("page")
+    val page: Int,
+    @SerialName("size")
+    val size: Int,
+    @SerialName("totalPages")
+    val totalPages: Int,
+    @SerialName("totalElements")
+    val totalElements: Int,
+    @SerialName("isFirst")
+    val isFirst: Boolean,
+    @SerialName("isLast")
+    val isLast: Boolean,
+) {
+    @Serializable
+    data class Content(
+        @SerialName("id")
+        val id: Long,
+        @SerialName("name")
+        val name: String,
+        @SerialName("colorCode")
+        val colorCode: String,
+    )
+}

--- a/android/app/src/main/java/com/onair/hearit/data/repository/CategoryRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/CategoryRepositoryImpl.kt
@@ -3,14 +3,17 @@ package com.onair.hearit.data.repository
 import com.onair.hearit.data.datasource.CategoryRemoteDataSource
 import com.onair.hearit.data.toDomain
 import com.onair.hearit.domain.model.Category
+import com.onair.hearit.domain.model.PageResult
 import com.onair.hearit.domain.repository.CategoryRepository
 
 class CategoryRepositoryImpl(
     private val categoryDataSource: CategoryRemoteDataSource,
 ) : CategoryRepository {
-    override suspend fun getCategories(): Result<List<Category>> =
+    override suspend fun getCategories(
+        page: Int?,
+        size: Int?,
+    ): Result<PageResult<Category>> =
         handleResult {
-            val response = categoryDataSource.getCategories().getOrThrow()
-            response.map { it.toDomain() }
+            categoryDataSource.getCategories(page, size).getOrThrow().toDomain()
         }
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/CategoryRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/CategoryRepository.kt
@@ -1,7 +1,11 @@
 package com.onair.hearit.domain.repository
 
 import com.onair.hearit.domain.model.Category
+import com.onair.hearit.domain.model.PageResult
 
 interface CategoryRepository {
-    suspend fun getCategories(): Result<List<Category>>
+    suspend fun getCategories(
+        page: Int? = null,
+        size: Int? = null,
+    ): Result<PageResult<Category>>
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.onair.hearit.R
 import com.onair.hearit.domain.UserNotRegisteredException
 import com.onair.hearit.domain.model.Category
+import com.onair.hearit.domain.model.Paging
 import com.onair.hearit.domain.model.RecentHearit
 import com.onair.hearit.domain.model.RecommendHearit
 import com.onair.hearit.domain.model.UserInfo
@@ -40,6 +41,10 @@ class HomeViewModel(
     private val _toastMessage = SingleLiveData<Int>()
     val toastMessage: LiveData<Int> = _toastMessage
 
+    private lateinit var paging: Paging
+    private var currentPage = 0
+    private var isLastPage = false
+
     init {
         fetchUserInfo()
         getRecentHearit()
@@ -59,9 +64,11 @@ class HomeViewModel(
 
         viewModelScope.launch {
             categoryRepository
-                .getCategories()
-                .onSuccess { categories ->
-                    _categories.value = categories
+                .getCategories(page = 0)
+                .onSuccess { pageCategories ->
+                    paging = pageCategories.paging
+                    _categories.value = pageCategories.items
+                    isLastPage = paging.isLast
                 }.onFailure {
                     _toastMessage.value = R.string.all_toast_categories_load_fail
                 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/search/SearchViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/search/SearchViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.onair.hearit.R
 import com.onair.hearit.domain.model.Category
 import com.onair.hearit.domain.model.Keyword
+import com.onair.hearit.domain.model.Paging
 import com.onair.hearit.domain.repository.CategoryRepository
 import com.onair.hearit.domain.repository.KeywordRepository
 import com.onair.hearit.presentation.SingleLiveData
@@ -24,6 +25,10 @@ class SearchViewModel(
 
     private val _toastMessage = SingleLiveData<Int>()
     val toastMessage: LiveData<Int> = _toastMessage
+
+    private lateinit var paging: Paging
+    private var currentPage = 0
+    private var isLastPage = false
 
     init {
         fetchData()
@@ -49,9 +54,11 @@ class SearchViewModel(
     private fun getCategories() {
         viewModelScope.launch {
             categoryRepository
-                .getCategories()
-                .onSuccess { categories ->
-                    _categories.value = categories
+                .getCategories(page = 0)
+                .onSuccess { pageCategories ->
+                    paging = pageCategories.paging
+                    _categories.value = pageCategories.items
+                    isLastPage = paging.isLast
                 }.onFailure {
                     _toastMessage.value = R.string.all_toast_categories_load_fail
                 }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 카테고리 목록 조회 응답 페이지네이션 적용

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#160 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카테고리 목록 조회에 페이지네이션(페이징) 기능이 추가되었습니다. 이제 카테고리를 페이지 단위로 불러올 수 있습니다.

* **버그 수정**
  * 없음

* **기타 변경사항**
  * 카테고리 관련 화면 및 데이터 구조가 페이징 정보를 포함하도록 개선되었습니다.
  * 앱 버전이 1.0.03으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->