### PR TITLE
[BE] chore: cd 워크플로우에서 테스트도 실행하도록 수정 #235

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -12,6 +12,25 @@ jobs:
     name: Build and Upload Artifact
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+        ports:
+          - 13307:3306
+        options: >-
+          --health-cmd="mysqladmin ping -uroot -p$MYSQL_ROOT_PASSWORD"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    env:
+      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+      TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
+      DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -22,9 +41,12 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Build bootJar
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build with Gradle
         working-directory: backend
-        run: ./gradlew bootJar
+        run: ./gradlew clean build
 
       - name: Rename jar to app.jar
         working-directory: backend/build/libs


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
Spring REST Docs 도입에 따라 API 문서를 포함한 Jar 파일을 빌드하고 배포하기 위해 CI/CD 파이프라인의 변경.

기존 CD 워크플로우는 API 문서 생성에 필요한 테스트를 실행할 DB 환경이 없어 빌드할 수가 없어서  CD의 build 잡에 CI처럼 MySQL service와 env를 추가하여 테스트부터 빌드까지 수행할 수 있도록 함.
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#235 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 백엔드 배포 워크플로우에 MySQL 8.0 서비스 컨테이너가 추가되었습니다.
  * Gradle 공식 액션을 사용하여 빌드 환경 설정이 명확하게 변경되었습니다.
  * 전체 클린 빌드(clean build)로 빌드 명령어가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->