### PR TITLE
[BE] refactor: 랜덤 히어릿 응답에 키워드 포함

### DIFF
--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -31,7 +31,7 @@ public class HearitService {
     private static final int RECOMMEND_HEARIT_COUNT = 5;
     private static final int GROUPED_CATEGORY_COUNT = 3;
     private static final int HEARITS_PER_GROUPED_CATEGORY = 5;
-    private static final int KEYWORDS_PER_HEARIT_FOR_CATEGORY = 3;
+    private static final int KEYWORDS_PER_CATEGORIZED_HEARIT = 3;
     private static final int KEYWORDS_PER_HEARIT_FOR_RANDOM = 5;
 
     private final HearitRepository hearitRepository;
@@ -100,7 +100,7 @@ public class HearitService {
 
     private HearitOfCategoryResponse toHearitOfCategoryResponse(Hearit hearit) {
         List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
-                KEYWORDS_PER_HEARIT_FOR_CATEGORY);
+                KEYWORDS_PER_CATEGORIZED_HEARIT);
         return HearitOfCategoryResponse.from(hearit, keywords);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -64,7 +64,6 @@ public class HearitService {
     private RandomHearitResponse toRandomHearitResponse(Hearit hearit, Long memberId) {
         List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
                 KEYWORDS_PER_HEARIT_FOR_RANDOM);
-
         Optional<Bookmark> bookmarkOptional = bookmarkRepository.findByHearitIdAndMemberId(hearit.getId(), memberId);
         if (bookmarkOptional.isPresent()) {
             return RandomHearitResponse.fromWithBookmark(hearit, bookmarkOptional.get(), keywords);

--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -31,7 +31,8 @@ public class HearitService {
     private static final int RECOMMEND_HEARIT_COUNT = 5;
     private static final int GROUPED_CATEGORY_COUNT = 3;
     private static final int HEARITS_PER_GROUPED_CATEGORY = 5;
-    private static final int KEYWORDS_PER_HEARIT = 3;
+    private static final int KEYWORDS_PER_HEARIT_FOR_CATEGORY = 3;
+    private static final int KEYWORDS_PER_HEARIT_FOR_RANDOM = 5;
 
     private final HearitRepository hearitRepository;
     private final BookmarkRepository bookmarkRepository;
@@ -90,13 +91,13 @@ public class HearitService {
     public PagedResponse<HearitOfCategoryResponse> getHearitsByCategory(Long categoryId, PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> hearits = hearitRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
-        Page<HearitOfCategoryResponse> hearitResponses = hearits.map(this::toHearitOfCategoryResponseByKeywords);
+        Page<HearitOfCategoryResponse> hearitResponses = hearits.map(this::toHearitOfCategoryResponse);
         return PagedResponse.from(hearitResponses);
     }
 
-    private HearitOfCategoryResponse toHearitOfCategoryResponseByKeywords(Hearit hearit) {
+    private HearitOfCategoryResponse toHearitOfCategoryResponse(Hearit hearit) {
         List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
-                KEYWORDS_PER_HEARIT);
+                KEYWORDS_PER_HEARIT_FOR_CATEGORY);
         return HearitOfCategoryResponse.from(hearit, keywords);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/application/HearitService.java
@@ -62,11 +62,14 @@ public class HearitService {
     }
 
     private RandomHearitResponse toRandomHearitResponse(Hearit hearit, Long memberId) {
+        List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
+                KEYWORDS_PER_HEARIT_FOR_RANDOM);
+
         Optional<Bookmark> bookmarkOptional = bookmarkRepository.findByHearitIdAndMemberId(hearit.getId(), memberId);
         if (bookmarkOptional.isPresent()) {
-            return RandomHearitResponse.fromWithBookmark(hearit, bookmarkOptional.get());
+            return RandomHearitResponse.fromWithBookmark(hearit, bookmarkOptional.get(), keywords);
         }
-        return RandomHearitResponse.from(hearit);
+        return RandomHearitResponse.from(hearit, keywords);
     }
 
     public List<RecommendHearitResponse> getRecommendedHearits() {

--- a/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
@@ -2,27 +2,49 @@ package com.onair.hearit.dto.response;
 
 import com.onair.hearit.domain.Bookmark;
 import com.onair.hearit.domain.Hearit;
-import java.time.LocalDateTime;
+import com.onair.hearit.domain.Keyword;
+import java.util.List;
 
 public record RandomHearitResponse(
         Long id,
         String title,
         Boolean isBookmarked,
-        Long bookmarkId
+        Long bookmarkId,
+        List<RandomHearitResponse.KeywordResponse> keywords
 ) {
-    public static RandomHearitResponse from(Hearit hearit) {
+    public static RandomHearitResponse from(Hearit hearit, List<Keyword> keywords) {
+        List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         return new RandomHearitResponse(
                 hearit.getId(),
                 hearit.getTitle(),
                 false,
-                null);
+                null,
+                keywordResponses);
     }
 
-    public static RandomHearitResponse fromWithBookmark(Hearit hearit, Bookmark bookmark) {
+    public static RandomHearitResponse fromWithBookmark(Hearit hearit, Bookmark bookmark, List<Keyword> keywords) {
+        List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         return new RandomHearitResponse(
                 hearit.getId(),
                 hearit.getTitle(),
                 true,
-                bookmark.getId());
+                bookmark.getId(),
+                keywordResponses);
+    }
+
+    private static List<RandomHearitResponse.KeywordResponse> getKeywordNames(List<Keyword> keywords) {
+        return keywords.stream().map(RandomHearitResponse.KeywordResponse::from).toList();
+    }
+
+    private record KeywordResponse(
+            Long id,
+            String name
+    ) {
+        public static RandomHearitResponse.KeywordResponse from(Keyword keyword) {
+            return new RandomHearitResponse.KeywordResponse(
+                    keyword.getId(),
+                    keyword.getName()
+            );
+        }
     }
 }

--- a/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
@@ -10,7 +10,7 @@ public record RandomHearitResponse(
         String title,
         Boolean isBookmarked,
         Long bookmarkId,
-        List<RandomHearitResponse.KeywordResponse> keywords
+        List<KeywordResponse> keywords
 ) {
     public static RandomHearitResponse from(Hearit hearit, List<Keyword> keywords) {
         List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
@@ -34,9 +34,9 @@ public record RandomHearitResponse(
         );
     }
 
-    private static List<RandomHearitResponse.KeywordResponse> getKeywordNames(List<Keyword> keywords) {
+    private static List<KeywordResponse> getKeywordNames(List<Keyword> keywords) {
         return keywords.stream()
-                .map(RandomHearitResponse.KeywordResponse::from)
+                .map(KeywordResponse::from)
                 .toList();
     }
 
@@ -44,8 +44,8 @@ public record RandomHearitResponse(
             Long id,
             String name
     ) {
-        public static RandomHearitResponse.KeywordResponse from(Keyword keyword) {
-            return new RandomHearitResponse.KeywordResponse(
+        public static KeywordResponse from(Keyword keyword) {
+            return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()
             );

--- a/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
@@ -19,7 +19,8 @@ public record RandomHearitResponse(
                 hearit.getTitle(),
                 false,
                 null,
-                keywordResponses);
+                keywordResponses
+        );
     }
 
     public static RandomHearitResponse fromWithBookmark(Hearit hearit, Bookmark bookmark, List<Keyword> keywords) {
@@ -29,11 +30,14 @@ public record RandomHearitResponse(
                 hearit.getTitle(),
                 true,
                 bookmark.getId(),
-                keywordResponses);
+                keywordResponses
+        );
     }
 
     private static List<RandomHearitResponse.KeywordResponse> getKeywordNames(List<Keyword> keywords) {
-        return keywords.stream().map(RandomHearitResponse.KeywordResponse::from).toList();
+        return keywords.stream()
+                .map(RandomHearitResponse.KeywordResponse::from)
+                .toList();
     }
 
     private record KeywordResponse(

--- a/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
@@ -7,10 +7,6 @@ import java.time.LocalDateTime;
 public record RandomHearitResponse(
         Long id,
         String title,
-        String summary,
-        String source,
-        Integer playTime,
-        LocalDateTime createdAt,
         Boolean isBookmarked,
         Long bookmarkId
 ) {
@@ -18,10 +14,6 @@ public record RandomHearitResponse(
         return new RandomHearitResponse(
                 hearit.getId(),
                 hearit.getTitle(),
-                hearit.getSummary(),
-                hearit.getSource(),
-                hearit.getPlayTime(),
-                hearit.getCreatedAt(),
                 false,
                 null);
     }
@@ -30,10 +22,6 @@ public record RandomHearitResponse(
         return new RandomHearitResponse(
                 hearit.getId(),
                 hearit.getTitle(),
-                hearit.getSummary(),
-                hearit.getSource(),
-                hearit.getPlayTime(),
-                hearit.getCreatedAt(),
                 true,
                 bookmark.getId());
     }

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -126,6 +126,37 @@ class HearitServiceTest {
     }
 
     @Test
+    @DisplayName("랜덤 히어릿 조회 시 각 히어릿에 키워드가 포함되어 반환된다.")
+    void getRandomHearitsWithKeywords() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Keyword keyword1 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword2 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit1));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit1, keyword1));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit1, keyword2));
+
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit2));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit2, keyword1));
+
+        PagingRequest pagingRequest = new PagingRequest(0, 10);
+
+        // when
+        PagedResponse<RandomHearitResponse> result = hearitService.getRandomHearits(member.getId(), pagingRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(result.content()).hasSize(2),
+                () -> assertThat(result.content().get(0).keywords()).hasSize(2),
+                () -> assertThat(result.content().get(1).keywords()).hasSize(1)
+        );
+    }
+
+    @Test
     @DisplayName("최대 5개의 추천 히어릿을 조회할 수 있다.")
     void getRecommendedHearits() {
         // given

--- a/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/application/HearitServiceTest.java
@@ -142,6 +142,7 @@ class HearitServiceTest {
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit2));
         dbHelper.insertHearitKeyword(new HearitKeyword(hearit2, keyword1));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit2, keyword2));
 
         PagingRequest pagingRequest = new PagingRequest(0, 10);
 
