### PR TITLE
[BE] fix: 상세 조회  비로그인, 로그인 문서 오류 수정 #262

### DIFF
--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -63,7 +63,7 @@ public class HearitController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<PagedResponse<HearitSearchResponse>> searchHearitsByTitle(
+    public ResponseEntity<PagedResponse<HearitSearchResponse>> readSearchedHHearits(
             @RequestParam(name = "searchTerm") String searchTerm,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size) {

--- a/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/presentation/HearitController.java
@@ -63,7 +63,7 @@ public class HearitController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<PagedResponse<HearitSearchResponse>> readSearchedHHearits(
+    public ResponseEntity<PagedResponse<HearitSearchResponse>> readSearchedHearits(
             @RequestParam(name = "searchTerm") String searchTerm,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size) {

--- a/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/CategoryControllerTest.java
@@ -17,7 +17,6 @@ import com.onair.hearit.fixture.IntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -387,7 +387,7 @@ class HearitControllerTest extends IntegrationTest {
                 .queryParam("size", 10)
                 .filter(document("category-search-hearits",
                         resource(ResourceSnippetParameters.builder()
-                                .tag("Category API")
+                                .tag("Hearit API")
                                 .summary("카테고리별 히어릿 목록 조회")
                                 .description("특정 카테고리에 속한 히어릿 목록을 페이지별로 조회합니다.")
                                 .queryParameters(

--- a/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/HearitControllerTest.java
@@ -56,11 +56,13 @@ class HearitControllerTest extends IntegrationTest {
         // when & then
         HearitDetailResponse response = RestAssured.given(this.spec)
                 .header("Authorization", "Bearer " + token)
-                .filter(document("hearit-read-detail-member",
+                .filter(document("hearit-read-detail",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
-                                .summary("히어릿 상세 조회 (로그인)")
-                                .description("로그인한 사용자가 히어릿의 상세 정보를 조회합니다. 북마크 여부가 포함됩니다.")
+                                .summary("히어릿 상세 조회")
+                                .description("히어릿의 상세 정보를 조회합니다. \n\n"
+                                        + "로그인한 사용자의 경우, `isBookmarked`와 `bookmarkId` 필드가 사용자의 북마크 상태를 반영하여 반환됩니다. \n\n"
+                                        + "비로그인 사용자의 경우, `isBookmarked`는 항상 `false`이며 `bookmarkId`는 `null` 입니다.")
                                 .pathParameters(
                                         parameterWithName("hearitId").description("조회할 히어릿의 ID")
                                 )
@@ -88,18 +90,6 @@ class HearitControllerTest extends IntegrationTest {
 
         // when & then
         HearitDetailResponse response = RestAssured.given(this.spec)
-                .filter(document("hearit-read-detail-not-member",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Hearit API")
-                                .summary("히어릿 상세 조회 (비로그인)")
-                                .description("비로그인 사용자가 히어릿의 상세 정보를 조회합니다. 북마크 여부는 항상 false입니다.")
-                                .pathParameters(
-                                        parameterWithName("hearitId").description("조회할 히어릿의 ID")
-                                )
-                                .responseSchema(Schema.schema("HearitDetailResponse"))
-                                .responseFields(getHearitDetailResponseFields())
-                                .build())
-                ))
                 .when()
                 .get("/api/v1/hearits/{hearitId}", hearit.getId())
                 .then()
@@ -161,7 +151,8 @@ class HearitControllerTest extends IntegrationTest {
                                                 Arrays.stream(new FieldDescriptor[]{
                                                         fieldWithPath("content[].id").description("히어릿 ID"),
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
-                                                        fieldWithPath("content[].categoryColorCode").description("카테고리 색상"),
+                                                        fieldWithPath("content[].categoryColorCode").description(
+                                                                "카테고리 색상"),
                                                         fieldWithPath("content[].isBookmarked").description("북마크 여부"),
                                                         fieldWithPath("content[].bookmarkId").description(
                                                                 "북마크 ID (북마크된 경우)").optional(),


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
스웨거 문서 내 히어릿 상세 조회의 비로그인, 로그인 문서가 겹치던 문제를 수정했습니다.
 - HearitController내의 검색 메서드명 수정했습니다. searchByTitle -> readSearchedHearits
 - 사용하지 않는 import 제거
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **문서화**
  * API 문서에서 일부 엔드포인트의 설명과 요약이 더 명확하게 수정되었습니다. 로그인 여부에 따른 응답 필드 설명이 추가되었습니다.
  * 특정 테스트에서 API 문서 생성을 중단하였습니다.
  * 필드 설명의 형식이 일부 개선되었습니다.

* **기타**
  * 내부 코드 및 테스트에서 불필요한 import가 제거되었습니다.  
  * 엔드포인트 메서드명이 변경되었으나, 기능에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->