### PR TITLE
[BE] feat: 회원 탈퇴 기능 추가 #275

### DIFF
--- a/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
+++ b/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
@@ -10,6 +10,7 @@ import com.onair.hearit.auth.infrastructure.client.KakaoUserInfoClient;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.auth.infrastructure.repository.RefreshTokenRepository;
 import com.onair.hearit.common.exception.custom.InvalidInputException;
+import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.infrastructure.MemberRepository;
@@ -119,7 +120,11 @@ public class AuthService {
         }
     }
 
-    public void logout(Long memberId) {
+    @Transactional
+    public void withdraw(Long memberId) {
         refreshTokenRepository.deleteByMemberId(memberId);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
+        member.withdraw();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
+++ b/backend/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,9 +55,9 @@ public class AuthController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@AuthenticationPrincipal CurrentMember currentMember) {
-        authService.logout(currentMember.memberId());
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal CurrentMember currentMember) {
+        authService.withdraw(currentMember.memberId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/common/log/message/JsonMaskingPrettyFormatter.java
+++ b/backend/src/main/java/com/onair/hearit/common/log/message/JsonMaskingPrettyFormatter.java
@@ -22,6 +22,7 @@ public class JsonMaskingPrettyFormatter {
         put("password", v -> "*****");
         put("localId", v -> maskEdge(v, 1));
         put("accessToken", v -> "*****");
+        put("refreshToken", v -> "*****");
     }};
 
     private final ObjectMapper objectMapper;

--- a/backend/src/main/java/com/onair/hearit/domain/Member.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Member.java
@@ -64,6 +64,10 @@ public class Member {
         return new Member(null, null, socialId, nickname, profileImage);
     }
 
+    public void withdraw() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -81,9 +85,5 @@ public class Member {
     @Override
     public int hashCode() {
         return Objects.hashCode(id);
-    }
-
-    public void withdraw() {
-        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/domain/Member.java
+++ b/backend/src/main/java/com/onair/hearit/domain/Member.java
@@ -82,4 +82,8 @@ public class Member {
     public int hashCode() {
         return Objects.hashCode(id);
     }
+
+    public void withdraw() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/MemberRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/MemberRepository.java
@@ -3,12 +3,16 @@ package com.onair.hearit.infrastructure;
 import com.onair.hearit.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByLocalId(String memberId);
+    @Query("SELECT m FROM Member m WHERE m.localId = :localId AND m.deletedAt IS NULL")
+    Optional<Member> findByLocalId(String localId);
 
+    @Query("SELECT m FROM Member m WHERE m.socialId = :socialId AND m.deletedAt IS NULL")
     Optional<Member> findBySocialId(String socialId);
 
-    boolean existsByLocalId(String memberId);
+    @Query("SELECT count(m) > 0 FROM Member m WHERE m.localId = :localId AND m.deletedAt IS NULL")
+    boolean existsByLocalId(String localId);
 }

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
@@ -58,61 +58,97 @@ class AuthServiceTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @Test
-    @DisplayName("아이디와 비밀번호로 회원가입할 수 있으며, 기본 프로필 이미지로 저장된다.")
-    void signup_success() {
-        // given
-        SignupRequest request = new SignupRequest("localId", "nickname", "password123");
+    @Nested
+    @DisplayName("회원가입")
+    class Signup {
 
-        // when
-        authService.signup(request);
+        @Test
+        @DisplayName("아이디와 비밀번호로 회원가입할 수 있으며, 기본 프로필 이미지로 저장된다.")
+        void signup_success() {
+            // given
+            SignupRequest request = new SignupRequest("localId", "nickname", "password123");
 
-        // then
-        Member saved = memberRepository.findByLocalId("localId").orElseThrow();
-        assertAll(() -> {
-            assertThat(saved.getNickname()).isEqualTo("nickname");
-            assertThat(passwordEncoder.matches("password123", saved.getPassword())).isTrue();
-            assertThat(saved.getProfileImage()).isNotNull();
-        });
+            // when
+            authService.signup(request);
+
+            // then
+            Member saved = memberRepository.findByLocalId("localId").orElseThrow();
+            assertAll(() -> {
+                assertThat(saved.getNickname()).isEqualTo("nickname");
+                assertThat(passwordEncoder.matches("password123", saved.getPassword())).isTrue();
+                assertThat(saved.getProfileImage()).isNotNull();
+            });
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 아이디로 회원가입 시 예외가 발생한다.")
+        void signup_duplicate_id() {
+            // given
+            dbHelper.insertMember(
+                    Member.createLocalUser("sameId", "nickname", passwordEncoder.encode("password"), "profile.jpg"));
+
+            SignupRequest signupRequest = new SignupRequest("sameId", "another", "password");
+
+            // when & then
+            assertThatThrownBy(() -> authService.signup(signupRequest))
+                    .isInstanceOf(InvalidInputException.class)
+                    .hasMessageContaining("이미 존재하는 아이디입니다.");
+        }
     }
 
-    @Test
-    @DisplayName("이미 존재하는 아이디로 회원가입 시 예외가 발생한다.")
-    void signup_duplicate_id() {
-        // given
-        dbHelper.insertMember(
-                Member.createLocalUser("sameId", "nickname", passwordEncoder.encode("password"), "profile.jpg"));
+    @Nested
+    @DisplayName("로그인")
+    class Login {
 
-        SignupRequest signupRequest = new SignupRequest("sameId", "another", "password");
+        @Test
+        @DisplayName("로그인 성공 시 엑세스토큰 + 리프래시토큰을 발급한다.")
+        void login_success() {
+            // given
+            dbHelper.insertMember(
+                    Member.createLocalUser("localId", "nickname", passwordEncoder.encode("password"), "profile.jpg"));
 
-        // when & then
-        assertThatThrownBy(() -> authService.signup(signupRequest))
-                .isInstanceOf(InvalidInputException.class)
-                .hasMessageContaining("이미 존재하는 아이디입니다.");
-    }
+            LoginRequest loginRequest = new LoginRequest("localId", "password");
 
-    @Test
-    @DisplayName("로그인 성공 시 엑세스토큰 + 리프래시토큰을 발급한다.")
-    void login_success() {
-        // given
-        dbHelper.insertMember(
-                Member.createLocalUser("localId", "nickname", passwordEncoder.encode("password"), "profile.jpg"));
+            // when
+            LoginTokenResponse loginTokenResponse = authService.login(loginRequest);
 
-        LoginRequest loginRequest = new LoginRequest("localId", "password");
+            // then
+            String responseAccessToken = loginTokenResponse.accessToken();
+            String responseRefreshToken = loginTokenResponse.refreshToken();
 
-        // when
-        LoginTokenResponse loginTokenResponse = authService.login(loginRequest);
+            assertAll(() -> {
+                assertThat(responseAccessToken).isNotNull();
+                assertThat(responseRefreshToken).isNotNull();
+                RefreshToken refreshToken = refreshTokenRepository.findByToken(responseRefreshToken).orElseThrow();
+                assertThat(refreshToken.getToken()).isEqualTo(responseRefreshToken);
+            });
+        }
 
-        // then
-        String responseAccessToken = loginTokenResponse.accessToken();
-        String responseRefreshToken = loginTokenResponse.refreshToken();
+        @Test
+        @DisplayName("아이디가 존재하지 않을 경우 인증예외가 발생한다")
+        void login_fail_member_not_found() {
+            // given
+            LoginRequest request = new LoginRequest("nonexistent", "password");
 
-        assertAll(() -> {
-            assertThat(responseAccessToken).isNotNull();
-            assertThat(responseRefreshToken).isNotNull();
-            RefreshToken refreshToken = refreshTokenRepository.findByToken(responseRefreshToken).orElseThrow();
-            assertThat(refreshToken.getToken()).isEqualTo(responseRefreshToken);
-        });
+            // when & then
+            assertThatThrownBy(() -> authService.login(request))
+                    .isInstanceOf(UnauthorizedException.class)
+                    .hasMessageContaining("아이디나 비밀번호가 일치하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("비밀번호가 틀릴 경우 인증예외가 발생한다")
+        void login_fail_wrong_password() {
+            // given
+            dbHelper.insertMember(Member.createLocalUser("localId", "nickname", "password", "profile.jpg"));
+
+            LoginRequest loginRequest = new LoginRequest("localId", "wrongpassword");
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(loginRequest))
+                    .isInstanceOf(UnauthorizedException.class)
+                    .hasMessageContaining("아이디나 비밀번호가 일치하지 않습니다.");
+        }
     }
 
     @Nested
@@ -186,33 +222,7 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("아이디가 존재하지 않을 경우 인증예외가 발생한다")
-    void login_fail_member_not_found() {
-        // given
-        LoginRequest request = new LoginRequest("nonexistent", "password");
-
-        // when & then
-        assertThatThrownBy(() -> authService.login(request))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessageContaining("아이디나 비밀번호가 일치하지 않습니다.");
-    }
-
-    @Test
-    @DisplayName("비밀번호가 틀릴 경우 인증예외가 발생한다")
-    void login_fail_wrong_password() {
-        // given
-        dbHelper.insertMember(Member.createLocalUser("localId", "nickname", "password", "profile.jpg"));
-
-        LoginRequest loginRequest = new LoginRequest("localId", "wrongpassword");
-
-        // when & then
-        assertThatThrownBy(() -> authService.login(loginRequest))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessageContaining("아이디나 비밀번호가 일치하지 않습니다.");
-    }
-
-    @Test
-    @DisplayName("로그아웃 시 해당 member의 리프레시토큰을 삭제한다.")
+    @DisplayName("회원탈퇴 시 리프레시토큰 제거 및 회원탈퇴한시각을 기록한다.")
     void logout_then_deleteRefreshToken() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
@@ -221,9 +231,11 @@ class AuthServiceTest {
         assertThat(refreshTokenRepository.findByMemberId(member.getId())).isPresent();
 
         // when
-        authService.logout(member.getId());
+        authService.withdraw(member.getId());
 
         // then
         assertThat(refreshTokenRepository.findByMemberId(member.getId())).isEmpty();
+        Member withdrawnMember = memberRepository.findById(member.getId()).orElseThrow();
+        assertThat(withdrawnMember.getDeletedAt()).isNotNull();
     }
 }

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -300,7 +300,7 @@ class AuthControllerTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("로그아웃 시 해당 회원의 리프레시토큰을 삭제하고 회원탈퇴 시간이 기록된다.")
+    @DisplayName("회원탈퇴 시 해당 회원의 리프레시토큰을 삭제하고 회원탈퇴 시간이 기록된다.")
     void withdraw() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
@@ -312,11 +312,11 @@ class AuthControllerTest extends IntegrationTest {
         // when
         RestAssured.given(this.spec).log().all()
                 .header("Authorization", "Bearer " + accessToken)
-                .filter(document("auth-logout",
+                .filter(document("auth-withdraw",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Auth API")
-                                .summary("로그아웃")
-                                .description("로그아웃 시 리프레시토큰을 삭제합니다.")
+                                .summary("회원탈퇴")
+                                .description("회원탈퇴 시 서버에서 회원을 탈퇴처리합니다.")
                                 .build())
                 ))
                 .when()

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -22,6 +22,7 @@ import com.onair.hearit.domain.Member;
 import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.fixture.TestFixture;
+import com.onair.hearit.infrastructure.MemberRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.time.LocalDateTime;
@@ -44,6 +45,9 @@ class AuthControllerTest extends IntegrationTest {
 
     @Autowired
     RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
 
     @Test
     @DisplayName("로그인 성공 시 200 OK 및 엑세스토큰 + 리프레시토큰을 반환한다.")
@@ -296,8 +300,8 @@ class AuthControllerTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("로그아웃 시 해당 회원의 리프레시토큰을 삭제한다.")
-    void logout_then_deleteRefreshToken() {
+    @DisplayName("로그아웃 시 해당 회원의 리프레시토큰을 삭제하고 회원탈퇴 시간이 기록된다.")
+    void withdraw() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         createAndSaveRefreshTokenFrom(member);
@@ -316,12 +320,15 @@ class AuthControllerTest extends IntegrationTest {
                                 .build())
                 ))
                 .when()
-                .post("/api/v1/auth/logout")
+                .delete("/api/v1/auth/withdraw")
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
 
         // then
-        assertThat(refreshTokenRepository.findByMemberId(member.getId())).isEmpty();
+        assertAll(() -> {
+            assertThat(refreshTokenRepository.findByMemberId(member.getId())).isEmpty();
+            assertThat(memberRepository.findById(member.getId()).orElseThrow().getDeletedAt()).isNotNull();
+        });
     }
 
     private RefreshToken createAndSaveRefreshTokenFrom(Member member) {

--- a/backend/src/test/java/com/onair/hearit/infrastructure/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/MemberRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.onair.hearit.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.config.TestJpaAuditingConfig;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.fixture.DbHelper;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({DbHelper.class, TestJpaAuditingConfig.class})
+@ActiveProfiles("fake-test")
+class MemberRepositoryTest {
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("localId로 활성 회원을 조회할 수 있다")
+    void findByLocalId_whenActiveMember_thenReturnMember() {
+        // given
+        dbHelper.insertMember(Member.createLocalUser("user123", "닉네임", "비번", null));
+
+        // when
+        Optional<Member> result = memberRepository.findByLocalId("user123");
+
+        // then
+        assertAll(() -> {
+            assertThat(result).isPresent();
+            assertThat(result.get().getLocalId()).isEqualTo("user123");
+        });
+    }
+
+    @Test
+    @DisplayName("localId로 탈퇴한 회원은 조회되지 않는다")
+    void findByLocalId_whenDeletedMember_thenEmpty() {
+        // given
+        Member member = dbHelper.insertMember(Member.createLocalUser("user123", "닉네임", "비번", null));
+        memberRepository.save(member);
+        member.withdraw();
+
+        // when
+        Optional<Member> result = memberRepository.findByLocalId("user123");
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("socialId로 활성 회원을 조회할 수 있다")
+    void findBySocialId_whenActiveMember_thenReturnMember() {
+        // given
+        dbHelper.insertMember(Member.createSocialUser("social123", "닉네임", null));
+
+        // when
+        Optional<Member> result = memberRepository.findBySocialId("social123");
+
+        // then
+        assertAll(() -> {
+            assertThat(result).isPresent();
+            assertThat(result.get().getSocialId()).isEqualTo("social123");
+        });
+    }
+
+    @Test
+    @DisplayName("localId가 존재하는 활성 회원이 있을 때 true를 반환한다")
+    void existsByLocalId_whenActiveMember_thenTrue() {
+        // given
+        dbHelper.insertMember(Member.createLocalUser("user123", "닉네임", "비번", null));
+
+        // when
+        boolean exists = memberRepository.existsByLocalId("user123");
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("localId가 존재하더라도 탈퇴한 회원이면 false를 반환한다")
+    void existsByLocalId_whenDeletedMember_thenFalse() {
+        // given
+        Member member = dbHelper.insertMember(Member.createLocalUser("user123", "닉네임", "비번", null));
+        member.withdraw();
+
+        // when
+        boolean exists = memberRepository.existsByLocalId("user123");
+
+        // then
+        assertThat(exists).isFalse();
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 현재 로그인된 멤버의 회원탈퇴 기능 추가
    - 구글플레이스토어 정책상 회원탈퇴 기능이 필요함.

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

AuthController
`@DisplayName("로그아웃 시 해당 회원의 리프레시토큰을 삭제하고 회원탈퇴 시간이 기록된다.")`
`@DisplayName("아이디가 존재하지 않을 경우 인증예외가 발생한다")`

AuthService
`@DisplayName("회원탈퇴 시 리프레시토큰 제거 및 회원탈퇴한시각을 기록한다.")`

MemberRepositoryTest 전체

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #275


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 탈퇴 기능이 추가되어, 탈퇴 시 리프레시 토큰이 삭제되고 회원의 탈퇴 시각이 기록됩니다.

* **버그 수정**
  * 탈퇴 회원이 더 이상 조회되지 않도록 회원 조회 관련 기능이 개선되었습니다.

* **테스트**
  * 회원 탈퇴 및 로그인 실패 등 다양한 시나리오에 대한 테스트가 추가 및 개선되었습니다.
  * 회원 리포지토리 동작에 대한 별도 테스트가 도입되었습니다.

* **리팩터링**
  * 테스트 코드 구조가 개선되어 가독성과 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->