### PR TITLE
[AN] refactor: 라이브러리 바텀 시트 제목/시간 연결 #303

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/library/BookmarkOptionBottomSheet.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/BookmarkOptionBottomSheet.kt
@@ -33,6 +33,16 @@ class BookmarkOptionBottomSheet : BottomSheetDialogFragment() {
     ) {
         super.onViewCreated(view, savedInstanceState)
 
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
+        viewModel.bookmarks.observe(viewLifecycleOwner) { bookmarkList ->
+            val targetBookmark = bookmarkList.find { it.bookmarkId == bookmarkId }
+            if (targetBookmark != null) {
+                binding.bookmark = targetBookmark
+            }
+        }
         binding.tvBookmarkOptionDeleteBookmark.setOnClickListener {
             viewModel.deleteBookmark(bookmarkId)
             dismiss()

--- a/android/app/src/main/res/layout/bottom_sheet_bookmark_option.xml
+++ b/android/app/src/main/res/layout/bottom_sheet_bookmark_option.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="bookmark"
+            type="com.onair.hearit.domain.model.Bookmark" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -16,20 +24,23 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
             android:layout_marginTop="20dp"
-            android:text="HTTP와 HTTPS의 차이"
+            android:text="@{bookmark.title}"
             android:textColor="@color/hearit_gray4"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="HTTP와 HTTPS의 차이" />
 
         <TextView
             android:id="@+id/tv_bookmark_option_time"
             style="@style/pretendard_body"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="00:00"
+            android:layout_marginTop="8dp"
             android:textColor="@color/hearit_gray2"
             app:layout_constraintStart_toStartOf="@id/tv_bookmark_option_title"
-            app:layout_constraintTop_toBottomOf="@id/tv_bookmark_option_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_bookmark_option_title"
+            app:playTimeFormatted="@{bookmark.playTime}"
+            tools:text="00:00" />
 
         <ImageView
             android:id="@+id/iv_bookmark_option_delete_bookmark"
@@ -47,7 +58,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="18dp"
-            android:text="북마크에서 삭제하기"
+            android:text="@string/library_bottom_sheet_bookmark_delete"
             android:textColor="@color/hearit_gray4"
             app:layout_constraintBottom_toBottomOf="@id/iv_bookmark_option_delete_bookmark"
             app:layout_constraintStart_toEndOf="@id/iv_bookmark_option_delete_bookmark"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="library_guide_when_no_login"><font color="#B677F3">히어릿</font>을 모아서 듣고 싶다면,\n로그인을 해주세요!</string>
     <string name="library_login_button_text">로그인 하러가기</string>
     <string name="library_toast_bookmark_load_fail">북마크 조회에 실패했습니다.</string>
+    <string name="library_bottom_sheet_bookmark_delete">북마크에서 삭제하기</string>
 
     <!-- SearchFragment-->
     <string name="search_category_text">카테고리</string>


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 북마크 바텀시트 제목/시간 연결

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부
<img width="260" alt="Screenshot_20250807_200416" src="https://github.com/user-attachments/assets/c22fddeb-1a28-4158-9e49-38fce9bf57e9" />


## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#303 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 북마크 데이터가 변경될 때 UI가 자동으로 최신 정보로 갱신됩니다.

* **스타일**
  * 북마크 옵션 하단시트 레이아웃이 데이터 바인딩을 사용하여 북마크 제목과 재생 시간을 동적으로 표시합니다.
  * 삭제 버튼 텍스트가 문자열 리소스를 사용하도록 개선되었습니다.

* **문서화**
  * 북마크 삭제 관련 새로운 문자열 리소스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->