### PR TITLE
[BE] fix: Jwt Filter에서 화이트리스트API여도 token이 비어있는 경우에만 통과하도록 수정 #269

### DIFF
--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = extractTokenFromHeader(header);
 
         // 화이트리스트면 그냥 통과
-        if (isWhitelisted(request)) {
+        if ((token == null || token.isBlank()) && isWhitelisted(request)) {
             chain.doFilter(request, response);
             return;
         }


### PR DESCRIPTION
- 기존: token이 있어도 화이트리스트에 포함되어있었으면 무시됨
- 변경: token이 있다면 정상적으로 CurrentMember가 주입됨

<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

JwtAuthenticationFilter에서 token이 비어있고 API가 화이트리스트에 포함되어있는 경우에만 Filter를 통과하도록 수정함.
- 만약 토큰이 있다면 통과하지 않고 정상적으로 CurrentMember를 주입해야됨.
- 기존에는 토큰이 있더라도 화이트리스트에 포함되어있기 때문에 `@AuthenticationPrincipal`을 통한 주입이 무시됨

## 주의점
이제 안드로이드에서 토큰이 필요없는 API의 경우 토큰을 포함하지 않아야만 예외가 터지지 않음
기존에는 토큰이 필요없는 API에 토큰 헤더에 보내도 예외가 터지지 않았음

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 화이트리스트에 포함된 경로라도 토큰이 있는 경우 필터를 우회하지 않도록 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->