### PR TITLE
[AN] bug: 로그인 안 했을 때 탐색/상세 재생 화면이 안 보이는 문제 수정

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/api/BookmarkService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/BookmarkService.kt
@@ -11,23 +11,22 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface BookmarkService {
-    @GET("hearits/bookmarks")
+    @GET("bookmarks/hearits")
     suspend fun getBookmarks(
-        @Header("Authorization") token: String,
+        @Header("Authorization") token: String?,
         @Query("page") page: Int?,
         @Query("size") size: Int?,
     ): Response<BookmarkResponse>
 
-    @POST("hearits/{hearitId}/bookmarks")
+    @POST("bookmarks/hearits/{hearitId}")
     suspend fun postBookmark(
-        @Header("Authorization") token: String,
+        @Header("Authorization") token: String?,
         @Path("hearitId") hearitId: Long,
     ): Response<BookmarkIdResponse>
 
-    @DELETE("hearits/{hearitId}/bookmarks/{bookmarkId}")
+    @DELETE("bookmarks/{bookmarkId}")
     suspend fun deleteBookmark(
-        @Header("Authorization") token: String,
-        @Path("hearitId") hearitId: Long,
+        @Header("Authorization") token: String?,
         @Path("bookmarkId") bookmarkId: Long,
     ): Response<Unit>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/api/HearitService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/HearitService.kt
@@ -13,7 +13,7 @@ import retrofit2.http.Query
 interface HearitService {
     @GET("hearits/{hearitId}")
     suspend fun getHearit(
-        @Header("Authorization") token: String,
+        @Header("Authorization") token: String?,
         @Path("hearitId") hearitId: Long,
     ): Response<HearitResponse>
 
@@ -22,7 +22,7 @@ interface HearitService {
 
     @GET("hearits/random")
     suspend fun getRandomHearits(
-        @Header("Authorization") token: String,
+        @Header("Authorization") token: String?,
         @Query("page") page: Int?,
         @Query("size") size: Int?,
     ): Response<RandomHearitResponse>

--- a/android/app/src/main/java/com/onair/hearit/data/api/MemberService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/MemberService.kt
@@ -8,6 +8,6 @@ import retrofit2.http.Header
 interface MemberService {
     @GET("members/me")
     suspend fun getUserInfo(
-        @Header("Authorization") token: String,
+        @Header("Authorization") token: String?,
     ): Response<UserInfoResponse>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/BookmarkRemoteDataSource.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/BookmarkRemoteDataSource.kt
@@ -11,8 +11,5 @@ interface BookmarkRemoteDataSource {
 
     suspend fun addBookmark(hearitId: Long): Result<BookmarkIdResponse>
 
-    suspend fun deleteBookmark(
-        hearitId: Long,
-        bookmarkId: Long,
-    ): Result<Unit>
+    suspend fun deleteBookmark(bookmarkId: Long): Result<Unit>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/HearitRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/HearitRemoteDataSourceImpl.kt
@@ -55,9 +55,13 @@ class HearitRemoteDataSourceImpl(
             },
         )
 
-    private fun getAuthHeader(): String {
-        val token = requireNotNull(TokenProvider.accessToken) { ERROR_TOKEN_NOT_FOUND_MESSAGE }
-        return TOKEN.format(token)
+    private fun getAuthHeader(): String? {
+        val token = TokenProvider.accessToken
+        return if (token.isNullOrBlank()) {
+            null
+        } else {
+            TOKEN.format(token)
+        }
     }
 
     companion object {
@@ -66,7 +70,6 @@ class HearitRemoteDataSourceImpl(
         private const val ERROR_RANDOM_HEARIT_MESSAGE = "랜덤 히어릿 조회 실패"
         private const val ERROR_SEARCH_HEARIT_MESSAGE = "검색 히어릿 조회 실패"
         private const val ERROR_RESPONSE_BODY_NULL_MESSAGE = "응답 바디가 null입니다."
-        private const val ERROR_TOKEN_NOT_FOUND_MESSAGE = "토큰이 존재하지 않음"
         private const val TOKEN = "Bearer %s"
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/MemberRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/MemberRemoteDataSourceImpl.kt
@@ -22,15 +22,18 @@ class MemberRemoteDataSourceImpl(
             }
         }
 
-    private fun getAuthHeader(): String {
-        val token = requireNotNull(TokenProvider.accessToken) { ERROR_TOKEN_NOT_FOUND_MESSAGE }
-        return TOKEN.format(token)
+    private fun getAuthHeader(): String? {
+        val token = TokenProvider.accessToken
+        return if (token.isNullOrBlank()) {
+            null
+        } else {
+            TOKEN.format(token)
+        }
     }
 
     companion object {
         private const val ERROR_SIGN_IN_MESSAGE = "회원가입되지 않은 사용자입니다."
         private const val ERROR_RESPONSE_BODY_NULL_MESSAGE = "응답 바디가 null입니다."
-        private const val ERROR_TOKEN_NOT_FOUND_MESSAGE = "토큰이 존재하지 않음"
         private const val TOKEN = "Bearer %s"
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
@@ -23,11 +23,8 @@ class BookmarkRepositoryImpl(
             response.id
         }
 
-    override suspend fun deleteBookmark(
-        hearitId: Long,
-        bookmarkId: Long,
-    ): Result<Unit> =
+    override suspend fun deleteBookmark(bookmarkId: Long): Result<Unit> =
         handleResult {
-            bookmarkDataSource.deleteBookmark(hearitId, bookmarkId).getOrThrow()
+            bookmarkDataSource.deleteBookmark(bookmarkId).getOrThrow()
         }
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/NoBookmarkException.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/NoBookmarkException.kt
@@ -1,0 +1,5 @@
+package com.onair.hearit.domain
+
+class NoBookmarkException(
+    message: String,
+) : Exception(message)

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/BookmarkRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/BookmarkRepository.kt
@@ -10,8 +10,5 @@ interface BookmarkRepository {
 
     suspend fun addBookmark(hearitId: Long): Result<Long>
 
-    suspend fun deleteBookmark(
-        hearitId: Long,
-        bookmarkId: Long,
-    ): Result<Unit>
+    suspend fun deleteBookmark(bookmarkId: Long): Result<Unit>
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailViewModel.kt
@@ -48,7 +48,7 @@ class PlayerDetailViewModel(
         if (id != null) {
             viewModelScope.launch {
                 bookmarkRepository
-                    .deleteBookmark(hearitId, id)
+                    .deleteBookmark(id)
                     .onSuccess {
                         _isBookmarked.value = false
                         _bookmarkId.value = null

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
@@ -50,20 +50,19 @@ class ExploreViewModel(
 
         val item = currentList[index]
         if (item.isBookmarked && item.bookmarkId != null) {
-            deleteBookmark(item.id, item.bookmarkId, index)
+            deleteBookmark(item.bookmarkId, index)
         } else {
             addBookmark(item.id, index)
         }
     }
 
     private fun deleteBookmark(
-        hearitId: Long,
         bookmarkId: Long,
         index: Int,
     ) {
         viewModelScope.launch {
             bookmarkRepository
-                .deleteBookmark(hearitId, bookmarkId)
+                .deleteBookmark(bookmarkId)
                 .onSuccess {
                     updateBookmarkState(index, isBookmarked = false, bookmarkId = null)
                 }.onFailure {

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.onair.hearit.R
+import com.onair.hearit.domain.NoBookmarkException
 import com.onair.hearit.domain.UserNotRegisteredException
 import com.onair.hearit.domain.model.Bookmark
 import com.onair.hearit.domain.model.UserInfo
@@ -39,9 +40,20 @@ class LibraryViewModel(
             bookmarkRepository
                 .getBookmarks(page = page, size = null)
                 .onSuccess {
+                    _uiState.value = BookmarkUiState.LoggedIn
                     _bookmarks.value = it
-                }.onFailure {
-                    _toastMessage.value = R.string.library_toast_bookmark_load_fail
+                }.onFailure { throwable ->
+                    when (throwable) {
+                        is NoBookmarkException -> {
+                            _uiState.value = BookmarkUiState.NotLoggedIn
+                        }
+
+                        else -> {
+                            _toastMessage.value = R.string.library_toast_bookmark_load_fail
+                        }
+                    }
+                    val defaultUserInfo = UserInfo(-1, "hEARit", null)
+                    _userInfo.value = defaultUserInfo
                 }
         }
     }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 로그인하지 않았을 때 사용자 정보 조회 수정
- 로그인하지 않았을 때 탐색/상세 재생 수정
- 로그인하지 않았을 때 북마크 조회 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#179 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 인증 토큰이 없는 경우에도 일부 기능(API 호출)이 정상적으로 동작하도록 개선되었습니다.  
* **리팩터**
  * 인증 토큰 처리 방식이 변경되어, 토큰이 없을 때 예외가 발생하지 않고 안전하게 처리됩니다.
  * 북마크 관련 API 경로 및 호출 방식이 간소화되었습니다.
* **신규 기능**
  * 북마크가 없을 때를 구분하는 새로운 예외 처리 기능이 추가되었습니다.
* **사용자 경험 개선**
  * 북마크 조회 실패 시 상황에 맞는 UI 상태 및 안내 메시지가 표시되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->