@@ -152,7 +153,7 @@ class HearitServiceTest {
         assertAll(
                 () -> assertThat(result.content()).hasSize(2),
                 () -> assertThat(result.content().get(0).keywords()).hasSize(2),
-                () -> assertThat(result.content().get(1).keywords()).hasSize(1)
+                () -> assertThat(result.content().get(1).keywords()).hasSize(2)
         );
     }
 

--- a/backend/src/test/resources/application-integration-test.properties
+++ b/backend/src/test/resources/application-integration-test.properties
@@ -19,7 +19,7 @@ kakao.user-info.base-url=https://kapi.kakao.com
 # Jwt
 jwt.secret=test-example-jwt-secret-test-example-jwt-secret
 jwt.access-token.expiration=6000
-jwt.refresh-token.expiration=1000
+jwt.refresh-token.expiration=12000
 
 # user-default-image
 hearit.profile.default-image-url=http://hearit.o-r.kr/images/default-profile.jpg


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 히어릿에 대한 키워드 개수를 지정하는 상수 두 가지로 분리
- Random 히어릿 조회시에도 응답 DTO에 키워드 리스트 포함

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #248 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 랜덤 히어릿 조회 시 각 히어릿에 연관된 키워드 목록이 함께 제공됩니다.
  * 카테고리별 히어릿 조회 시 키워드 수가 조정되어 더 정확한 키워드 정보가 표시됩니다.

* **버그 수정**
  * 없음

* **테스트**
  * 랜덤 히어릿 응답에 키워드가 포함되는지 검증하는 테스트가 추가되었습니다.

* **환경설정**
  * 통합 테스트 환경에서 JWT 리프레시 토큰의 만료 시간이 연장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->