### PR TITLE
[BE] fix: 정의되지 않은 예외 발생 시 500 에러 처리 #184

### DIFF
--- a/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정보를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String title;

--- a/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
@@ -9,7 +9,8 @@ public enum ErrorCode {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정보를 찾을 수 없습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다.");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
 
     private final HttpStatus httpStatus;
     private final String title;

--- a/backend/src/main/java/com/onair/hearit/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/GlobalExceptionHandler.java
@@ -23,6 +23,11 @@ public class GlobalExceptionHandler {
         return buildProblemDetail(ErrorCode.INVALID_INPUT, detail, request);
     }
 
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleUnhandledException(Exception ex, HttpServletRequest request) {
+        return buildProblemDetail(ErrorCode.INTERNAL_SERVER_ERROR, ex.getMessage(), request);
+    }
+
     private String extractValidationDetail(MethodArgumentNotValidException ex) {
         return ex.getBindingResult()
                 .getFieldErrors()

--- a/backend/src/main/java/com/onair/hearit/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/GlobalExceptionHandler.java
@@ -16,8 +16,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HearitException.class)
     public ProblemDetail handleHearitException(HearitException ex, HttpServletRequest request) {
-        log.error("서버 내부 오류", ex);
-        return buildProblemDetail(ErrorCode.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getTitle(), request);
+        return buildProblemDetail(ex.getErrorCode(), ex.getDetail(), request);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -28,7 +27,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ProblemDetail handleUnhandledException(Exception ex, HttpServletRequest request) {
-        return buildProblemDetail(ErrorCode.INTERNAL_SERVER_ERROR, ex.getMessage(), request);
+        log.error("서버 내부 오류", ex);
+        return buildProblemDetail(ErrorCode.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getTitle(), request);
     }
 
     private String extractValidationDetail(MethodArgumentNotValidException ex) {

--- a/backend/src/main/java/com/onair/hearit/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/GlobalExceptionHandler.java
@@ -4,17 +4,20 @@ import com.onair.hearit.common.exception.custom.HearitException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(HearitException.class)
     public ProblemDetail handleHearitException(HearitException ex, HttpServletRequest request) {
-        return buildProblemDetail(ex.getErrorCode(), ex.getDetail(), request);
+        log.error("서버 내부 오류", ex);
+        return buildProblemDetail(ErrorCode.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.getTitle(), request);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
원래는 GlobalExceptionHandler에서 커스텀 예외만 처리하여, 예상치 못한 런타임 예외가 403 Forbidden으로 반환됨.
따라서 @ExceptionHandler(Exception.class)를 추가하여 모든 예외를 적절히 500 Internal Server Error로 처리하도록 수정함.
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#184 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 처리되지 않은 서버 오류 발생 시, 내부 서버 오류 메시지가 반환되도록 예외 처리 기능이 추가되었습니다.
  * 서버 내부 오류에 대한 명확한 오류 코드와 메시지가 추가되어 문제 상황 인지가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->