### PR TITLE
[BE] fix: 예외 처리 개선 - 파라미터 타입 불일치 및 메서드 미지원 처리 추가 #314

### DIFF
--- a/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정보를 찾을 수 없습니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     ;
 

--- a/backend/src/main/java/com/onair/hearit/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/GlobalExceptionHandler.java
@@ -7,9 +7,11 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -34,6 +36,16 @@ public class GlobalExceptionHandler {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.status(404).build();
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ProblemDetail handleTypeMismatch(MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+        return buildProblemDetail(ErrorCode.INVALID_INPUT, "잘못된 파라미터 값: " + ex.getValue(), request);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ProblemDetail handleMethodNotAllowed(HttpRequestMethodNotSupportedException ex, HttpServletRequest request) {
+        return buildProblemDetail(ErrorCode.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다.", request);
     }
 
     @ExceptionHandler(Exception.class)


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

Spring MVC 요청 처리 과정에서 ExceptionHandler로 처리하지 않은 예외가 발생할 경우, 내부 서버 오류(500)로 처리되던 문제를 개선
- 잘못된 요청 파라미터 타입 (예: `@PathVariable` Long에 "random" 입력)
- 정의되지 않은 HTTP 메서드 호출 (예: `@GetMapping`만 정의된 엔드포인트에 PATCH 요청)

    - `MethodArgumentTypeMismatchException` 핸들러 추가
→ 400 Bad Request로 변환하여 클라이언트에 명확한 에러 메시지 전달
    - `HttpRequestMethodNotSupportedException` 핸들러 추가
→ 405 Method Not Allowed로 처리, 명확한 응답 제공

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->
더 추가할 필요 있는 예외는 있어보이는데, 우선 최근 1주일간 로깅에 찍힌 예외 위주로만 처리했슴

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #314 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 잘못된 파라미터 값이나 지원하지 않는 HTTP 메서드 요청 시, 보다 명확한 에러 메시지가 제공됩니다.
* **버그 수정**
  * 입력값 타입 오류 및 허용되지 않은 HTTP 메서드 요청에 대해 각각 구체적인 에러 응답이 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->