### PR TITLE
[BE] refactor: bookmark api endpoint 변경 #181

### DIFF
--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -1,5 +1,6 @@
 package com.onair.hearit.application;
 
+import com.onair.hearit.auth.dto.CurrentMember;
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
@@ -28,8 +29,8 @@ public class BookmarkService {
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public PagedResponse<BookmarkHearitResponse> getBookmarkHearits(Long memberId, PagingRequest pagingRequest) {
-        Member member = getMemberById(memberId);
+    public PagedResponse<BookmarkHearitResponse> getBookmarkHearits(CurrentMember currentMember, PagingRequest pagingRequest) {
+        Member member = getMemberByCurrentMember(currentMember);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByCreatedAtDesc(member, pageable);
         Page<BookmarkHearitResponse> bookmarkHearits = bookmarks.map(
@@ -38,25 +39,32 @@ public class BookmarkService {
     }
 
     @Transactional
-    public BookmarkInfoResponse addBookmark(Long hearitId, Long memberId) {
-        if (bookmarkRepository.existsByHearitIdAndMemberId(hearitId, memberId)) {
+    public BookmarkInfoResponse addBookmark(CurrentMember currentMember, Long hearitId) {
+        Member member = getMemberByCurrentMember(currentMember);
+        Hearit hearit = getHearitById(hearitId);
+        if (bookmarkRepository.existsByHearitIdAndMemberId(hearit.getId(), member.getId())) {
             throw new AlreadyExistException("이미 북마크된 히어릿입니다.");
         }
-        Hearit hearit = getHearitById(hearitId);
-        Member member = getMemberById(memberId);
         Bookmark bookmark = new Bookmark(member, hearit);
         Bookmark saved = bookmarkRepository.save(bookmark);
         return BookmarkInfoResponse.from(saved);
     }
 
     @Transactional
-    public void deleteBookmark(Long bookmarkId, Long memberId) {
+    public void deleteBookmark(Long bookmarkId, CurrentMember currentMember) {
         Bookmark bookmark = getBookmarkById(bookmarkId);
-        Member member = getMemberById(memberId);
+        Member member = getMemberByCurrentMember(currentMember);
         if (!bookmark.isCreatedBy(member)) {
             throw new UnauthorizedException("북마크를 삭제할 권한이 없습니다.");
         }
         bookmarkRepository.delete(bookmark);
+    }
+
+    private Member getMemberByCurrentMember(CurrentMember currentMember) {
+        if(currentMember == null) {
+            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+        }
+        return getMemberById(currentMember.memberId());
     }
 
     private Member getMemberById(Long memberId) {

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -54,7 +54,7 @@ public class BookmarkController {
             @PathVariable Long hearitId,
             @AuthenticationPrincipal CurrentMember member) {
         BookmarkInfoResponse response = bookmarkService.addBookmark(member, hearitId);
-        return ResponseEntity.created(URI.create("/api/v1/hearits/" + hearitId)).body(response);
+        return ResponseEntity.created(URI.create("/")).body(response);
     }
 
     @Operation(summary = "북마크 삭제", description = "로그인한 히어릿 ID와 북마크 ID로 북마크를 삭제합니다.")

--- a/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/BookmarkController.java
@@ -26,21 +26,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/hearits/")
+@RequestMapping("/api/v1/bookmarks")
 @Tag(name = "Bookmark", description = "북마크 및 북마크 재생목록")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
     @Operation(summary = "북마크 재생목록 조회", description = "로그인한 회원이 page, size로 재생목록을 조회합니다.")
-    @GetMapping("/bookmarks")
+    @GetMapping("/hearits")
     public ResponseEntity<PagedResponse<BookmarkHearitResponse>> readBookmarkHearits(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
             @AuthenticationPrincipal CurrentMember member) {
-        PagingRequest condition = new PagingRequest(page, size);
-        PagedResponse<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member.memberId(),
-                condition);
+        PagingRequest pagingRequest = new PagingRequest(page, size);
+        PagedResponse<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(member, pagingRequest);
         return ResponseEntity.ok(responses);
     }
 
@@ -50,20 +49,20 @@ public class BookmarkController {
                     @ApiResponse(responseCode = "400", description = "이미 북마크된 히어릿",
                             content = @Content(schema = @Schema(implementation = ProblemDetail.class)))
             })
-    @PostMapping("/{hearitId}/bookmarks")
+    @PostMapping("/hearits/{hearitId}")
     public ResponseEntity<BookmarkInfoResponse> createBookmark(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal CurrentMember member) {
-        BookmarkInfoResponse response = bookmarkService.addBookmark(hearitId, member.memberId());
+        BookmarkInfoResponse response = bookmarkService.addBookmark(member, hearitId);
         return ResponseEntity.created(URI.create("/api/v1/hearits/" + hearitId)).body(response);
     }
 
     @Operation(summary = "북마크 삭제", description = "로그인한 히어릿 ID와 북마크 ID로 북마크를 삭제합니다.")
-    @DeleteMapping("/{hearitId}/bookmarks/{bookmarkId}")
+    @DeleteMapping("/{bookmarkId}")
     public ResponseEntity<Void> deleteBookmark(
             @PathVariable Long bookmarkId,
             @AuthenticationPrincipal CurrentMember member) {
-        bookmarkService.deleteBookmark(bookmarkId, member.memberId());
+        bookmarkService.deleteBookmark(bookmarkId, member);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -44,7 +44,7 @@ class BookmarkControllerTest extends IntegrationTest {
                     .param("page", i)
                     .param("size", size)
                     .when()
-                    .get("/api/v1/hearits/bookmarks")
+                    .get("/api/v1/bookmarks/hearits")
                     .then()
                     .statusCode(HttpStatus.OK.value())
                     .body("content.size()", equalTo(5));
@@ -65,7 +65,7 @@ class BookmarkControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .param("page", -1)
                 .when()
-                .get("/api/v1/hearits/bookmarks")
+                .get("/api/v1/bookmarks/hearits")
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value()).log();
     }
@@ -85,9 +85,31 @@ class BookmarkControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .param("size", -1)
                 .when()
-                .get("/api/v1/hearits/bookmarks")
+                .get("/api/v1/bookmarks/hearits")
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value()).log();
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 북마크 목록 조회 시, 401 UNAUTHORIZATION가 발생한다.")
+    void readBookmarkHearits_error_401_whenNotLogin() {
+        // given
+        Member member = saveMember();
+        int bookmarkCount = 10;
+        for (int i = 0; i < bookmarkCount; i++) {
+            Hearit hearit = saveHearitWithSuffix(i);
+            dbHelper.insertBookmark(new Bookmark(member, hearit));
+        }
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "")
+                .param("page", 0)
+                .param("size", 20)
+                .when()
+                .get("/api/v1/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
     @Test
@@ -102,7 +124,7 @@ class BookmarkControllerTest extends IntegrationTest {
         BookmarkInfoResponse response = RestAssured.given()
                 .header("Authorization", "Bearer " + token)
                 .when()
-                .post("/api/v1/hearits/" + hearit.getId() + "/bookmarks")
+                .post("/api/v1/bookmarks/hearits/" + hearit.getId())
                 .then()
                 .statusCode(HttpStatus.CREATED.value())
                 .extract().as(BookmarkInfoResponse.class);
@@ -123,7 +145,7 @@ class BookmarkControllerTest extends IntegrationTest {
         RestAssured.given()
                 .header("Authorization", "Bearer " + token)
                 .when()
-                .post("/api/v1/hearits/" + hearit.getId() + "/bookmarks")
+                .post("/api/v1/bookmarks/hearits/" + hearit.getId())
                 .then()
                 .statusCode(HttpStatus.CONFLICT.value());
     }
@@ -141,7 +163,7 @@ class BookmarkControllerTest extends IntegrationTest {
         RestAssured.given()
                 .header("Authorization", "Bearer " + token)
                 .when()
-                .delete("/api/v1/hearits/" + hearit.getId() + "/bookmarks/" + bookmark.getId())
+                .delete("/api/v1/bookmarks/" + bookmark.getId())
                 .then()
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
@@ -160,7 +182,7 @@ class BookmarkControllerTest extends IntegrationTest {
         RestAssured.given()
                 .header("Authorization", "Bearer " + token)
                 .when()
-                .delete("/api/v1/hearits/" + hearit.getId() + "/bookmarks/" + bookmark.getId())
+                .delete("/api/v1/bookmarks/" + bookmark.getId())
                 .then()
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

- 북마크 api endpoint 변경
  - /bookmarks/hearits
  - /bookmarks/hearits/{hearit_id}
  - /bookmarks/{bookmark_id}
- CurrentMember null 체크 추가

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->

close #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 인증되지 않은 사용자가 북마크 목록을 조회할 때 401 Unauthorized 응답을 반환하도록 개선되었습니다.

* **Refactor**
  * 북마크 관련 API 엔드포인트 경로가 더 직관적으로 변경되었습니다.
  * 서비스 및 컨트롤러에서 memberId 대신 인증 객체(CurrentMember)를 사용하도록 구조가 개선되었습니다.

* **Tests**
  * 인증 객체 도입 및 엔드포인트 변경에 맞춰 테스트 코드가 업데이트되었습니다.
  * 인증되지 않은 접근에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->