### PR TITLE
[BE] fix: Refresh api 누락된 문서 추가 #255

### DIFF
--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -106,7 +106,7 @@ class AuthControllerTest extends IntegrationTest {
         TokenReissueResponse response = RestAssured.given(this.spec).log().all()
                 .contentType(ContentType.JSON)
                 .body(tokenReissueRequest)
-                .filter(document("auth-login",
+                .filter(document("auth-login-reissue",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Auth API")
                                 .summary("엑세스토큰 재발급 요청")

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -106,7 +106,7 @@ class AuthControllerTest extends IntegrationTest {
         TokenReissueResponse response = RestAssured.given(this.spec).log().all()
                 .contentType(ContentType.JSON)
                 .body(tokenReissueRequest)
-                .filter(document("auth-login-reissue",
+                .filter(document("auth-refresh",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Auth API")
                                 .summary("엑세스토큰 재발급 요청")


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
'/api/v1/auth/token/refresh' api 문서의 identifier를  '/api/v1/auth/login'문서의 identifier 와 같게 설정해 문서가 누락되어 안 나오던 오류를 수정
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#255 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * 토큰 재발급 엔드포인트 테스트의 API 문서 스니펫 이름이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->