### PR TITLE
[BE] refactor: 탐색 화면 상의 카테고리 컬러 응답값 추가

### DIFF
--- a/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/RandomHearitResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record RandomHearitResponse(
         Long id,
         String title,
+        String categoryColorCode,
         Boolean isBookmarked,
         Long bookmarkId,
         List<KeywordResponse> keywords
@@ -17,6 +18,7 @@ public record RandomHearitResponse(
         return new RandomHearitResponse(
                 hearit.getId(),
                 hearit.getTitle(),
+                hearit.getCategory().getColorCode(),
                 false,
                 null,
                 keywordResponses
@@ -28,6 +30,7 @@ public record RandomHearitResponse(
         return new RandomHearitResponse(
                 hearit.getId(),
                 hearit.getTitle(),
+                hearit.getCategory().getColorCode(),
                 true,
                 bookmark.getId(),
                 keywordResponses

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -161,6 +161,7 @@ class HearitControllerTest extends IntegrationTest {
                                                 Arrays.stream(new FieldDescriptor[]{
                                                         fieldWithPath("content[].id").description("히어릿 ID"),
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
+                                                        fieldWithPath("content[].categoryColorCode").description("카테고리 색상"),
                                                         fieldWithPath("content[].isBookmarked").description("북마크 여부"),
                                                         fieldWithPath("content[].bookmarkId").description(
                                                                 "북마크 ID (북마크된 경우)").optional(),


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 탐색 화면 ui 변경으로 인해 반환값에 히어릿의 카테고리 컬러코드 추가합니다.

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #261 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 랜덤 히어릿 응답에 카테고리 색상 코드(`categoryColorCode`)가 추가되었습니다.

* **문서화**
  * 랜덤 히어릿 조회 API 응답 문서에 카테고리 색상 코드 필드가 반영되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->