### PR TITLE
[BE] feat: 관리자 페이지 카테고리&키워드 수정 기능 추가 #224 

### DIFF
--- a/backend/src/main/java/com/onair/hearit/admin/application/AdminCategoryService.java
+++ b/backend/src/main/java/com/onair/hearit/admin/application/AdminCategoryService.java
@@ -1,11 +1,14 @@
 package com.onair.hearit.admin.application;
 
 import com.onair.hearit.admin.dto.request.CategoryCreateRequest;
+import com.onair.hearit.admin.dto.request.CategoryUpdateRequest;
 import com.onair.hearit.admin.dto.response.CategoryInfoResponse;
+import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.CategoryRepository;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,5 +40,12 @@ public class AdminCategoryService {
     public void addCategory(CategoryCreateRequest request) {
         Category category = new Category(request.name(), request.colorCode());
         categoryRepository.save(category);
+    }
+
+    @Transactional
+    public void updateCategory(Long categoryId, CategoryUpdateRequest request) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new NotFoundException("categoryId", categoryId.toString()));
+        category.update(request.name(), request.colorCode());
     }
 }

--- a/backend/src/main/java/com/onair/hearit/admin/application/AdminKeywordService.java
+++ b/backend/src/main/java/com/onair/hearit/admin/application/AdminKeywordService.java
@@ -1,11 +1,14 @@
 package com.onair.hearit.admin.application;
 
 import com.onair.hearit.admin.dto.request.KeywordCreateRequest;
+import com.onair.hearit.admin.dto.request.KeywordUpdateRequest;
 import com.onair.hearit.admin.dto.response.KeywordInfoResponse;
+import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.PagedResponse;
 import com.onair.hearit.infrastructure.KeywordRepository;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,5 +40,13 @@ public class AdminKeywordService {
     public void addKeyword(KeywordCreateRequest request) {
         Keyword keyword = new Keyword(request.name());
         keywordRepository.save(keyword);
+    }
+
+
+    @Transactional
+    public void updateKeyword(Long keywordId, KeywordUpdateRequest request) {
+        Keyword keyword = keywordRepository.findById(keywordId)
+                .orElseThrow(() -> new NotFoundException("keywordId", keywordId.toString()));
+        keyword.updateName(request.name());
     }
 }

--- a/backend/src/main/java/com/onair/hearit/admin/application/AdminKeywordService.java
+++ b/backend/src/main/java/com/onair/hearit/admin/application/AdminKeywordService.java
@@ -42,7 +42,6 @@ public class AdminKeywordService {
         keywordRepository.save(keyword);
     }
 
