### PR TITLE
[BE] 테스트 픽스처 분리 #169

### DIFF
--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -29,7 +29,9 @@ public class BookmarkService {
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public PagedResponse<BookmarkHearitResponse> getBookmarkHearits(CurrentMember currentMember, PagingRequest pagingRequest) {
+    public PagedResponse<BookmarkHearitResponse> getBookmarkHearits(
+            CurrentMember currentMember,
+            PagingRequest pagingRequest) {
         Member member = getMemberByCurrentMember(currentMember);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByCreatedAtDesc(member, pageable);
@@ -61,7 +63,7 @@ public class BookmarkService {
     }
 
     private Member getMemberByCurrentMember(CurrentMember currentMember) {
-        if(currentMember == null) {
+        if (currentMember == null) {
             throw new UnauthorizedException("로그인한 회원이 아닙니다.");
         }
         return getMemberById(currentMember.memberId());

--- a/backend/src/main/java/com/onair/hearit/auth/config/SecurityConfig.java
+++ b/backend/src/main/java/com/onair/hearit/auth/config/SecurityConfig.java
@@ -22,13 +22,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider;
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
     private static final String[] AUTH_WHITELIST = {
             "/api/v1/auth/**",
             "/api/v1/hearits/**",
@@ -41,6 +34,13 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/v3/api-docs/**"
     };
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/backend/src/main/java/com/onair/hearit/auth/dto/response/KakaoUserInfoResponse.java
+++ b/backend/src/main/java/com/onair/hearit/auth/dto/response/KakaoUserInfoResponse.java
@@ -4,17 +4,17 @@ public record KakaoUserInfoResponse(
         String id,
         Properties properties
 ) {
-    public record Properties(
-            String nickname,
-            String profile_image
-    ) {
-    }
-
     public String nickname() {
         return this.properties().nickname();
     }
 
     public String profileImage() {
         return this.properties().profile_image();
+    }
+
+    public record Properties(
+            String nickname,
+            String profile_image
+    ) {
     }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Bookmark.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Bookmark.java
@@ -36,7 +36,7 @@ public class Bookmark {
     private Hearit hearit;
 
     @CreatedDate
-    @Column(name = "created_at", updatable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     public Bookmark(Member member, Hearit hearit) {

--- a/backend/src/main/java/com/onair/hearit/domain/Hearit.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Hearit.java
@@ -57,19 +57,6 @@ public class Hearit {
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
-    public Hearit(String title, String summary, Integer playTime, String originalAudioUrl, String shortAudioUrl,
-                  String scriptUrl, String source, LocalDateTime createdAt, Category category) {
-        this.title = title;
-        this.summary = summary;
-        this.playTime = playTime;
-        this.originalAudioUrl = originalAudioUrl;
-        this.shortAudioUrl = shortAudioUrl;
-        this.scriptUrl = scriptUrl;
-        this.source = source;
-        this.createdAt = createdAt;
-        this.category = category;
-    }
-
     public Hearit(String title, String summary, Integer playTime, String originalAudioUrl,
                   String shortAudioUrl, String scriptUrl, String source, Category category) {
         this.title = title;

--- a/backend/src/main/java/com/onair/hearit/domain/HearitKeyword.java
+++ b/backend/src/main/java/com/onair/hearit/domain/HearitKeyword.java
@@ -23,11 +23,11 @@ public class HearitKeyword {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "hearit_id")
+    @JoinColumn(name = "hearit_id", nullable = false)
     private Hearit hearit;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "keyword_id")
+    @JoinColumn(name = "keyword_id", nullable = false)
     private Keyword keyword;
 
     public HearitKeyword(Hearit hearit, Keyword keyword) {

--- a/backend/src/main/java/com/onair/hearit/domain/Member.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Member.java
@@ -42,7 +42,7 @@ public class Member {
     private String profileImage;
 
     @CreatedDate
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Column(name = "deleted_at")

--- a/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.TestFixture;
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.domain.Bookmark;

--- a/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
@@ -58,9 +58,9 @@ class BookmarkServiceTest {
     void getBookmarkHearitsTest() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        ;
+
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        ;
+
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
@@ -77,9 +77,9 @@ class BookmarkServiceTest {
     void getBookmarkHearitsTest_() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        ;
+
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        ;
+
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
@@ -94,9 +94,9 @@ class BookmarkServiceTest {
     void addBookmarkTest() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        ;
+
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        ;
+
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
         int previousBookmarkCount = bookmarkRepository.findAll().size();
 
@@ -116,9 +116,9 @@ class BookmarkServiceTest {
     void addBookmarkTest_AlreadyExistTest() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        ;
+
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        ;
+
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
@@ -133,9 +133,9 @@ class BookmarkServiceTest {
     void deleteBookmarkTest() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        ;
+
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        ;
+
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 

--- a/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
@@ -57,10 +57,12 @@ class BookmarkServiceTest {
     @DisplayName("멤버 아이디에 따라 북마크한 히어릿 목록을 페이지에 따라 조회한다.")
     void getBookmarkHearitsTest() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        Bookmark bookmark = saveBookmark(member, hearit);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        ;
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        ;
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
         List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(
@@ -74,10 +76,12 @@ class BookmarkServiceTest {
     @DisplayName("로그인하지 않은 사용자는 북마크 목록 조회시 Unauthorized 예외를 던진다.")
     void getBookmarkHearitsTest_() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        Bookmark bookmark = saveBookmark(member, hearit);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        ;
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        ;
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
         assertThatThrownBy(() -> bookmarkService.getBookmarkHearits(
@@ -89,9 +93,11 @@ class BookmarkServiceTest {
     @DisplayName("멤버 아이디와 히어릿 아이디로 북마크를 추가한다.")
     void addBookmarkTest() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        ;
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        ;
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
         int previousBookmarkCount = bookmarkRepository.findAll().size();
 
         // when
@@ -109,10 +115,12 @@ class BookmarkServiceTest {
     @DisplayName("북마크 추가 시, 이미 북마크가 존재한다면 AlreadyExistException을 던진다.")
     void addBookmarkTest_AlreadyExistTest() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        Bookmark bookmark = saveBookmark(member, hearit);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        ;
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        ;
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
         assertThatThrownBy(() -> bookmarkService.addBookmark(new CurrentMember(member.getId()), hearit.getId()))
@@ -124,10 +132,12 @@ class BookmarkServiceTest {
     @DisplayName("북마크 아이디와 멤버 아이디로 북마크를 삭제한다.")
     void deleteBookmarkTest() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        Bookmark bookmark = saveBookmark(member, hearit);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        ;
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        ;
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
         bookmarkService.deleteBookmark(bookmark.getId(), new CurrentMember(member.getId()));
@@ -140,32 +150,19 @@ class BookmarkServiceTest {
     @DisplayName("북마크 삭제 시, 북마크를 한 멤버가 아니라면 UnauthorizedException을 던진다.")
     void deleteBookmark_UnauthorizedTest() {
         // given
-        Member bookmarkMember = saveMember();
-        Member notBookmarkMember = saveMember();
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        Bookmark bookmark = saveBookmark(bookmarkMember, hearit);
+        Member bookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
+
+        Member notBookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
+
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(bookmarkMember, hearit));
 
         // when & then
         assertThatThrownBy(
                 () -> bookmarkService.deleteBookmark(bookmark.getId(), new CurrentMember(notBookmarkMember.getId())))
                 .isInstanceOf(UnauthorizedException.class)
                 .hasMessageContaining("북마크를 삭제할 권한이 없습니다.");
-    }
-
-    private Member saveMember() {
-        return dbHelper.insertMember(TestFixture.createFixedMember());
-    }
-
-    private Category saveCategory() {
-        return dbHelper.insertCategory(TestFixture.createFixedCategory());
-    }
-
-    private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-    }
-
-    private Bookmark saveBookmark(Member member, Hearit hearit) {
-        return dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/BookmarkServiceTest.java
@@ -61,7 +61,7 @@ class BookmarkServiceTest {
 
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
@@ -80,7 +80,7 @@ class BookmarkServiceTest {
 
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
@@ -97,7 +97,7 @@ class BookmarkServiceTest {
 
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         int previousBookmarkCount = bookmarkRepository.findAll().size();
 
         // when
@@ -119,7 +119,7 @@ class BookmarkServiceTest {
 
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
@@ -136,7 +136,7 @@ class BookmarkServiceTest {
 
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
@@ -156,7 +156,7 @@ class BookmarkServiceTest {
 
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(bookmarkMember, hearit));
 
         // when & then

--- a/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
@@ -3,7 +3,7 @@ package com.onair.hearit.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.request.PagingRequest;
@@ -13,7 +13,6 @@ import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.CategoryRepository;
 import com.onair.hearit.infrastructure.HearitRepository;
 import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
@@ -74,9 +74,9 @@ class CategoryServiceTest {
         // given
         Category category1 = saveCategory("Spring", "#001");
         Category category2 = saveCategory("Java", "#002");
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearit(category1));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearit(category1));
-        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearit(category2));
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category2));
         PagingRequest request = new PagingRequest(0, 10);
 
         // when
@@ -95,9 +95,9 @@ class CategoryServiceTest {
     void searchHearitsByCategory_pagination() {
         // given
         Category category = saveCategory("Spring", "#001");
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         PagingRequest request = new PagingRequest(1, 2);
 
         // when

--- a/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
@@ -74,9 +74,9 @@ class CategoryServiceTest {
         // given
         Category category1 = saveCategory("Spring", "#001");
         Category category2 = saveCategory("Java", "#002");
-        Hearit hearit1 = saveHearit(category1);
-        Hearit hearit2 = saveHearit(category1);
-        Hearit hearit3 = saveHearit(category2);
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearit(category1));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearit(category1));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearit(category2));
         PagingRequest request = new PagingRequest(0, 10);
 
         // when
@@ -95,9 +95,9 @@ class CategoryServiceTest {
     void searchHearitsByCategory_pagination() {
         // given
         Category category = saveCategory("Spring", "#001");
-        Hearit hearit1 = saveHearit(category);
-        Hearit hearit2 = saveHearit(category);
-        Hearit hearit3 = saveHearit(category);
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
         PagingRequest request = new PagingRequest(1, 2);
 
         // when
@@ -113,9 +113,5 @@ class CategoryServiceTest {
     private Category saveCategory(String name, String color) {
         Category category = new Category(name, color);
         return dbHelper.insertCategory(category);
-    }
-
-    private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/FileSourceServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/FileSourceServiceTest.java
@@ -46,7 +46,7 @@ class FileSourceServiceTest {
     void getOriginalAudioTest() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when
         OriginalAudioResponse response = fileSourceService.getOriginalAudio(hearit.getId());
@@ -60,7 +60,7 @@ class FileSourceServiceTest {
     void getShortAudioTest() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when
         ShortAudioResponse response = fileSourceService.getShortAudio(hearit.getId());
@@ -74,7 +74,7 @@ class FileSourceServiceTest {
     void getScriptTest() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when
         ScriptResponse response = fileSourceService.getScript(hearit.getId());

--- a/backend/src/test/java/com/onair/hearit/application/FileSourceServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/FileSourceServiceTest.java
@@ -3,7 +3,7 @@ package com.onair.hearit.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;

--- a/backend/src/test/java/com/onair/hearit/application/FileSourceServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/FileSourceServiceTest.java
@@ -3,15 +3,16 @@ package com.onair.hearit.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.config.TestJpaAuditingConfig;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.OriginalAudioResponse;
 import com.onair.hearit.dto.response.ScriptResponse;
 import com.onair.hearit.dto.response.ShortAudioResponse;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
 import com.onair.hearit.infrastructure.HearitRepository;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
-@Import(DbHelper.class)
+@Import({DbHelper.class, TestJpaAuditingConfig.class})
 @ActiveProfiles("fake-test")
 class FileSourceServiceTest {
 
@@ -44,7 +45,8 @@ class FileSourceServiceTest {
     @DisplayName("히어릿 아이디로 요청 시 original audio url을 제공한다.")
     void getOriginalAudioTest() {
         // given
-        Hearit hearit = saveHearitWithSuffix(1);
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
 
         // when
         OriginalAudioResponse response = fileSourceService.getOriginalAudio(hearit.getId());
@@ -57,7 +59,8 @@ class FileSourceServiceTest {
     @DisplayName("히어릿 아이디로 요청 시 short audio url을 제공한다.")
     void getShortAudioTest() {
         // given
-        Hearit hearit = saveHearitWithSuffix(1);
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
 
         // when
         ShortAudioResponse response = fileSourceService.getShortAudio(hearit.getId());
@@ -70,7 +73,8 @@ class FileSourceServiceTest {
     @DisplayName("히어릿 아이디로 요청 시 script url을 제공한다.")
     void getScriptTest() {
         // given
-        Hearit hearit = saveHearitWithSuffix(1);
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
 
         // when
         ScriptResponse response = fileSourceService.getScript(hearit.getId());
@@ -91,19 +95,11 @@ class FileSourceServiceTest {
                 .hasMessageContaining("hearitId");
     }
 
-    private Hearit saveHearitWithSuffix(int suffix) {
-        Category category = new Category("name" + suffix, "#FFFFFFFF");
-        dbHelper.insertCategory(category);
+    private Category saveCategory() {
+        return dbHelper.insertCategory(TestFixture.createFixedCategory());
+    }
 
-        Hearit hearit = new Hearit(
-                "title" + suffix,
-                "summary" + suffix, suffix,
-                "originalAudioUrl" + suffix,
-                "shortAudioUrl" + suffix,
-                "scriptUrl" + suffix,
-                "source" + suffix,
-                LocalDateTime.now(),
-                category);
-        return dbHelper.insertHearit(hearit);
+    private Hearit saveHearit(Category category) {
+        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/FileSourceServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/FileSourceServiceTest.java
@@ -45,8 +45,8 @@ class FileSourceServiceTest {
     @DisplayName("히어릿 아이디로 요청 시 original audio url을 제공한다.")
     void getOriginalAudioTest() {
         // given
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when
         OriginalAudioResponse response = fileSourceService.getOriginalAudio(hearit.getId());
@@ -59,8 +59,8 @@ class FileSourceServiceTest {
     @DisplayName("히어릿 아이디로 요청 시 short audio url을 제공한다.")
     void getShortAudioTest() {
         // given
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when
         ShortAudioResponse response = fileSourceService.getShortAudio(hearit.getId());
@@ -73,8 +73,8 @@ class FileSourceServiceTest {
     @DisplayName("히어릿 아이디로 요청 시 script url을 제공한다.")
     void getScriptTest() {
         // given
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when
         ScriptResponse response = fileSourceService.getScript(hearit.getId());
@@ -93,13 +93,5 @@ class FileSourceServiceTest {
         assertThatThrownBy(() -> fileSourceService.getScript(notSavedHearitId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("hearitId");
-    }
-
-    private Category saveCategory() {
-        return dbHelper.insertCategory(TestFixture.createFixedCategory());
-    }
-
-    private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
@@ -3,7 +3,7 @@ package com.onair.hearit.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.HearitKeyword;

--- a/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitSearchServiceTest.java
@@ -153,15 +153,11 @@ class HearitSearchServiceTest {
     }
 
     private Hearit saveHearitWithTitleAndKeyword(String title, Keyword keyword) {
-        Category category = saveCategory();
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = saveHearit(title, category);
 
         dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword));
         return hearit;
-    }
-
-    private Category saveCategory() {
-        return dbHelper.insertCategory(TestFixture.createFixedCategory());
     }
 
     private Hearit saveHearit(String title, Category category) {

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.TestFixture;
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Category;

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -54,10 +54,10 @@ class HearitServiceTest {
     @DisplayName("히어릿 아이디로 단일 히어릿 정보를 조회 할 수 있다.")
     void getHearitDetailTest() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        Bookmark bookmark = saveBookmark(member, hearit);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
         HearitDetailResponse response = hearitService.getHearitDetail(hearit.getId(), member.getId());
@@ -77,7 +77,7 @@ class HearitServiceTest {
     void getHearitDetailNotFoundTest() {
         // given
         Long notExistHearitId = 1L;
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
 
         // when & then
         assertThatThrownBy(() -> hearitService.getHearitDetail(notExistHearitId, member.getId()))
@@ -89,12 +89,12 @@ class HearitServiceTest {
     @DisplayName("최대 10개의 랜덤 히어릿을 조회할 수 있다.")
     void getRandomHearits() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
         for (int i = 1; i <= 11; i++) {
-            Hearit hearit = saveHearit(category);
-            saveBookmark(member, hearit);
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
         }
         PagingRequest pagingRequest = new PagingRequest(0, 10);
 
@@ -109,30 +109,14 @@ class HearitServiceTest {
     @DisplayName("최대 5개의 추천 히어릿을 조회할 수 있다.")
     void getRecommendedHearits() {
         // given
-        Category category = saveCategory();
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         IntStream.rangeClosed(1, 6)
-                .forEach((num) -> saveHearit(category));
+                .forEach((num) -> dbHelper.insertHearit(TestFixture.createFixedHearit(category)));
 
         // when
         List<RecommendHearitResponse> hearits = hearitService.getRecommendedHearits();
 
         // then
         assertThat(hearits).hasSize(5);
-    }
-
-    private Member saveMember() {
-        return dbHelper.insertMember(TestFixture.createFixedMember());
-    }
-
-    private Category saveCategory() {
-        return dbHelper.insertCategory(TestFixture.createFixedCategory());
-    }
-
-    private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-    }
-
-    private Bookmark saveBookmark(Member member, Hearit hearit) {
-        return dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -56,7 +56,7 @@ class HearitServiceTest {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
@@ -93,7 +93,7 @@ class HearitServiceTest {
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
         for (int i = 1; i <= 11; i++) {
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
         }
         PagingRequest pagingRequest = new PagingRequest(0, 10);
@@ -111,7 +111,7 @@ class HearitServiceTest {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         IntStream.rangeClosed(1, 6)
-                .forEach((num) -> dbHelper.insertHearit(TestFixture.createFixedHearit(category)));
+                .forEach((num) -> dbHelper.insertHearit(TestFixture.createFixedHearitWith(category)));
 
         // when
         List<RecommendHearitResponse> hearits = hearitService.getRecommendedHearits();

--- a/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
@@ -9,7 +9,6 @@ import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.KeywordResponse;
 import com.onair.hearit.fixture.DbHelper;
-import com.onair.hearit.fixture.TestFixture;
 import com.onair.hearit.infrastructure.KeywordRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,11 +41,11 @@ class KeywordServiceTest {
     @DisplayName("키워드 목록 조회 시 페이지네이션이 적용되어 반환된다.")
     void getKeywords_withPagination() {
         // given
-        Keyword keyword1 = saveKeyword();
-        Keyword keyword2 = saveKeyword();
-        Keyword keyword3 = saveKeyword();
-        Keyword keyword4 = saveKeyword();
-        Keyword keyword5 = saveKeyword();
+        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("keyword1"));
+        Keyword keyword2 = dbHelper.insertKeyword(new Keyword("keyword2"));
+        Keyword keyword3 = dbHelper.insertKeyword(new Keyword("keyword3"));
+        Keyword keyword4 = dbHelper.insertKeyword(new Keyword("keyword4"));
+        Keyword keyword5 = dbHelper.insertKeyword(new Keyword("keyword5"));
 
         PagingRequest pagingRequest = new PagingRequest(1, 2);// page = 1 (두 번째 페이지), size = 2
 
@@ -65,7 +64,7 @@ class KeywordServiceTest {
     @DisplayName("단일 키워드를 조회할 수 있다.")
     void getKeywordByIdById() {
         // given
-        Keyword keyword = saveKeyword();
+        Keyword keyword = dbHelper.insertKeyword(new Keyword("keyword1"));
 
         // when
         KeywordResponse result = keywordService.getKeyword(keyword.getId());
@@ -91,11 +90,11 @@ class KeywordServiceTest {
     @DisplayName("오늘의 추천 키워드를 지정한 개수만큼 조회할 수 있다.")
     void getRecommendedKeywords() {
         // given
-        saveKeyword();
-        saveKeyword();
-        saveKeyword();
-        saveKeyword();
-        saveKeyword();
+        dbHelper.insertKeyword(new Keyword("keyword1"));
+        dbHelper.insertKeyword(new Keyword("keyword2"));
+        dbHelper.insertKeyword(new Keyword("keyword3"));
+        dbHelper.insertKeyword(new Keyword("keyword4"));
+        dbHelper.insertKeyword(new Keyword("keyword5"));
 
         int size = 3;
 
@@ -110,11 +109,12 @@ class KeywordServiceTest {
     @DisplayName("같은 날 호출하면 추천 키워드 결과는 항상 동일하다.")
     void getRecommendedKeywords_shouldBeDeterministicForSameSeed() {
         // given
-        saveKeyword();
-        saveKeyword();
-        saveKeyword();
-        saveKeyword();
-        saveKeyword();
+        dbHelper.insertKeyword(new Keyword("keyword1"));
+        dbHelper.insertKeyword(new Keyword("keyword2"));
+        dbHelper.insertKeyword(new Keyword("keyword3"));
+        dbHelper.insertKeyword(new Keyword("keyword4"));
+        dbHelper.insertKeyword(new Keyword("keyword5"));
+        dbHelper.insertKeyword(new Keyword("keyword6"));
         int size = 3;
 
         // when
@@ -126,9 +126,5 @@ class KeywordServiceTest {
                 .containsExactlyElementsOf(
                         second.stream().map(KeywordResponse::id).toList()
                 );
-    }
-
-    private Keyword saveKeyword() {
-        return dbHelper.insertKeyword(TestFixture.createFixedKeyword());
     }
 } 

--- a/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.dto.request.PagingRequest;

--- a/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/KeywordServiceTest.java
@@ -4,11 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.KeywordResponse;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
 import com.onair.hearit.infrastructure.KeywordRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +30,7 @@ class KeywordServiceTest {
 
     @Autowired
     private KeywordRepository keywordRepository;
+
     private KeywordService keywordService;
 
     @BeforeEach
@@ -40,11 +42,11 @@ class KeywordServiceTest {
     @DisplayName("키워드 목록 조회 시 페이지네이션이 적용되어 반환된다.")
     void getKeywords_withPagination() {
         // given
-        Keyword keyword1 = saveKeyword("keyword1");
-        Keyword keyword2 = saveKeyword("keyword2");
-        Keyword keyword3 = saveKeyword("keyword3");
-        Keyword keyword4 = saveKeyword("keyword4");
-        Keyword keyword5 = saveKeyword("keyword5");
+        Keyword keyword1 = saveKeyword();
+        Keyword keyword2 = saveKeyword();
+        Keyword keyword3 = saveKeyword();
+        Keyword keyword4 = saveKeyword();
+        Keyword keyword5 = saveKeyword();
 
         PagingRequest pagingRequest = new PagingRequest(1, 2);// page = 1 (두 번째 페이지), size = 2
 
@@ -58,12 +60,12 @@ class KeywordServiceTest {
                         .containsExactly(keyword3.getId(), keyword4.getId())
         );
     }
-    
+
     @Test
     @DisplayName("단일 키워드를 조회할 수 있다.")
     void getKeywordByIdById() {
         // given
-        Keyword keyword = saveKeyword("keyword");
+        Keyword keyword = saveKeyword();
 
         // when
         KeywordResponse result = keywordService.getKeyword(keyword.getId());
@@ -89,11 +91,11 @@ class KeywordServiceTest {
     @DisplayName("오늘의 추천 키워드를 지정한 개수만큼 조회할 수 있다.")
     void getRecommendedKeywords() {
         // given
-        saveKeyword("keyword1");
-        saveKeyword("keyword2");
-        saveKeyword("keyword3");
-        saveKeyword("keyword4");
-        saveKeyword("keyword5");
+        saveKeyword();
+        saveKeyword();
+        saveKeyword();
+        saveKeyword();
+        saveKeyword();
 
         int size = 3;
 
@@ -108,11 +110,11 @@ class KeywordServiceTest {
     @DisplayName("같은 날 호출하면 추천 키워드 결과는 항상 동일하다.")
     void getRecommendedKeywords_shouldBeDeterministicForSameSeed() {
         // given
-        saveKeyword("keyword1");
-        saveKeyword("keyword2");
-        saveKeyword("keyword3");
-        saveKeyword("keyword4");
-        saveKeyword("keyword5");
+        saveKeyword();
+        saveKeyword();
+        saveKeyword();
+        saveKeyword();
+        saveKeyword();
         int size = 3;
 
         // when
@@ -126,8 +128,7 @@ class KeywordServiceTest {
                 );
     }
 
-    private Keyword saveKeyword(String name) {
-        Keyword keyword = new Keyword(name);
-        return dbHelper.insertKeyword(keyword);
+    private Keyword saveKeyword() {
+        return dbHelper.insertKeyword(TestFixture.createFixedKeyword());
     }
 } 

--- a/backend/src/test/java/com/onair/hearit/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/MemberServiceTest.java
@@ -41,7 +41,7 @@ class MemberServiceTest {
     @DisplayName("회원 정보를 ID로 조회할 수 있다.")
     void getMemberById_localMember() {
         // given
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
 
         // when
         MemberInfoResponse response = memberService.getMember(member.getId());
@@ -64,9 +64,5 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.getMember(nonExistId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("memberId");
-    }
-
-    private Member saveMember() {
-        return dbHelper.insertMember(TestFixture.createFixedMember());
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/MemberServiceTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.TestFixture;
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.dto.response.MemberInfoResponse;

--- a/backend/src/test/java/com/onair/hearit/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/MemberServiceTest.java
@@ -4,11 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.fixture.TestFixture;
-import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.config.TestJpaAuditingConfig;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.dto.response.MemberInfoResponse;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
 import com.onair.hearit.infrastructure.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
-@Import(DbHelper.class)
+@Import({DbHelper.class, TestJpaAuditingConfig.class})
 @ActiveProfiles("fake-test")
 class MemberServiceTest {
 
@@ -40,7 +41,7 @@ class MemberServiceTest {
     @DisplayName("회원 정보를 ID로 조회할 수 있다.")
     void getMemberById_localMember() {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Member member = saveMember();
 
         // when
         MemberInfoResponse response = memberService.getMember(member.getId());
@@ -63,5 +64,9 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.getMember(nonExistId))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("memberId");
+    }
+
+    private Member saveMember() {
+        return dbHelper.insertMember(TestFixture.createFixedMember());
     }
 }

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthKakaoServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthKakaoServiceTest.java
@@ -3,7 +3,7 @@ package com.onair.hearit.auth.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.auth.dto.request.KakaoLoginRequest;
 import com.onair.hearit.auth.dto.response.KakaoUserInfoResponse;
 import com.onair.hearit.auth.dto.response.TokenResponse;

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthKakaoServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthKakaoServiceTest.java
@@ -3,14 +3,14 @@ package com.onair.hearit.auth.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.onair.hearit.config.TestJpaAuditingConfig;
-import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.auth.dto.request.KakaoLoginRequest;
 import com.onair.hearit.auth.dto.response.KakaoUserInfoResponse;
 import com.onair.hearit.auth.dto.response.TokenResponse;
 import com.onair.hearit.auth.infrastructure.client.KakaoUserInfoClient;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.config.TestJpaAuditingConfig;
 import com.onair.hearit.domain.Member;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.infrastructure.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthKakaoServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthKakaoServiceTest.java
@@ -3,6 +3,7 @@ package com.onair.hearit.auth.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.onair.hearit.config.TestJpaAuditingConfig;
 import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.auth.dto.request.KakaoLoginRequest;
 import com.onair.hearit.auth.dto.response.KakaoUserInfoResponse;
@@ -23,7 +24,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
 @ActiveProfiles("fake-test")
-@Import({AuthService.class, BCryptPasswordEncoder.class, JwtTokenProvider.class, DbHelper.class})
+@Import({AuthService.class, BCryptPasswordEncoder.class, JwtTokenProvider.class,
+        DbHelper.class, TestJpaAuditingConfig.class})
 class AuthKakaoServiceTest {
 
     @MockitoBean

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.auth.dto.request.LoginRequest;
 import com.onair.hearit.auth.dto.request.SignupRequest;
 import com.onair.hearit.auth.dto.response.TokenResponse;

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.config.TestJpaAuditingConfig;
-import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.auth.dto.request.LoginRequest;
 import com.onair.hearit.auth.dto.request.SignupRequest;
 import com.onair.hearit.auth.dto.response.TokenResponse;
@@ -13,7 +11,9 @@ import com.onair.hearit.auth.infrastructure.client.KakaoUserInfoClient;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.exception.custom.InvalidInputException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.config.TestJpaAuditingConfig;
 import com.onair.hearit.domain.Member;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.infrastructure.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.onair.hearit.config.TestJpaAuditingConfig;
 import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.auth.dto.request.LoginRequest;
 import com.onair.hearit.auth.dto.request.SignupRequest;
@@ -26,7 +27,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @DataJpaTest
 @ActiveProfiles("fake-test")
-@Import({AuthService.class, BCryptPasswordEncoder.class, JwtTokenProvider.class, DbHelper.class})
+@Import({AuthService.class, BCryptPasswordEncoder.class, JwtTokenProvider.class,
+        DbHelper.class, TestJpaAuditingConfig.class})
 class AuthServiceTest {
 
     @MockitoBean

--- a/backend/src/test/java/com/onair/hearit/auth/infrastructure/client/KakaoUserInfoClientTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/infrastructure/client/KakaoUserInfoClientTest.java
@@ -1,7 +1,7 @@
 package com.onair.hearit.auth.infrastructure.client;
 
-import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.auth.dto.response.KakaoUserInfoResponse;
+import com.onair.hearit.fixture.IntegrationTest;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/onair/hearit/auth/infrastructure/client/KakaoUserInfoClientTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/infrastructure/client/KakaoUserInfoClientTest.java
@@ -1,6 +1,6 @@
 package com.onair.hearit.auth.infrastructure.client;
 
-import com.onair.hearit.IntegrationTest;
+import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.auth.dto.response.KakaoUserInfoResponse;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Disabled;

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -4,11 +4,11 @@ package com.onair.hearit.auth.presentation;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.onair.hearit.fixture.DbHelper;
-import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.auth.dto.request.LoginRequest;
 import com.onair.hearit.auth.dto.response.TokenResponse;
 import com.onair.hearit.domain.Member;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.IntegrationTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -4,8 +4,8 @@ package com.onair.hearit.auth.presentation;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.onair.hearit.DbHelper;
-import com.onair.hearit.IntegrationTest;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.auth.dto.request.LoginRequest;
 import com.onair.hearit.auth.dto.response.TokenResponse;
 import com.onair.hearit.domain.Member;

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthKakaoLoginControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthKakaoLoginControllerTest.java
@@ -6,7 +6,7 @@ import static io.restassured.RestAssured.given;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.onair.hearit.IntegrationTest;
+import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.auth.dto.request.KakaoLoginRequest;
 import com.onair.hearit.auth.dto.response.TokenResponse;
 import com.onair.hearit.auth.infrastructure.client.KakaoUserInfoClient;

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthKakaoLoginControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthKakaoLoginControllerTest.java
@@ -6,10 +6,10 @@ import static io.restassured.RestAssured.given;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.auth.dto.request.KakaoLoginRequest;
 import com.onair.hearit.auth.dto.response.TokenResponse;
 import com.onair.hearit.auth.infrastructure.client.KakaoUserInfoClient;
+import com.onair.hearit.fixture.IntegrationTest;
 import io.restassured.http.ContentType;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;

--- a/backend/src/test/java/com/onair/hearit/config/TestJpaAuditingConfig.java
+++ b/backend/src/test/java/com/onair/hearit/config/TestJpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.onair.hearit.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaAuditingConfig {
+}

--- a/backend/src/test/java/com/onair/hearit/fixture/DbHelper.java
+++ b/backend/src/test/java/com/onair/hearit/fixture/DbHelper.java
@@ -1,4 +1,4 @@
-package com.onair.hearit;
+package com.onair.hearit.fixture;
 
 import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Category;

--- a/backend/src/test/java/com/onair/hearit/fixture/IntegrationTest.java
+++ b/backend/src/test/java/com/onair/hearit/fixture/IntegrationTest.java
@@ -1,4 +1,4 @@
-package com.onair.hearit;
+package com.onair.hearit.fixture;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;

--- a/backend/src/test/java/com/onair/hearit/fixture/TestFixture.java
+++ b/backend/src/test/java/com/onair/hearit/fixture/TestFixture.java
@@ -24,7 +24,7 @@ public class TestFixture {
         return new Category("name", "colorCode");
     }
 
-    public static Hearit createFixedHearit(Category category) {
+    public static Hearit createFixedHearitWith(Category category) {
         return new Hearit(
                 "title",
                 "summary",

--- a/backend/src/test/java/com/onair/hearit/fixture/TestFixture.java
+++ b/backend/src/test/java/com/onair/hearit/fixture/TestFixture.java
@@ -1,4 +1,4 @@
-package com.onair;
+package com.onair.hearit.fixture;
 
 import com.onair.hearit.domain.Member;
 

--- a/backend/src/test/java/com/onair/hearit/fixture/TestFixture.java
+++ b/backend/src/test/java/com/onair/hearit/fixture/TestFixture.java
@@ -1,10 +1,42 @@
 package com.onair.hearit.fixture;
 
+import com.onair.hearit.domain.Bookmark;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.domain.Member;
 
 public class TestFixture {
 
     public static Member createFixedMember() {
-        return Member.createLocalUser("memberID", "nickname", "password", "profile-image.jpg");
+        return Member.createLocalUser(
+                "memberID",
+                "nickname",
+                "password",
+                "profile-image.jpg");
+    }
+
+    public static Keyword createFixedKeyword() {
+        return new Keyword("name");
+    }
+
+    public static Category createFixedCategory() {
+        return new Category("name", "colorCode");
+    }
+
+    public static Hearit createFixedHearit(Category category) {
+        return new Hearit(
+                "title",
+                "summary",
+                500,
+                "originalAudioUrl",
+                "shortAudioUrl",
+                "scriptUrl",
+                "source",
+                category);
+    }
+
+    public static Bookmark createFixedBookmark(Member member, Hearit hearit) {
+        return new Bookmark(member, hearit);
     }
 }

--- a/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
@@ -3,7 +3,7 @@ package com.onair.hearit.infrastructure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.HearitKeyword;

--- a/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/HearitRepositoryTest.java
@@ -118,7 +118,7 @@ class HearitRepositoryTest {
     }
 
     private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        return dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
     }
 
     private Hearit saveHearitWithTitleAndKeyword(String title, Keyword keyword) {

--- a/backend/src/test/java/com/onair/hearit/infrastructure/KeywordRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/KeywordRepositoryTest.java
@@ -2,7 +2,7 @@ package com.onair.hearit.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.domain.Keyword;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/onair/hearit/infrastructure/KeywordRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/KeywordRepositoryTest.java
@@ -2,8 +2,9 @@ package com.onair.hearit.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.domain.Keyword;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,9 +28,9 @@ class KeywordRepositoryTest {
     @DisplayName("저장된 키워드들의 ID 목록을 조회할 수 있다.")
     void findAllIds_returnsAllKeywordIds() {
         // given
-        Keyword keyword1 = saveKeyword("keyword1");
-        Keyword keyword2 = saveKeyword("keyword2");
-        Keyword keyword3 = saveKeyword("keyword3");
+        Keyword keyword1 = saveKeyword();
+        Keyword keyword2 = saveKeyword();
+        Keyword keyword3 = saveKeyword();
 
         // when
         List<Long> ids = keywordRepository.findAllIds();
@@ -42,9 +43,9 @@ class KeywordRepositoryTest {
     @DisplayName("ID 목록으로 키워드를 조회할 수 있다.")
     void findAllByIdIn_returnsMatchingKeywords() {
         // given
-        Keyword keyword1 = saveKeyword("keyword1");
-        Keyword keyword2 = saveKeyword("keyword2");
-        saveKeyword("keyword3");
+        Keyword keyword1 = saveKeyword();
+        Keyword keyword2 = saveKeyword();
+        Keyword keyword3 = saveKeyword();
 
         List<Long> selectedIds = List.of(keyword1.getId(), keyword2.getId());
 
@@ -56,7 +57,7 @@ class KeywordRepositoryTest {
                 .containsExactlyInAnyOrderElementsOf(selectedIds);
     }
 
-    private Keyword saveKeyword(String name) {
-        return dbHelper.insertKeyword(new Keyword(name));
+    private Keyword saveKeyword() {
+        return dbHelper.insertKeyword(TestFixture.createFixedKeyword());
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -27,13 +27,13 @@ class BookmarkControllerTest extends IntegrationTest {
     @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
     void readBookmarkHearitsTest() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         String token = generateToken(member);
         int bookmarkCount = 30;
         for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = saveHearit(category);
-            saveBookmark(member, hearit);
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
         }
 
         // when & then
@@ -55,11 +55,11 @@ class BookmarkControllerTest extends IntegrationTest {
     @DisplayName("로그인한 사용자가 북마크 목록 조회 시, page가 0 미만인 경우 400 BADREQUEST가 발생한다.")
     void readBookmarkHearitsTestWithBadRequestByPage() {
         // given
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        saveBookmark(member, hearit);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
         RestAssured.given()
@@ -76,11 +76,11 @@ class BookmarkControllerTest extends IntegrationTest {
     @DisplayName("로그인한 사용자가 북마크 목록 조회 시, size가 0 ~ 50이 아닌 경우 400 BADREQUEST가 발생한다.")
     void readBookmarkHearitsTestWithBadRequestBySize() {
         // given
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        saveBookmark(member, hearit);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
         RestAssured.given()
@@ -96,12 +96,12 @@ class BookmarkControllerTest extends IntegrationTest {
     @DisplayName("로그인하지 않은 사용자가 북마크 목록 조회 시, 401 UNAUTHORIZATION가 발생한다.")
     void readBookmarkHearits_error_401_whenNotLogin() {
         // given
-        Member member = saveMember();
-        Category category = saveCategory();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         int bookmarkCount = 10;
         for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = saveHearit(category);
-            saveBookmark(member, hearit);
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
         }
 
         // when & then
@@ -119,10 +119,10 @@ class BookmarkControllerTest extends IntegrationTest {
     @DisplayName("로그인한 사용자가 북마크 추가 시, 추가 후 201 CREATED를 반환한다.")
     void createBookmarkTest() {
         // given
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when & then
         BookmarkInfoResponse response = RestAssured.given()
@@ -140,11 +140,11 @@ class BookmarkControllerTest extends IntegrationTest {
     @DisplayName("로그인한 사용자가 이미 추가된 북마크 추가 시, 추가 후 409 CONFLICT를 반환한다.")
     void createBookmarkTestWithConflict() {
         // given
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        saveBookmark(member, hearit);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
         RestAssured.given()
@@ -159,11 +159,11 @@ class BookmarkControllerTest extends IntegrationTest {
     @DisplayName("로그인한 사용자가 북마크 삭제 시, 삭제 후 204 NOCONTENT를 반환한다.")
     void deleteBookmark() {
         // given
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        Bookmark bookmark = saveBookmark(member, hearit);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
         RestAssured.given()
@@ -178,12 +178,12 @@ class BookmarkControllerTest extends IntegrationTest {
     @DisplayName("자신의 북마크가 아닌 북마크 삭제 시, 403 UNAUTHORIZED를 반환한다.")
     void notFoundHearitId() {
         // given
-        Member bookmarkMember = saveMember();
-        Member notBookmarkMember = saveMember();
+        Member bookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
+        Member notBookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(notBookmarkMember);
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
-        Bookmark bookmark = saveBookmark(bookmarkMember, hearit);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(bookmarkMember, hearit));
 
         // when & then
         RestAssured.given()
@@ -196,21 +196,5 @@ class BookmarkControllerTest extends IntegrationTest {
 
     private String generateToken(Member member) {
         return jwtTokenProvider.createToken(member.getId());
-    }
-
-    private Member saveMember() {
-        return dbHelper.insertMember(TestFixture.createFixedMember());
-    }
-
-    private Category saveCategory() {
-        return dbHelper.insertCategory(TestFixture.createFixedCategory());
-    }
-
-    private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-    }
-
-    private Bookmark saveBookmark(Member member, Hearit hearit) {
-        return dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -32,7 +32,7 @@ class BookmarkControllerTest extends IntegrationTest {
         String token = generateToken(member);
         int bookmarkCount = 30;
         for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
         }
 
@@ -58,7 +58,7 @@ class BookmarkControllerTest extends IntegrationTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
@@ -79,7 +79,7 @@ class BookmarkControllerTest extends IntegrationTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
@@ -100,7 +100,7 @@ class BookmarkControllerTest extends IntegrationTest {
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         int bookmarkCount = 10;
         for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
         }
 
@@ -122,7 +122,7 @@ class BookmarkControllerTest extends IntegrationTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when & then
         BookmarkInfoResponse response = RestAssured.given()
@@ -143,7 +143,7 @@ class BookmarkControllerTest extends IntegrationTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
@@ -162,7 +162,7 @@ class BookmarkControllerTest extends IntegrationTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when & then
@@ -182,7 +182,7 @@ class BookmarkControllerTest extends IntegrationTest {
         Member notBookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(notBookmarkMember);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(bookmarkMember, hearit));
 
         // when & then

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -3,7 +3,7 @@ package com.onair.hearit.presentation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.onair.TestFixture;
+import com.onair.hearit.fixture.TestFixture;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Category;

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -3,15 +3,14 @@ package com.onair.hearit.presentation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import com.onair.hearit.fixture.TestFixture;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.dto.response.BookmarkInfoResponse;
+import com.onair.hearit.fixture.TestFixture;
 import io.restassured.RestAssured;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,11 +28,12 @@ class BookmarkControllerTest extends IntegrationTest {
     void readBookmarkHearitsTest() {
         // given
         Member member = saveMember();
+        Category category = saveCategory();
         String token = generateToken(member);
         int bookmarkCount = 30;
         for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = saveHearitWithSuffix(i);
-            dbHelper.insertBookmark(new Bookmark(member, hearit));
+            Hearit hearit = saveHearit(category);
+            saveBookmark(member, hearit);
         }
 
         // when & then
@@ -57,8 +57,9 @@ class BookmarkControllerTest extends IntegrationTest {
         // given
         Member member = saveMember();
         String token = generateToken(member);
-        Hearit hearit = saveHearitWithSuffix(1);
-        dbHelper.insertBookmark(new Bookmark(member, hearit));
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
+        saveBookmark(member, hearit);
 
         // when & then
         RestAssured.given()
@@ -77,8 +78,9 @@ class BookmarkControllerTest extends IntegrationTest {
         // given
         Member member = saveMember();
         String token = generateToken(member);
-        Hearit hearit = saveHearitWithSuffix(1);
-        dbHelper.insertBookmark(new Bookmark(member, hearit));
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
+        saveBookmark(member, hearit);
 
         // when & then
         RestAssured.given()
@@ -95,10 +97,11 @@ class BookmarkControllerTest extends IntegrationTest {
     void readBookmarkHearits_error_401_whenNotLogin() {
         // given
         Member member = saveMember();
+        Category category = saveCategory();
         int bookmarkCount = 10;
         for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = saveHearitWithSuffix(i);
-            dbHelper.insertBookmark(new Bookmark(member, hearit));
+            Hearit hearit = saveHearit(category);
+            saveBookmark(member, hearit);
         }
 
         // when & then
@@ -118,7 +121,8 @@ class BookmarkControllerTest extends IntegrationTest {
         // given
         Member member = saveMember();
         String token = generateToken(member);
-        Hearit hearit = saveHearitWithSuffix(1);
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
 
         // when & then
         BookmarkInfoResponse response = RestAssured.given()
@@ -138,8 +142,9 @@ class BookmarkControllerTest extends IntegrationTest {
         // given
         Member member = saveMember();
         String token = generateToken(member);
-        Hearit hearit = saveHearitWithSuffix(1);
-        dbHelper.insertBookmark(new Bookmark(member, hearit));
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
+        saveBookmark(member, hearit);
 
         // when & then
         RestAssured.given()
@@ -156,8 +161,9 @@ class BookmarkControllerTest extends IntegrationTest {
         // given
         Member member = saveMember();
         String token = generateToken(member);
-        Hearit hearit = saveHearitWithSuffix(1);
-        Bookmark bookmark = dbHelper.insertBookmark(new Bookmark(member, hearit));
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
+        Bookmark bookmark = saveBookmark(member, hearit);
 
         // when & then
         RestAssured.given()
@@ -175,8 +181,9 @@ class BookmarkControllerTest extends IntegrationTest {
         Member bookmarkMember = saveMember();
         Member notBookmarkMember = saveMember();
         String token = generateToken(notBookmarkMember);
-        Hearit hearit = saveHearitWithSuffix(1);
-        Bookmark bookmark = dbHelper.insertBookmark(new Bookmark(bookmarkMember, hearit));
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
+        Bookmark bookmark = saveBookmark(bookmarkMember, hearit);
 
         // when & then
         RestAssured.given()
@@ -187,27 +194,23 @@ class BookmarkControllerTest extends IntegrationTest {
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
-    private Member saveMember() {
-        return dbHelper.insertMember(TestFixture.createFixedMember());
-    }
-
     private String generateToken(Member member) {
         return jwtTokenProvider.createToken(member.getId());
     }
 
-    private Hearit saveHearitWithSuffix(int suffix) {
-        Category category = new Category("name" + suffix, "#123");
-        dbHelper.insertCategory(category);
+    private Member saveMember() {
+        return dbHelper.insertMember(TestFixture.createFixedMember());
+    }
 
-        Hearit hearit = new Hearit(
-                "title" + suffix,
-                "summary" + suffix, suffix,
-                "originalAudioUrl" + suffix,
-                "shortAudioUrl" + suffix,
-                "scriptUrl" + suffix,
-                "source" + suffix,
-                LocalDateTime.now(),
-                category);
-        return dbHelper.insertHearit(hearit);
+    private Category saveCategory() {
+        return dbHelper.insertCategory(TestFixture.createFixedCategory());
+    }
+
+    private Hearit saveHearit(Category category) {
+        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+    }
+
+    private Bookmark saveBookmark(Member member, Hearit hearit) {
+        return dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
@@ -22,11 +22,11 @@ class CategoryControllerTest extends IntegrationTest {
     @DisplayName("전체 카테고리를 조회 시 200 OK 및 페이징이 적용된 카테고리 목록을 반환한다.")
     void readAllCategories() {
         // given
-        Category category1 = saveCategory("category1", "#111");
-        Category category2 = saveCategory("category2", "#222");
-        Category category3 = saveCategory("category3", "#333");
-        Category category4 = saveCategory("category4", "#444");
-        Category category5 = saveCategory("category5", "#555");
+        Category category1 = dbHelper.insertCategory(new Category("category1", "#111"));
+        Category category2 = dbHelper.insertCategory(new Category("category2", "#222"));
+        Category category3 = dbHelper.insertCategory(new Category("category3", "#333"));
+        Category category4 = dbHelper.insertCategory(new Category("category4", "#444"));
+        Category category5 = dbHelper.insertCategory(new Category("category5", "#555"));
 
         // when
         PagedResponse<CategoryResponse> result = RestAssured.given()
@@ -54,12 +54,12 @@ class CategoryControllerTest extends IntegrationTest {
     @DisplayName("카테고리로 히어릿 검색 시 200 OK 및 해당 카테고리의 히어릿들을 최신순으로 반환한다.")
     void searchHearitsByCategoryWithPagination() {
         // given
-        Category category1 = saveCategory("Spring", "#001");
-        Category category2 = saveCategory("Java", "#002");
+        Category category1 = dbHelper.insertCategory(new Category("Spring", "#001"));
+        Category category2 = dbHelper.insertCategory(new Category("Java", "#002"));
 
-        Hearit hearit1 = saveHearit(category1);
-        Hearit hearit2 = saveHearit(category1);
-        saveHearit(category2); // 다른 카테고리
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearit(category1));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearit(category1));
+        dbHelper.insertHearit(TestFixture.createFixedHearit(category2)); // 다른 카테고리
 
         // when
         PagedResponse<HearitSearchResponse> pagedResponse = RestAssured
@@ -82,13 +82,5 @@ class CategoryControllerTest extends IntegrationTest {
                 () -> assertThat(responses.get(0).id()).isEqualTo(hearit2.getId()), // 최신 hearit 먼저
                 () -> assertThat(responses.get(1).id()).isEqualTo(hearit1.getId())
         );
-    }
-
-    private Category saveCategory(String name, String color) {
-        return dbHelper.insertCategory(new Category(name, color));
-    }
-
-    private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
@@ -8,9 +8,9 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.CategoryResponse;
 import com.onair.hearit.dto.response.HearitSearchResponse;
 import com.onair.hearit.dto.response.PagedResponse;
+import com.onair.hearit.fixture.TestFixture;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,9 +57,9 @@ class CategoryControllerTest extends IntegrationTest {
         Category category1 = saveCategory("Spring", "#001");
         Category category2 = saveCategory("Java", "#002");
 
-        Hearit hearit1 = saveHearitWithCategory(category1);
-        Hearit hearit2 = saveHearitWithCategory(category1);
-        saveHearitWithCategory(category2); // 다른 카테고리
+        Hearit hearit1 = saveHearit(category1);
+        Hearit hearit2 = saveHearit(category1);
+        saveHearit(category2); // 다른 카테고리
 
         // when
         PagedResponse<HearitSearchResponse> pagedResponse = RestAssured
@@ -84,23 +84,11 @@ class CategoryControllerTest extends IntegrationTest {
         );
     }
 
-
     private Category saveCategory(String name, String color) {
         return dbHelper.insertCategory(new Category(name, color));
     }
 
-    private Hearit saveHearitWithCategory(Category category) {
-        Hearit hearit = new Hearit(
-                "title",
-                "summary",
-                1,
-                "originalAudioUrl",
-                "shortAudioUrl",
-                "scriptUrl",
-                "source",
-                LocalDateTime.now(),
-                category
-        );
-        return dbHelper.insertHearit(hearit);
+    private Hearit saveHearit(Category category) {
+        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
@@ -57,9 +57,9 @@ class CategoryControllerTest extends IntegrationTest {
         Category category1 = dbHelper.insertCategory(new Category("Spring", "#001"));
         Category category2 = dbHelper.insertCategory(new Category("Java", "#002"));
 
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearit(category1));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearit(category1));
-        dbHelper.insertHearit(TestFixture.createFixedHearit(category2)); // 다른 카테고리
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
+        dbHelper.insertHearit(TestFixture.createFixedHearitWith(category2)); // 다른 카테고리
 
         // when
         PagedResponse<HearitSearchResponse> pagedResponse = RestAssured

--- a/backend/src/test/java/com/onair/hearit/presentation/FileSourceControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/FileSourceControllerTest.java
@@ -20,7 +20,7 @@ class FileSourceControllerTest extends IntegrationTest {
     void readOriginalAudioUrlWithSuccess() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when
         OriginalAudioResponse response = RestAssured.when()
@@ -38,7 +38,7 @@ class FileSourceControllerTest extends IntegrationTest {
     void readShortAudioUrlWithSuccess() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when
         ShortAudioResponse response = RestAssured.when()
@@ -56,7 +56,7 @@ class FileSourceControllerTest extends IntegrationTest {
     void readScriptUrlWithSuccess() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when
         ScriptResponse response = RestAssured.when()

--- a/backend/src/test/java/com/onair/hearit/presentation/FileSourceControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/FileSourceControllerTest.java
@@ -19,8 +19,8 @@ class FileSourceControllerTest extends IntegrationTest {
     @DisplayName("원본 오디오 url 요청 시, 200 OK 및 id와 url을 반환한다.")
     void readOriginalAudioUrlWithSuccess() {
         // given
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when
         OriginalAudioResponse response = RestAssured.when()
@@ -37,8 +37,8 @@ class FileSourceControllerTest extends IntegrationTest {
     @DisplayName("1분 오디오 url 요청 시, 200 OK 및 id와 url을 반환한다.")
     void readShortAudioUrlWithSuccess() {
         // given
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when
         ShortAudioResponse response = RestAssured.when()
@@ -55,8 +55,8 @@ class FileSourceControllerTest extends IntegrationTest {
     @DisplayName("대본 url 요청 시 200 OK 및 id와 url을 반환한다.")
     void readScriptUrlWithSuccess() {
         // given
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when
         ScriptResponse response = RestAssured.when()
@@ -80,13 +80,5 @@ class FileSourceControllerTest extends IntegrationTest {
                 .get("/api/v1/hearits/" + notSavedHearitId + "/script-url")
                 .then()
                 .statusCode(HttpStatus.NOT_FOUND.value());
-    }
-
-    private Category saveCategory() {
-        return dbHelper.insertCategory(TestFixture.createFixedCategory());
-    }
-
-    private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/FileSourceControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/FileSourceControllerTest.java
@@ -7,8 +7,8 @@ import com.onair.hearit.domain.Hearit;
 import com.onair.hearit.dto.response.OriginalAudioResponse;
 import com.onair.hearit.dto.response.ScriptResponse;
 import com.onair.hearit.dto.response.ShortAudioResponse;
+import com.onair.hearit.fixture.TestFixture;
 import io.restassured.RestAssured;
-import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -19,7 +19,8 @@ class FileSourceControllerTest extends IntegrationTest {
     @DisplayName("원본 오디오 url 요청 시, 200 OK 및 id와 url을 반환한다.")
     void readOriginalAudioUrlWithSuccess() {
         // given
-        Hearit hearit = saveHearitWithSuffix(1);
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
 
         // when
         OriginalAudioResponse response = RestAssured.when()
@@ -36,7 +37,8 @@ class FileSourceControllerTest extends IntegrationTest {
     @DisplayName("1분 오디오 url 요청 시, 200 OK 및 id와 url을 반환한다.")
     void readShortAudioUrlWithSuccess() {
         // given
-        Hearit hearit = saveHearitWithSuffix(1);
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
 
         // when
         ShortAudioResponse response = RestAssured.when()
@@ -53,7 +55,8 @@ class FileSourceControllerTest extends IntegrationTest {
     @DisplayName("대본 url 요청 시 200 OK 및 id와 url을 반환한다.")
     void readScriptUrlWithSuccess() {
         // given
-        Hearit hearit = saveHearitWithSuffix(1);
+        Category category = saveCategory();
+        Hearit hearit = saveHearit(category);
 
         // when
         ScriptResponse response = RestAssured.when()
@@ -79,19 +82,11 @@ class FileSourceControllerTest extends IntegrationTest {
                 .statusCode(HttpStatus.NOT_FOUND.value());
     }
 
-    private Hearit saveHearitWithSuffix(int suffix) {
-        Category category = new Category("name" + suffix, "#FFFFFFFF");
-        dbHelper.insertCategory(category);
+    private Category saveCategory() {
+        return dbHelper.insertCategory(TestFixture.createFixedCategory());
+    }
 
-        Hearit hearit = new Hearit(
-                "title" + suffix,
-                "summary" + suffix, suffix,
-                "originalAudioUrl" + suffix,
-                "shortAudioUrl" + suffix,
-                "scriptUrl" + suffix,
-                "source" + suffix,
-                LocalDateTime.now(),
-                category);
-        return dbHelper.insertHearit(hearit);
+    private Hearit saveHearit(Category category) {
+        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -3,7 +3,7 @@ package com.onair.hearit.presentation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.TestFixture;
+import com.onair.hearit.fixture.TestFixture;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -32,10 +32,10 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("로그인한 사용자가 히어릿 단일 조회 시, 200 OK 및 히어릿 정보를 제공한다.")
     void readHearitWithSuccessWithMember() {
         // given
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when & then
         HearitDetailResponse response = RestAssured.given()
@@ -53,8 +53,8 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("로그인 하지 않은 사용자가 히어릿 단일 조회 시, 200 OK 및 히어릿 정보를 제공한다.")
     void readHearitWithSuccessWithNotMember() {
         // given
-        Category category = saveCategory();
-        Hearit hearit = saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when & then
         HearitDetailResponse response = RestAssured.given()
@@ -74,7 +74,7 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("히어릿 단일 조회 시, 존재하지 않는 아이디인 경우 404 NOT_FOUND를 반환한다.")
     void readHearitWithNotFound() {
         // given
-        Member member = saveMember();
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
         Long notFoundHearitId = 1L;
 
@@ -91,10 +91,10 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("랜덤 히어릿을 조회 시, 200 OK 및 최대 10개 히어릿 정보 목록을 제공한다.")
     void readRandomHearits() {
         // given
-        Category category = saveCategory();
-        saveHearit(category);
-        saveHearit(category);
-        saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when
         PagedResponse<RandomHearitResponse> responses = RestAssured.given()
@@ -114,10 +114,10 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("추천 히어릿을 조회 시, 200 OK 및 최대 5개 히어릿 정보 목록을 제공한다.")
     void readRecommendedHearits() {
         // given
-        Category category = saveCategory();
-        saveHearit(category);
-        saveHearit(category);
-        saveHearit(category);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
 
         // when
         List<RecommendHearitResponse> responses = RestAssured.given()
@@ -137,8 +137,8 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("히어릿 검색 요청 시 200 OK 및 제목 또는 키워드에 검색어가 포함된 히어릿을 최신순으로 반환한다.")
     void searchHearitsWithPagination() {
         // given
-        Keyword keyword = saveKeyword("Spring");
-        Keyword keyword1 = saveKeyword("noKeyword");
+        Keyword keyword = dbHelper.insertKeyword(new Keyword("Spring"));
+        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("noKeyword"));
 
         Hearit hearit = saveHearitWithTitleAndKeyword("examplespring1", keyword);     // 제목 매칭
         Hearit hearit1 = saveHearitWithTitleAndKeyword("SPRING1example", keyword1);   // 제목 매칭
@@ -196,24 +196,12 @@ class HearitControllerTest extends IntegrationTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
-    private Member saveMember() {
-        return dbHelper.insertMember(TestFixture.createFixedMember());
-    }
-
     private String generateToken(Member member) {
         return jwtTokenProvider.createToken(member.getId());
     }
 
-    private Category saveCategory() {
-        return dbHelper.insertCategory(TestFixture.createFixedCategory());
-    }
-
-    private Hearit saveHearit(Category category) {
-        return dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-    }
-
     private Hearit saveHearitWithTitleAndKeyword(String title, Keyword keyword) {
-        Category category = saveCategory();
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = new Hearit(
                 title,
                 "summary",
@@ -226,9 +214,5 @@ class HearitControllerTest extends IntegrationTest {
         Hearit savedHearit = dbHelper.insertHearit(hearit);
         dbHelper.insertHearitKeyword(new HearitKeyword(savedHearit, keyword));
         return savedHearit;
-    }
-
-    private Keyword saveKeyword(String name) {
-        return dbHelper.insertKeyword(new Keyword(name));
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -35,7 +35,7 @@ class HearitControllerTest extends IntegrationTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when & then
         HearitDetailResponse response = RestAssured.given()
@@ -54,7 +54,7 @@ class HearitControllerTest extends IntegrationTest {
     void readHearitWithSuccessWithNotMember() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when & then
         HearitDetailResponse response = RestAssured.given()
@@ -92,9 +92,9 @@ class HearitControllerTest extends IntegrationTest {
     void readRandomHearits() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when
         PagedResponse<RandomHearitResponse> responses = RestAssured.given()
@@ -115,9 +115,9 @@ class HearitControllerTest extends IntegrationTest {
     void readRecommendedHearits() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
-        dbHelper.insertHearit(TestFixture.createFixedHearit(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
         // when
         List<RecommendHearitResponse> responses = RestAssured.given()

--- a/backend/src/test/java/com/onair/hearit/presentation/IntegrationTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/IntegrationTest.java
@@ -1,6 +1,6 @@
 package com.onair.hearit.presentation;
 
-import com.onair.hearit.DbHelper;
+import com.onair.hearit.fixture.DbHelper;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/src/test/java/com/onair/hearit/presentation/KeywordControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/KeywordControllerTest.java
@@ -18,11 +18,11 @@ class KeywordControllerTest extends IntegrationTest {
     @DisplayName("전체 키워드를 조회 시 200 OK 및 페이징이 적용된 키워드 목록을 반환한다.")
     void readAllKeywords() {
         // given
-        Keyword keyword1 = saveKeyword();
-        Keyword keyword2 = saveKeyword();
-        Keyword keyword3 = saveKeyword();
-        Keyword keyword4 = saveKeyword();
-        Keyword keyword5 = saveKeyword();
+        Keyword keyword1 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword2 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword3 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword4 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword5 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
 
         // when
         List<KeywordResponse> result = RestAssured.given()
@@ -49,7 +49,7 @@ class KeywordControllerTest extends IntegrationTest {
     @DisplayName("단일 키워드 조회 시 200 OK 및 해당 키워드 정보를 반환한다.")
     void readSingleKeyword() {
         // given
-        Keyword keyword = saveKeyword();
+        Keyword keyword = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
 
         // when
         Keyword result = RestAssured.given()
@@ -83,9 +83,9 @@ class KeywordControllerTest extends IntegrationTest {
     @DisplayName("추천 키워드 조회 시 200 OK 및 요청 개수만큼의 키워드를 반환한다.")
     void readRecommendedKeywords() {
         // given
-        saveKeyword();
-        saveKeyword();
-        saveKeyword();
+        dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        dbHelper.insertKeyword(TestFixture.createFixedKeyword());
         int size = 2;
 
         // when
@@ -101,9 +101,5 @@ class KeywordControllerTest extends IntegrationTest {
 
         // then
         assertThat(result).hasSize(size);
-    }
-
-    private Keyword saveKeyword() {
-        return dbHelper.insertKeyword(TestFixture.createFixedKeyword());
     }
 }

--- a/backend/src/test/java/com/onair/hearit/presentation/KeywordControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/KeywordControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.dto.response.KeywordResponse;
+import com.onair.hearit.fixture.TestFixture;
 import io.restassured.RestAssured;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -17,11 +18,11 @@ class KeywordControllerTest extends IntegrationTest {
     @DisplayName("전체 키워드를 조회 시 200 OK 및 페이징이 적용된 키워드 목록을 반환한다.")
     void readAllKeywords() {
         // given
-        Keyword keyword1 = saveKeyword("keyword1");
-        Keyword keyword2 = saveKeyword("keyword2");
-        Keyword keyword3 = saveKeyword("keyword3");
-        Keyword keyword4 = saveKeyword("keyword4");
-        Keyword keyword5 = saveKeyword("keyword5");
+        Keyword keyword1 = saveKeyword();
+        Keyword keyword2 = saveKeyword();
+        Keyword keyword3 = saveKeyword();
+        Keyword keyword4 = saveKeyword();
+        Keyword keyword5 = saveKeyword();
 
         // when
         List<KeywordResponse> result = RestAssured.given()
@@ -48,7 +49,7 @@ class KeywordControllerTest extends IntegrationTest {
     @DisplayName("단일 키워드 조회 시 200 OK 및 해당 키워드 정보를 반환한다.")
     void readSingleKeyword() {
         // given
-        Keyword keyword = saveKeyword("keyword");
+        Keyword keyword = saveKeyword();
 
         // when
         Keyword result = RestAssured.given()
@@ -82,9 +83,9 @@ class KeywordControllerTest extends IntegrationTest {
     @DisplayName("추천 키워드 조회 시 200 OK 및 요청 개수만큼의 키워드를 반환한다.")
     void readRecommendedKeywords() {
         // given
-        saveKeyword("keyword1");
-        saveKeyword("keyword2");
-        saveKeyword("keyword3");
+        saveKeyword();
+        saveKeyword();
+        saveKeyword();
         int size = 2;
 
         // when
@@ -102,7 +103,7 @@ class KeywordControllerTest extends IntegrationTest {
         assertThat(result).hasSize(size);
     }
 
-    private Keyword saveKeyword(String name) {
-        return dbHelper.insertKeyword(new Keyword(name));
+    private Keyword saveKeyword() {
+        return dbHelper.insertKeyword(TestFixture.createFixedKeyword());
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 테스트에 존재하는 기본 데이터 추가를 픽스처로 클래스 분리
- Hearit 생성자 중, 테스트에서만 사용하는 생성자 제거

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #169 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터링**
  * 테스트 코드의 데이터 생성 방식을 고정된 테스트 픽스처 기반으로 통일하여 중복을 줄이고 일관성을 높였습니다.
  * 여러 테스트 헬퍼 메서드가 간소화되거나 대체되었으며, 테스트 설정이 개선되었습니다.
  * 일부 엔터티 필드에 not-null 제약 조건이 추가되어 데이터 무결성이 강화되었습니다.

* **테스트**
  * JPA 감사 기능이 테스트 환경에 적용되어 자동으로 생성일 등 감사 필드가 관리됩니다.
  * 테스트 픽스처, 헬퍼 클래스, 설정 파일의 패키지 구조가 정비되었습니다.
  * 테스트 코드의 가독성과 유지보수성이 향상되었습니다.

* **기타**
  * 코드 스타일 및 포맷팅이 일부 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->