### PR TITLE
[BE] chore: CI 환경 변수 secrets으로 변경 #186

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,27 +12,27 @@ jobs:
     runs-on: ubuntu-latest
 
     defaults:
-          run:
-            working-directory: backend
-            
+      run:
+        working-directory: backend
+
     services:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: hearit_db
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
         ports:
-          - 13307:3306
+          - ${{ secrets.TEST_MYSQL_PORT }}:3306
         options: >-
-          --health-cmd="mysqladmin ping -uroot -proot"
+          --health-cmd="mysqladmin ping -uroot -p${{ secrets.MYSQL_ROOT_PASSWORD }}"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: root
-      TEST_MYSQL_PORT: 13307
-      db.mysql.host: localhost:13307
+      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+      TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
+      DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 
     steps:
       - name: Checkout
@@ -49,6 +49,6 @@ jobs:
 
       - name: Run tests
         run: ./gradlew test
-      
+
       - name: Build with Gradle
         run: ./gradlew build -x test

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -22,9 +22,9 @@ jobs:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
         ports:
-          - ${{ secrets.TEST_MYSQL_PORT }}:3306
+          - 13307:3306
         options: >-
-          --health-cmd="mysqladmin ping -uroot -p${{ secrets.MYSQL_ROOT_PASSWORD }}"
+          --health-cmd="mysqladmin ping -uroot -p$MYSQL_ROOT_PASSWORD"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5

--- a/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
@@ -59,7 +59,7 @@ class CategoryControllerTest extends IntegrationTest {
 
         Hearit hearit1 = saveHearitWithCategory(category1);
         Hearit hearit2 = saveHearitWithCategory(category1);
-        saveHearitWithCategory(category2); // 다른 카테고리
+        Hearit hearit3 = saveHearitWithCategory(category2);// 다른 카테고리
 
         // when
         PagedResponse<HearitSearchResponse> pagedResponse = RestAssured


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
ci.yml 안에 하드코딩된 mysql 관련 데이터들을 환경 변수 secrets을 사용하게 변경
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #186 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Chores**
  * 백엔드 CI 워크플로우에서 MySQL 서비스 설정이 저장소 시크릿을 사용하도록 개선되었습니다.  
  * 환경 변수와 포트, 비밀번호 등 민감 정보가 하드코딩에서 시크릿 참조로 변경되었습니다.  
  * 일부 포맷 및 들여쓰기 정리가 이루어졌습니다.  
  * 테스트 코드 내에서 카테고리별 검색 테스트 시 사용되는 객체 할당이 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->