-
     @Transactional
     public void updateKeyword(Long keywordId, KeywordUpdateRequest request) {
         Keyword keyword = keywordRepository.findById(keywordId)

--- a/backend/src/main/java/com/onair/hearit/admin/application/FileStorageService.java
+++ b/backend/src/main/java/com/onair/hearit/admin/application/FileStorageService.java
@@ -38,7 +38,7 @@ public class FileStorageService {
                             .build(),
                     RequestBody.fromInputStream(inputStream, multipartFile.getSize())
             );
-            return key;
+            return "/" + key;
         } catch (IOException e) {
             log.error("S3 파일 업로드 실패: " + multipartFile.getOriginalFilename(), e);
             throw new S3Exception("S3 파일 업로드 실패", e);

--- a/backend/src/main/java/com/onair/hearit/admin/dto/request/CategoryCreateRequest.java
+++ b/backend/src/main/java/com/onair/hearit/admin/dto/request/CategoryCreateRequest.java
@@ -1,7 +1,9 @@
 package com.onair.hearit.admin.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record CategoryCreateRequest(
-        String name,
-        String colorCode
+        @NotBlank String name,
+        @NotBlank String colorCode
 ) {
 }

--- a/backend/src/main/java/com/onair/hearit/admin/dto/request/CategoryUpdateRequest.java
+++ b/backend/src/main/java/com/onair/hearit/admin/dto/request/CategoryUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.onair.hearit.admin.dto.request;
+
+public record CategoryUpdateRequest(
+        String name,
+        String colorCode
+) {
+}

--- a/backend/src/main/java/com/onair/hearit/admin/dto/request/CategoryUpdateRequest.java
+++ b/backend/src/main/java/com/onair/hearit/admin/dto/request/CategoryUpdateRequest.java
@@ -1,7 +1,9 @@
 package com.onair.hearit.admin.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record CategoryUpdateRequest(
-        String name,
-        String colorCode
+        @NotBlank String name,
+        @NotBlank String colorCode
 ) {
 }

--- a/backend/src/main/java/com/onair/hearit/admin/dto/request/HearitUpdateRequest.java
+++ b/backend/src/main/java/com/onair/hearit/admin/dto/request/HearitUpdateRequest.java
@@ -1,16 +1,18 @@
 package com.onair.hearit.admin.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record HearitUpdateRequest(
-        String title,
-        String summary,
-        Integer playTime,
-        String originalAudioUrl,
-        String shortAudioUrl,
-        String scriptUrl,
-        String source,
-        Long categoryId,
+        @NotBlank String title,
+        @NotBlank String summary,
+        @NotNull Integer playTime,
+        @NotBlank String originalAudioUrl,
+        @NotBlank String shortAudioUrl,
+        @NotBlank String scriptUrl,
+        @NotBlank String source,
+        @NotNull Long categoryId,
         List<Long> keywordIds
 ) {
 }

--- a/backend/src/main/java/com/onair/hearit/admin/dto/request/KeywordCreateRequest.java
+++ b/backend/src/main/java/com/onair/hearit/admin/dto/request/KeywordCreateRequest.java
@@ -1,6 +1,8 @@
 package com.onair.hearit.admin.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record KeywordCreateRequest(
-        String name
+        @NotBlank String name
 ) {
 }

--- a/backend/src/main/java/com/onair/hearit/admin/dto/request/KeywordUpdateRequest.java
+++ b/backend/src/main/java/com/onair/hearit/admin/dto/request/KeywordUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.onair.hearit.admin.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record KeywordUpdateRequest(
-        String name
+        @NotBlank String name
 ) {
 }

--- a/backend/src/main/java/com/onair/hearit/admin/dto/request/KeywordUpdateRequest.java
+++ b/backend/src/main/java/com/onair/hearit/admin/dto/request/KeywordUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.onair.hearit.admin.dto.request;
+
+public record KeywordUpdateRequest(
+        String name
+) {
+}

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminCategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminCategoryController.java
@@ -49,12 +49,12 @@ public class AdminCategoryController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("/{categoryId}")
     public ResponseEntity<Void> updateCategory(
-            @PathVariable Long id,
+            @PathVariable Long categoryId,
             @RequestBody CategoryUpdateRequest request
     ) {
-        adminCategoryService.updateCategory(id, request);
+        adminCategoryService.updateCategory(categoryId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminCategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminCategoryController.java
@@ -2,6 +2,7 @@ package com.onair.hearit.admin.presentation;
 
 import com.onair.hearit.admin.application.AdminCategoryService;
 import com.onair.hearit.admin.dto.request.CategoryCreateRequest;
+import com.onair.hearit.admin.dto.request.CategoryUpdateRequest;
 import com.onair.hearit.admin.dto.response.CategoryInfoResponse;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.PagedResponse;
@@ -11,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -44,5 +47,14 @@ public class AdminCategoryController {
     public ResponseEntity<Void> createCategory(@RequestBody CategoryCreateRequest request) {
         adminCategoryService.addCategory(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateCategory(
+            @PathVariable Long id,
+            @RequestBody CategoryUpdateRequest request
+    ) {
+        adminCategoryService.updateCategory(id, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminCategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminCategoryController.java
@@ -7,6 +7,7 @@ import com.onair.hearit.admin.dto.response.CategoryInfoResponse;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.PagedResponse;
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -44,7 +45,7 @@ public class AdminCategoryController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createCategory(@RequestBody CategoryCreateRequest request) {
+    public ResponseEntity<Void> createCategory(@RequestBody @Valid CategoryCreateRequest request) {
         adminCategoryService.addCategory(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -52,7 +53,7 @@ public class AdminCategoryController {
     @PutMapping("/{categoryId}")
     public ResponseEntity<Void> updateCategory(
             @PathVariable Long categoryId,
-            @RequestBody CategoryUpdateRequest request
+            @RequestBody @Valid CategoryUpdateRequest request
     ) {
         adminCategoryService.updateCategory(categoryId, request);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminCategoryController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminCategoryController.java
@@ -53,8 +53,7 @@ public class AdminCategoryController {
     @PutMapping("/{categoryId}")
     public ResponseEntity<Void> updateCategory(
             @PathVariable Long categoryId,
-            @RequestBody @Valid CategoryUpdateRequest request
-    ) {
+            @RequestBody @Valid CategoryUpdateRequest request) {
         adminCategoryService.updateCategory(categoryId, request);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminHearitController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminHearitController.java
@@ -48,7 +48,7 @@ public class AdminHearitController {
     @PutMapping("/hearits/{hearitId}")
     public ResponseEntity<Void> updateHearitById(
             @PathVariable Long hearitId,
-            @RequestBody HearitUpdateRequest request) {
+            @RequestBody @Valid HearitUpdateRequest request) {
         adminHearitService.modifyHearit(hearitId, request);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminKeywordController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminKeywordController.java
@@ -2,6 +2,7 @@ package com.onair.hearit.admin.presentation;
 
 import com.onair.hearit.admin.application.AdminKeywordService;
 import com.onair.hearit.admin.dto.request.KeywordCreateRequest;
+import com.onair.hearit.admin.dto.request.KeywordUpdateRequest;
 import com.onair.hearit.admin.dto.response.KeywordInfoResponse;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.PagedResponse;
@@ -11,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -44,5 +47,15 @@ public class AdminKeywordController {
     public ResponseEntity<Void> createKeyword(@RequestBody KeywordCreateRequest request) {
         adminKeywordService.addKeyword(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+
+    @PutMapping("/{keywordId}")
+    public ResponseEntity<Void> updateKeyword(
+            @PathVariable Long keywordId,
+            @RequestBody KeywordUpdateRequest request
+    ) {
+        adminKeywordService.updateKeyword(keywordId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminKeywordController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminKeywordController.java
@@ -7,6 +7,7 @@ import com.onair.hearit.admin.dto.response.KeywordInfoResponse;
 import com.onair.hearit.dto.request.PagingRequest;
 import com.onair.hearit.dto.response.PagedResponse;
 import io.swagger.v3.oas.annotations.Hidden;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -44,7 +45,7 @@ public class AdminKeywordController {
     }
 
     @PostMapping
-    public ResponseEntity<Void> createKeyword(@RequestBody KeywordCreateRequest request) {
+    public ResponseEntity<Void> createKeyword(@RequestBody @Valid KeywordCreateRequest request) {
         adminKeywordService.addKeyword(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -53,7 +54,7 @@ public class AdminKeywordController {
     @PutMapping("/{keywordId}")
     public ResponseEntity<Void> updateKeyword(
             @PathVariable Long keywordId,
-            @RequestBody KeywordUpdateRequest request
+            @RequestBody @Valid KeywordUpdateRequest request
     ) {
         adminKeywordService.updateKeyword(keywordId, request);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/onair/hearit/admin/presentation/AdminKeywordController.java
+++ b/backend/src/main/java/com/onair/hearit/admin/presentation/AdminKeywordController.java
@@ -54,8 +54,7 @@ public class AdminKeywordController {
     @PutMapping("/{keywordId}")
     public ResponseEntity<Void> updateKeyword(
             @PathVariable Long keywordId,
-            @RequestBody @Valid KeywordUpdateRequest request
-    ) {
+            @RequestBody @Valid KeywordUpdateRequest request) {
         adminKeywordService.updateKeyword(keywordId, request);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
+++ b/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService {
     }
 
     // 소셜 로그인의 경우 회원가입이 따로 없으며 로그인 시 자동으로 회원가입되도록 구현
-    public TokenResponse loginWithKakao(KakaoLoginRequest request) {
+    public TokenResponse loginOrSignupWithKakao(KakaoLoginRequest request) {
         KakaoUserInfoResponse kakaoUser = kakaoUserInfoClient.getUserInfo(request.accessToken());
 
         Member member = memberRepository.findBySocialId(kakaoUser.id())

--- a/backend/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
     @Operation(summary = "카카오 로그인", description = "카카오 액세스토큰으로 로그인 시 토큰을 발급받습니다.")
     @PostMapping("/kakao-login")
     public ResponseEntity<TokenResponse> loginWithKakao(@RequestBody KakaoLoginRequest request) {
-        TokenResponse response = authService.loginWithKakao(request);
+        TokenResponse response = authService.loginOrSignupWithKakao(request);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/onair/hearit/domain/Category.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Category.java
@@ -30,4 +30,9 @@ public class Category {
         this.name = name;
         this.colorCode = colorCode;
     }
+
+    public void update(String name, String colorCode) {
+        this.name = name;
+        this.colorCode = colorCode;
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Category.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Category.java
@@ -43,7 +43,7 @@ public class Category {
     }
 
     private void validateName(String name) {
-        if (name == null || name.length() > CATEGORY_NAME_MAX_LENGTH) {
+        if (name == null || name.trim().isBlank() || name.length() > CATEGORY_NAME_MAX_LENGTH) {
             throw new InvalidInputException("카테고리 이름은 15자 이하여야 합니다.");
         }
     }

--- a/backend/src/main/java/com/onair/hearit/domain/Category.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Category.java
@@ -1,11 +1,13 @@
 package com.onair.hearit.domain;
 
+import com.onair.hearit.common.exception.custom.InvalidInputException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +17,9 @@ import lombok.NoArgsConstructor;
 @Table(name = "category")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category {
+
+    public static final int CATEGORY_NAME_MAX_LENGTH = 15;
+    private static final Pattern COLOR_CODE_PATTERN = Pattern.compile("^#[0-9a-fA-F]{6}$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,11 +32,30 @@ public class Category {
     private String colorCode;
 
     public Category(String name, String colorCode) {
+        validate(name, colorCode);
         this.name = name;
         this.colorCode = colorCode;
     }
 
+    private void validate(String name, String colorCode) {
+        validateName(name);
+        validateColorCode(colorCode);
+    }
+
+    private void validateName(String name) {
+        if (name == null || name.length() > CATEGORY_NAME_MAX_LENGTH) {
+            throw new InvalidInputException("카테고리 이름은 15자 이하여야 합니다.");
+        }
+    }
+
+    private void validateColorCode(String colorCode) {
+        if (colorCode == null || !COLOR_CODE_PATTERN.matcher(colorCode).matches()) {
+            throw new InvalidInputException("컬러 코드는 '#'으로 시작하고 6자리 16진수여야 합니다.");
+        }
+    }
+
     public void update(String name, String colorCode) {
+        validate(name, colorCode);
         this.name = name;
         this.colorCode = colorCode;
     }

--- a/backend/src/main/java/com/onair/hearit/domain/Keyword.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Keyword.java
@@ -26,4 +26,8 @@ public class Keyword {
     public Keyword(String name) {
         this.name = name;
     }
+
+    public void updateName(String newName) {
+        this.name = newName;
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Keyword.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Keyword.java
@@ -37,7 +37,7 @@ public class Keyword {
     }
 
     public void updateName(String newName) {
-        validate(name);
+        validate(newName);
         this.name = newName;
     }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Keyword.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Keyword.java
@@ -1,5 +1,6 @@
 package com.onair.hearit.domain;
 
+import com.onair.hearit.common.exception.custom.InvalidInputException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -16,6 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Keyword {
 
+    public static final int KEYWORD_NAME_MAX_LENGTH = 20;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -24,10 +26,18 @@ public class Keyword {
     private String name;
 
     public Keyword(String name) {
+        validate(name);
         this.name = name;
     }
 
+    private void validate(String name) {
+        if (name == null || name.length() > KEYWORD_NAME_MAX_LENGTH) {
+            throw new InvalidInputException("키워드 이름은 20자 이하여야 합니다.");
+        }
+    }
+
     public void updateName(String newName) {
+        validate(name);
         this.name = newName;
     }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Keyword.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Keyword.java
@@ -31,7 +31,7 @@ public class Keyword {
     }
 
     private void validate(String name) {
-        if (name == null || name.length() > KEYWORD_NAME_MAX_LENGTH) {
+        if (name == null || name.trim().isBlank() || name.length() > KEYWORD_NAME_MAX_LENGTH) {
             throw new InvalidInputException("키워드 이름은 20자 이하여야 합니다.");
         }
     }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/HearitRepository.java
@@ -17,8 +17,8 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
     @Query("SELECT h FROM Hearit h ORDER BY function('RAND')")
     Page<Hearit> findRandom(Pageable pageable);
 
-    @Query("SELECT h FROM Hearit h ORDER BY function('RAND') LIMIT :limit")
-    List<Hearit> findRandom(@Param("limit") int limit);
+    @Query("SELECT h FROM Hearit h ORDER BY function('RAND') LIMIT :size")
+    List<Hearit> findRandom(@Param("size") int size);
 
     Page<Hearit> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
 

--- a/backend/src/main/resources/templates/admin/category-list.html
+++ b/backend/src/main/resources/templates/admin/category-list.html
@@ -56,9 +56,9 @@
                             <input type="text" class="form-control" id="category-name" name="name" required>
                         </div>
                         <div class="mb-3">
-                            <label for="category-color" class="form-label">컬러 코드 (e.g., #RRGGBBAA)</label>
+                            <label for="category-color" class="form-label">컬러 코드 (e.g., #RRGGBB)</label>
                             <div class="input-group">
-                                <input type="text" class="form-control" id="category-color" name="colorCode" value="#9900A3E4" required>
+                                <input type="text" class="form-control" id="category-color" name="colorCode" value="#000000" required>
                                 <span class="input-group-text p-2">
                                     <span id="color-preview"
                                           style="display: inline-block; width: 1.5rem; height: 1.5rem; border: 1px solid #ccc; border-radius: .25rem;"></span>
@@ -89,7 +89,6 @@
         return (yiq >= 128) ? '#000' : '#FFF';
     }
 
-
     // Pagination variables
     let currentPage = 0;
     const pageSize = 15;
@@ -116,14 +115,36 @@
             categories.forEach(category => {
                 const row = document.createElement('tr');
                 const textColor = getContrastYIQ(category.colorCode);
-                const rgba = hex8ToRgba(category.colorCode) || category.colorCode;
-                row.innerHTML = `
-                    <td>${category.id}</td>
-                    <td>${category.name}</td>
-                    <td>
-                        <span class="badge" style="background-color: ${rgba}; color: ${textColor};">${category.colorCode}</span>
-                    </td>
-                `;
+                const rgba = hexToRgba(category.colorCode) || category.colorCode;
+                // Check if this row is in edit mode
+                if (window.__editingCategoryId === category.id) {
+                    row.innerHTML = `
+                        <td>${category.id}</td>
+                        <td><input type="text" class="form-control form-control-sm" value="${category.name}" id="name-${category.id}"></td>
+                        <td>
+                            <div class="input-group input-group-sm">
+                                <input type="text" class="form-control" value="${category.colorCode}" id="color-${category.id}">
+                                <span class="input-group-text p-1">
+                                    <span style="display:inline-block;width:1rem;height:1rem;border:1px solid #ccc;border-radius:.25rem;background-color:${rgba};color:${textColor};"></span>
+                                </span>
+                            </div>
+                        </td>
+                        <td>
+                            <button class="btn btn-sm btn-success" onclick="submitEditCategory(${category.id})">저장</button>
+                        </td>
+                    `;
+                } else {
+                    row.innerHTML = `
+                        <td>${category.id}</td>
+                        <td>${category.name}</td>
+                        <td>
+                            <span class="badge" style="background-color: ${rgba}; color: ${textColor};">${category.colorCode}</span>
+                        </td>
+                        <td>
+                            <button class="btn btn-sm btn-outline-primary" onclick="startEditCategory(${category.id})">수정</button>
+                        </td>
+                    `;
+                }
                 tableBody.appendChild(row);
             });
         }
@@ -139,9 +160,40 @@
         nextBtn.disabled = pageNumber >= totalPages - 1;
     }
 
-    function getCookie(name) {
-        const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
-        return match ? decodeURIComponent(match[2]) : null;
+    // Track which category is being edited (by id)
+    window.__editingCategoryId = null;
+
+    function startEditCategory(id) {
+        window.__editingCategoryId = id;
+        fetchCategories(currentPage, pageSize);
+    }
+
+    function submitEditCategory(id) {
+        const newName = document.getElementById(`name-${id}`).value.trim();
+        const newColor = document.getElementById(`color-${id}`).value.trim();
+        if (!newName || !newColor) return alert("값을 모두 입력해주세요.");
+
+        const csrfToken = document.querySelector('meta[name="_csrf"]').content;
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
+
+        fetch(`/api/v1/admin/categories/${id}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                [csrfHeader]: csrfToken
+            },
+            body: JSON.stringify({ name: newName, colorCode: newColor })
+        })
+            .then(res => {
+                if (!res.ok) throw new Error("카테고리 수정 실패");
+                window.__editingCategoryId = null;
+                alert("수정 성공");
+                fetchCategories(currentPage, pageSize);
+            })
+            .catch(err => {
+                console.error(err);
+                alert("수정 중 오류 발생");
+            });
     }
 
     document.addEventListener('DOMContentLoaded', () => {
@@ -165,7 +217,7 @@
 
         const updateColorPreview = () => {
             const hex = colorInput.value;
-            const rgbaColor = hex8ToRgba(hex);
+            const rgbaColor = hexToRgba(hex);
             if (rgbaColor) {
                 colorPreview.style.backgroundColor = rgbaColor;
             } else {
@@ -177,15 +229,14 @@
         colorInput.addEventListener('input', updateColorPreview);
     });
 
-    function hex8ToRgba(hex) {
-        if (!/^#([A-Fa-f0-9]{8})$/.test(hex)) return null;
+    function hexToRgba(hex) {
+        if (!/^#([A-Fa-f0-9]{6})$/.test(hex)) return null;
 
-        const a = parseInt(hex.slice(1, 3), 16) / 255;
-        const r = parseInt(hex.slice(3, 5), 16);
-        const g = parseInt(hex.slice(5, 7), 16);
-        const b = parseInt(hex.slice(7, 9), 16);
+        const r = parseInt(hex.slice(1, 3), 16);
+        const g = parseInt(hex.slice(3, 5), 16);
+        const b = parseInt(hex.slice(5, 7), 16);
 
-        return `rgba(${r}, ${g}, ${b}, ${a.toFixed(2)})`;
+        return `rgba(${r}, ${g}, ${b}, 1)`;
     }
 
     // 카테고리 추가 폼 JS: fetch + CSRF via header

--- a/backend/src/main/resources/templates/admin/hearit-create.html
+++ b/backend/src/main/resources/templates/admin/hearit-create.html
@@ -17,7 +17,7 @@
 
     <!-- 히어릿 추가 폼 -->
     <div id="upload-section" class="card card-body mb-4" style="display: block;">
-        <h2 class="mb-3">새 히어릿 업로드</h2>
+        <h2 class="mb-3">새 히어릿 추가</h2>
         <form id="upload-form">
             <div class="row">
                 <div class="col-md-6 mb-3"><label for="title" class="form-label">제목</label><input type="text" class="form-control" id="title" name="title"></div>
@@ -128,7 +128,7 @@
                     body: formData
                 });
                 if (response.ok) {
-                    alert('히어릿이 성공적으로 업로드되었습니다.');
+                    alert('히어릿이 성공적으로 추가되었습니다.');
                     form.reset();
                 } else {
                     const responseText = await response.text();
@@ -144,11 +144,11 @@
                                 .join('\n');
                         }
                     } catch (_) {}
-                    alert('업로드 실패:\n' + errorMessage);
+                    alert('추가 실패:\n' + errorMessage);
                 }
             } catch (error) {
                 console.error('Error uploading hearit:', error);
-                alert('업로드 중 오류가 발생했습니다.');
+                alert('추가 중 오류가 발생했습니다.');
             }
         });
     });

--- a/backend/src/main/resources/templates/admin/home.html
+++ b/backend/src/main/resources/templates/admin/home.html
@@ -23,10 +23,10 @@
                     히어릿 업로드
                 </a>
                 <a th:href="@{/admin/categories}" class="list-group-item list-group-item-action">
-                    카테고리 관리 (조회, 추가)
+                    카테고리 관리 (조회, 추가, 수정)
                 </a>
                 <a th:href="@{/admin/keywords}" class="list-group-item list-group-item-action">
-                    키워드 관리 (조회, 추가)
+                    키워드 관리 (조회, 추가, 수정)
                 </a>
             </div>
         </div>

--- a/backend/src/main/resources/templates/admin/home.html
+++ b/backend/src/main/resources/templates/admin/home.html
@@ -17,10 +17,10 @@
             <p class="card-text">아래 메뉴를 선택하여 작업을 시작하세요.</p>
             <div class="list-group">
                 <a th:href="@{/admin/hearits}" class="list-group-item list-group-item-action">
-                    히어릿 관리 (조회, 추가, 수정)
+                    히어릿 관리 (조회, 수정)
                 </a>
                 <a th:href="@{/admin/hearits-create}" class="list-group-item list-group-item-action">
-                    히어릿 업로드
+                    히어릿 추가
                 </a>
                 <a th:href="@{/admin/categories}" class="list-group-item list-group-item-action">
                     카테고리 관리 (조회, 추가, 수정)

--- a/backend/src/main/resources/templates/admin/keyword-list.html
+++ b/backend/src/main/resources/templates/admin/keyword-list.html
@@ -74,11 +74,29 @@
         const tbody = document.getElementById('keyword-list-body');
         tbody.innerHTML = '';
         if (!response.content.length) {
-            tbody.innerHTML = '<tr><td colspan="2" class="text-center">표시할 키워드가 없습니다.</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="3" class="text-center">표시할 키워드가 없습니다.</td></tr>';
         } else {
             response.content.forEach(kw => {
                 const row = document.createElement('tr');
-                row.innerHTML = `<td>${kw.id}</td><td>${kw.name}</td>`;
+                if (window.__editingKeywordId === kw.id) {
+                    row.innerHTML = `
+                        <td>${kw.id}</td>
+                        <td>
+                            <input type="text" class="form-control form-control-sm" id="edit-name-${kw.id}" value="${kw.name}">
+                        </td>
+                        <td>
+                            <button class="btn btn-sm btn-success" onclick="submitEditKeyword(${kw.id})">저장</button>
+                        </td>
+                    `;
+                } else {
+                    row.innerHTML = `
+                        <td>${kw.id}</td>
+                        <td>${kw.name}</td>
+                        <td>
+                            <button class="btn btn-sm btn-outline-primary" onclick="startEditKeyword(${kw.id})">수정</button>
+                        </td>
+                    `;
+                }
                 tbody.appendChild(row);
             });
         }
@@ -154,6 +172,45 @@
         const b = parseInt(hex.slice(5, 7), 16);
         const a = parseInt(hex.slice(7, 9), 16) / 255;
         return `rgba(${r}, ${g}, ${b}, ${a.toFixed(2)})`;
+    }
+
+    // --- Inline Editing Functions ---
+    window.__editingKeywordId = null;
+
+    function startEditKeyword(id) {
+        window.__editingKeywordId = id;
+        fetchKeywordsForManage(currentPage, pageSize);
+    }
+
+    async function submitEditKeyword(id) {
+        const newName = document.getElementById(`edit-name-${id}`).value.trim();
+        if (!newName) {
+            alert("이름을 입력해주세요.");
+            return;
+        }
+
+        const csrfToken = document.querySelector('meta[name="_csrf"]').content;
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
+
+        try {
+            const res = await fetch(`/api/v1/admin/keywords/${id}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json',
+                    [csrfHeader]: csrfToken
+                },
+                body: JSON.stringify({ name: newName })
+            });
+
+            if (!res.ok) throw new Error("키워드 수정 실패");
+
+            window.__editingKeywordId = null;
+            alert("수정 성공");
+            fetchKeywordsForManage(currentPage, pageSize);
+        } catch (error) {
+            console.error(error);
+            alert("수정 중 오류 발생");
+        }
     }
 </script>
 </body>

--- a/backend/src/main/resources/templates/admin/navbar.html
+++ b/backend/src/main/resources/templates/admin/navbar.html
@@ -7,7 +7,7 @@
                     <a class="nav-link" th:href="@{/admin/hearits}">Hearits</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" th:href="@{/admin/hearits-create}">Hearits 업로드</a>
+                    <a class="nav-link" th:href="@{/admin/hearits-create}">Hearits 추가</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" th:href="@{/admin/categories}">Categories</a>

--- a/backend/src/test/java/com/onair/hearit/admin/presentation/AdminCategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/admin/presentation/AdminCategoryControllerTest.java
@@ -91,7 +91,6 @@ class AdminCategoryControllerTest extends IntegrationTest {
                 .statusCode(HttpStatus.CREATED);
     }
 
-
     @Test
     @DisplayName("카테고리를 수정할 수 있다.")
     void updateCategory() {

--- a/backend/src/test/java/com/onair/hearit/admin/presentation/AdminCategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/admin/presentation/AdminCategoryControllerTest.java
@@ -77,7 +77,7 @@ class AdminCategoryControllerTest extends IntegrationTest {
     void createCategory() {
         // given
         CsrfSession csrf = AdminSecurityTestHelper.loginAdminAndGetCsrfSession(dbHelper);
-        CategoryCreateRequest request = new CategoryCreateRequest("새 카테고리", "#12345678");
+        CategoryCreateRequest request = new CategoryCreateRequest("새 카테고리", "#123456");
 
         // when & then
         RestAssured.given().log().all()
@@ -96,9 +96,9 @@ class AdminCategoryControllerTest extends IntegrationTest {
     void updateCategory() {
         // given
         CsrfSession csrf = AdminSecurityTestHelper.loginAdminAndGetCsrfSession(dbHelper);
-        Category category = dbHelper.insertCategory(new Category("카테고리", "#11111111"));
+        Category category = dbHelper.insertCategory(new Category("카테고리", "#111111"));
 
-        CategoryUpdateRequest updateRequest = new CategoryUpdateRequest("수정된 카테고리", "#22222222");
+        CategoryUpdateRequest updateRequest = new CategoryUpdateRequest("수정된 카테고리", "#222222");
 
         // when
         RestAssured.given().log().all()
@@ -115,13 +115,13 @@ class AdminCategoryControllerTest extends IntegrationTest {
         Category updatedCategory = categoryRepository.findById(category.getId()).orElseThrow();
         assertAll(() -> {
             assertThat(updatedCategory.getName()).isEqualTo("수정된 카테고리");
-            assertThat(updatedCategory.getColorCode()).isEqualTo("#22222222");
+            assertThat(updatedCategory.getColorCode()).isEqualTo("#222222");
         });
     }
 
     private void insertTestCategories(int count) {
         for (int i = 0; i < count; i++) {
-            dbHelper.insertCategory(new Category("카테고리" + i, "#12345678"));
+            dbHelper.insertCategory(new Category("카테고리" + i, "#000000"));
         }
     }
 }

--- a/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/CategoryServiceTest.java
@@ -47,11 +47,11 @@ class CategoryServiceTest {
     @DisplayName("카테고리 목록 조회 시 페이지네이션이 적용되어 반환된다.")
     void getCategories_withPagination() {
         // given
-        saveCategory("category1", "#111");
-        saveCategory("category2", "#222");
-        saveCategory("category3", "#333");
-        saveCategory("category4", "#444");
-        saveCategory("category5", "#555");
+        saveCategory("category1", "#111111");
+        saveCategory("category2", "#222222");
+        saveCategory("category3", "#333333");
+        saveCategory("category4", "#444444");
+        saveCategory("category5", "#555555");
 
         PagingRequest pagingRequest = new PagingRequest(1, 2);// page 1 (두 번째 페이지), size 2
 
@@ -64,7 +64,7 @@ class CategoryServiceTest {
             assertThat(result.content()).extracting(CategoryResponse::name)
                     .containsExactly("category3", "category4");
             assertThat(result.content()).extracting(CategoryResponse::colorCode)
-                    .containsExactly("#333", "#444");
+                    .containsExactly("#333333", "#444444");
         });
     }
 
@@ -72,8 +72,8 @@ class CategoryServiceTest {
     @DisplayName("히어릿 목록을 카테고리 조회 시 카테고리에 해당하는 히어릿만 반환한다.")
     void searchHearitsByCategory_onlyMatchingCategory() {
         // given
-        Category category1 = saveCategory("Spring", "#001");
-        Category category2 = saveCategory("Java", "#002");
+        Category category1 = saveCategory("Spring", "#111111");
+        Category category2 = saveCategory("Java", "#222222");
         Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
         Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category2));
@@ -94,7 +94,7 @@ class CategoryServiceTest {
     @DisplayName("히어릿 목록을 카테고리 조회 시 최신순으로 페이지네이션이 적용된다.")
     void searchHearitsByCategory_pagination() {
         // given
-        Category category = saveCategory("Spring", "#001");
+        Category category = saveCategory("Spring", "#000000");
         Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthKakaoServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthKakaoServiceTest.java
@@ -55,7 +55,7 @@ class AuthKakaoServiceTest {
         KakaoLoginRequest request = new KakaoLoginRequest(accessToken);
 
         // when
-        TokenResponse response = authService.loginWithKakao(request);
+        TokenResponse response = authService.loginOrSignupWithKakao(request);
 
         // then
         assertThat(response.accessToken()).isNotBlank();
@@ -81,7 +81,7 @@ class AuthKakaoServiceTest {
         KakaoLoginRequest request = new KakaoLoginRequest(accessToken);
 
         // when
-        TokenResponse response = authService.loginWithKakao(request);
+        TokenResponse response = authService.loginOrSignupWithKakao(request);
 
         // then
         assertThat(response.accessToken()).isNotBlank();
@@ -99,7 +99,7 @@ class AuthKakaoServiceTest {
         KakaoLoginRequest request = new KakaoLoginRequest(invalidToken);
 
         // when & then
-        assertThatThrownBy(() -> authService.loginWithKakao(request))
+        assertThatThrownBy(() -> authService.loginOrSignupWithKakao(request))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("유효하지 않은 카카오 액세스 토큰");
     }

--- a/backend/src/test/java/com/onair/hearit/fixture/TestFixture.java
+++ b/backend/src/test/java/com/onair/hearit/fixture/TestFixture.java
@@ -17,11 +17,11 @@ public class TestFixture {
     }
 
     public static Keyword createFixedKeyword() {
-        return new Keyword("name");
+        return new Keyword("AI");
     }
 
     public static Category createFixedCategory() {
-        return new Category("name", "colorCode");
+        return new Category("Spring", "#000000");
     }
 
     public static Hearit createFixedHearitWith(Category category) {

--- a/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
@@ -23,11 +23,11 @@ class CategoryControllerTest extends IntegrationTest {
     @DisplayName("전체 카테고리를 조회 시 200 OK 및 페이징이 적용된 카테고리 목록을 반환한다.")
     void readAllCategories() {
         // given
-        Category category1 = dbHelper.insertCategory(new Category("category1", "#111"));
-        Category category2 = dbHelper.insertCategory(new Category("category2", "#222"));
-        Category category3 = dbHelper.insertCategory(new Category("category3", "#333"));
-        Category category4 = dbHelper.insertCategory(new Category("category4", "#444"));
-        Category category5 = dbHelper.insertCategory(new Category("category5", "#555"));
+        Category category1 = dbHelper.insertCategory(new Category("category1", "#111111"));
+        Category category2 = dbHelper.insertCategory(new Category("category2", "#222222"));
+        Category category3 = dbHelper.insertCategory(new Category("category3", "#333333"));
+        Category category4 = dbHelper.insertCategory(new Category("category4", "#444444"));
+        Category category5 = dbHelper.insertCategory(new Category("category5", "#555555"));
 
         // when
         PagedResponse<CategoryResponse> result = RestAssured.given()
@@ -47,7 +47,7 @@ class CategoryControllerTest extends IntegrationTest {
                 () -> assertThat(result.content()).extracting(CategoryResponse::id)
                         .containsExactly(category3.getId(), category4.getId()),
                 () -> assertThat(result.content()).extracting(CategoryResponse::colorCode)
-                        .containsExactly("#333", "#444")
+                        .containsExactly("#333333", "#444444")
         );
     }
 
@@ -55,8 +55,8 @@ class CategoryControllerTest extends IntegrationTest {
     @DisplayName("카테고리로 히어릿 검색 시 200 OK 및 해당 카테고리의 히어릿들을 최신순으로 반환한다.")
     void searchHearitsByCategoryWithPagination() {
         // given
-        Category category1 = dbHelper.insertCategory(new Category("Spring", "#001"));
-        Category category2 = dbHelper.insertCategory(new Category("Java", "#002"));
+        Category category1 = dbHelper.insertCategory(new Category("Spring", "#111111"));
+        Category category2 = dbHelper.insertCategory(new Category("Java", "#222222"));
 
         Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 관리자 키워드 관리 페이지에서 키워드의 `name` 수정 기능 추가
- 관리자 카테고리 관리 페이지에서 카테고리의 `name`, `colorCode` 수정 기능 추가

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

AdminKeywordController
    `@DisplayName("키워드를 수정할 수 있다.")`

AdminCategoryControllerTest
   `@DisplayName("카테고리를 수정할 수 있다.")`

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #224 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 관리자 카테고리 및 키워드 목록에서 인라인 수정(이름/색상) 기능이 추가되었습니다.
  * 카테고리와 키워드 수정 API가 추가되었습니다.

* **버그 수정**
  * 카테고리 색상 입력값이 8자리에서 6자리(hex)로 변경되었습니다.

* **문서**
  * 관리자 홈 메뉴에 '수정' 기능이 반영되었습니다.
  * 히어릿 추가 관련 UI 문구가 '업로드'에서 '추가'로 변경되었습니다.
  * 관리자 내비게이션 및 메뉴 텍스트가 일부 변경되었습니다.

* **스타일**
  * 카테고리 및 키워드 관리 화면에 수정 버튼과 입력 필드가 추가되었습니다.

* **테스트**
  * 카테고리 및 키워드 수정 기능에 대한 테스트가 추가되었습니다.
  * 테스트 데이터의 색상 코드가 6자리 hex 형식으로 업데이트되었습니다.

* **기타**
  * 생성 및 수정 요청에 대한 입력값 유효성 검증이 강화되었습니다.
  * 카테고리 및 키워드 도메인에 이름 및 색상 코드 유효성 검증 로직이 추가되었습니다.
  * 카카오 로그인 관련 메서드명이 로그인과 회원가입을 통합하는 의미로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->