### PR TITLE
[AN] refactor: 토큰 interceptor에서 넣도록 수정

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/api/BookmarkService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/BookmarkService.kt
@@ -5,7 +5,6 @@ import com.onair.hearit.data.dto.BookmarkResponse
 import retrofit2.Response
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -19,13 +18,11 @@ interface BookmarkService {
 
     @POST("bookmarks/hearits/{hearitId}")
     suspend fun postBookmark(
-        @Header("Authorization") token: String?,
         @Path("hearitId") hearitId: Long,
     ): Response<BookmarkIdResponse>
 
     @DELETE("bookmarks/{bookmarkId}")
     suspend fun deleteBookmark(
-        @Header("Authorization") token: String?,
         @Path("bookmarkId") bookmarkId: Long,
     ): Response<Unit>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/api/BookmarkService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/BookmarkService.kt
@@ -13,7 +13,6 @@ import retrofit2.http.Query
 interface BookmarkService {
     @GET("bookmarks/hearits")
     suspend fun getBookmarks(
-        @Header("Authorization") token: String?,
         @Query("page") page: Int?,
         @Query("size") size: Int?,
     ): Response<BookmarkResponse>

--- a/android/app/src/main/java/com/onair/hearit/data/api/HearitService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/HearitService.kt
@@ -7,19 +7,15 @@ import com.onair.hearit.data.dto.RecommendHearitResponse
 import com.onair.hearit.data.dto.SearchHearitResponse
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface HearitService {
     @GET("hearits/recommend-category")
-    suspend fun getCategoryHearits(
-        @Header("Authorization") token: String?,
-    ): Response<List<GroupedCategoryHearitResponse>>
+    suspend fun getCategoryHearits(): Response<List<GroupedCategoryHearitResponse>>
 
     @GET("hearits/explore")
     suspend fun getRandomHearits(
-        @Header("Authorization") token: String?,
         @Query("cursorId") cursorId: Long?,
         @Query("size") size: Int?,
     ): Response<RandomHearitResponse>
@@ -36,7 +32,6 @@ interface HearitService {
 
     @GET("hearits/{hearitId}")
     suspend fun getHearit(
-        @Header("Authorization") token: String?,
         @Path("hearitId") hearitId: Long,
     ): Response<HearitResponse>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/api/MediaFileService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/MediaFileService.kt
@@ -6,6 +6,7 @@ import com.onair.hearit.data.dto.ShortAudioUrlResponse
 import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Url
 
@@ -28,5 +29,6 @@ interface MediaFileService {
     @GET
     suspend fun getScriptJson(
         @Url url: String,
+        @Header("No-Auth") noAuth: Boolean = true,
     ): Response<ResponseBody>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/api/MemberService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/MemberService.kt
@@ -3,11 +3,8 @@ package com.onair.hearit.data.api
 import com.onair.hearit.data.dto.UserInfoResponse
 import retrofit2.Response
 import retrofit2.http.GET
-import retrofit2.http.Header
 
 interface MemberService {
     @GET("members/me")
-    suspend fun getUserInfo(
-        @Header("Authorization") token: String?,
-    ): Response<UserInfoResponse>
+    suspend fun getUserInfo(): Response<UserInfoResponse>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/BookmarkRemoteDataSource.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/BookmarkRemoteDataSource.kt
@@ -6,7 +6,6 @@ import com.onair.hearit.data.dto.BookmarkResponse
 
 interface BookmarkRemoteDataSource {
     suspend fun getBookmarks(
-        token: String?,
         page: Int?,
         size: Int?,
     ): Result<NetworkResult<BookmarkResponse>>

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/BookmarkRemoteDataSource.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/BookmarkRemoteDataSource.kt
@@ -10,13 +10,7 @@ interface BookmarkRemoteDataSource {
         size: Int?,
     ): Result<NetworkResult<BookmarkResponse>>
 
-    suspend fun addBookmark(
-        token: String?,
-        hearitId: Long,
-    ): Result<NetworkResult<BookmarkIdResponse>>
+    suspend fun addBookmark(hearitId: Long): Result<NetworkResult<BookmarkIdResponse>>
 
-    suspend fun deleteBookmark(
-        token: String?,
-        bookmarkId: Long,
-    ): Result<NetworkResult<Unit>>
+    suspend fun deleteBookmark(bookmarkId: Long): Result<NetworkResult<Unit>>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/BookmarkRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/BookmarkRemoteDataSourceImpl.kt
@@ -24,24 +24,18 @@ class BookmarkRemoteDataSourceImpl(
             errorHandler = errorResponseHandler,
         )
 
-    override suspend fun addBookmark(
-        token: String?,
-        hearitId: Long,
-    ): Result<NetworkResult<BookmarkIdResponse>> =
+    override suspend fun addBookmark(hearitId: Long): Result<NetworkResult<BookmarkIdResponse>> =
         handleApiCall(
-            apiCall = { bookmarkService.postBookmark(token, hearitId) },
+            apiCall = { bookmarkService.postBookmark(hearitId) },
             transform = { response ->
                 response.body() ?: throw IllegalStateException(ERROR_RESPONSE_BODY_NULL_MESSAGE)
             },
             errorHandler = errorResponseHandler,
         )
 
-    override suspend fun deleteBookmark(
-        token: String?,
-        bookmarkId: Long,
-    ): Result<NetworkResult<Unit>> =
+    override suspend fun deleteBookmark(bookmarkId: Long): Result<NetworkResult<Unit>> =
         handleApiCall(
-            apiCall = { bookmarkService.deleteBookmark(token, bookmarkId) },
+            apiCall = { bookmarkService.deleteBookmark(bookmarkId) },
             transform = { },
             errorHandler = errorResponseHandler,
         )

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/BookmarkRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/BookmarkRemoteDataSourceImpl.kt
@@ -13,12 +13,11 @@ class BookmarkRemoteDataSourceImpl(
     private val errorResponseHandler: ErrorResponseHandler,
 ) : BookmarkRemoteDataSource {
     override suspend fun getBookmarks(
-        token: String?,
         page: Int?,
         size: Int?,
     ): Result<NetworkResult<BookmarkResponse>> =
         handleApiCall(
-            apiCall = { bookmarkService.getBookmarks(token, page, size) },
+            apiCall = { bookmarkService.getBookmarks(page, size) },
             transform = { response ->
                 response.body() ?: throw IllegalStateException(ERROR_RESPONSE_BODY_NULL_MESSAGE)
             },

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSource.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSource.kt
@@ -8,15 +8,11 @@ import com.onair.hearit.data.dto.RecommendHearitResponse
 import com.onair.hearit.data.dto.SearchHearitResponse
 
 interface HearitRemoteDataSource {
-    suspend fun getHearit(
-        token: String?,
-        hearitId: Long,
-    ): Result<NetworkResult<HearitResponse>>
+    suspend fun getHearit(hearitId: Long): Result<NetworkResult<HearitResponse>>
 
     suspend fun getRecommendHearits(): Result<NetworkResult<List<RecommendHearitResponse>>>
 
     suspend fun getRandomHearits(
-        token: String?,
         cursorId: Long?,
         size: Int?,
     ): Result<NetworkResult<RandomHearitResponse>>
@@ -27,5 +23,5 @@ interface HearitRemoteDataSource {
         size: Int?,
     ): Result<NetworkResult<SearchHearitResponse>>
 
-    suspend fun getCategoryHearits(token: String?): Result<NetworkResult<List<GroupedCategoryHearitResponse>>>
+    suspend fun getCategoryHearits(): Result<NetworkResult<List<GroupedCategoryHearitResponse>>>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSourceImpl.kt
@@ -15,12 +15,9 @@ class HearitRemoteDataSourceImpl(
     private val hearitService: HearitService,
     private val errorResponseHandler: ErrorResponseHandler,
 ) : HearitRemoteDataSource {
-    override suspend fun getHearit(
-        token: String?,
-        hearitId: Long,
-    ): Result<NetworkResult<HearitResponse>> =
+    override suspend fun getHearit(hearitId: Long): Result<NetworkResult<HearitResponse>> =
         handleApiCall(
-            apiCall = { hearitService.getHearit(token, hearitId) },
+            apiCall = { hearitService.getHearit(hearitId) },
             transform = { response ->
                 response.body() ?: throw IllegalStateException(ERROR_RESPONSE_BODY_NULL_MESSAGE)
             },
@@ -37,12 +34,11 @@ class HearitRemoteDataSourceImpl(
         )
 
     override suspend fun getRandomHearits(
-        token: String?,
         cursorId: Long?,
         size: Int?,
     ): Result<NetworkResult<RandomHearitResponse>> =
         handleApiCall(
-            apiCall = { hearitService.getRandomHearits(token, cursorId, size) },
+            apiCall = { hearitService.getRandomHearits(cursorId, size) },
             transform = { response ->
                 response.body() ?: throw IllegalStateException(ERROR_RESPONSE_BODY_NULL_MESSAGE)
             },
@@ -62,9 +58,9 @@ class HearitRemoteDataSourceImpl(
             errorHandler = errorResponseHandler,
         )
 
-    override suspend fun getCategoryHearits(token: String?): Result<NetworkResult<List<GroupedCategoryHearitResponse>>> =
+    override suspend fun getCategoryHearits(): Result<NetworkResult<List<GroupedCategoryHearitResponse>>> =
         handleApiCall(
-            apiCall = { hearitService.getCategoryHearits(token) },
+            apiCall = { hearitService.getCategoryHearits() },
             transform = { response ->
                 response.body() ?: throw IllegalStateException(ERROR_RESPONSE_BODY_NULL_MESSAGE)
             },

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/MemberRemoteDataSource.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/MemberRemoteDataSource.kt
@@ -4,5 +4,5 @@ import com.onair.hearit.data.datasource.NetworkResult
 import com.onair.hearit.data.dto.UserInfoResponse
 
 interface MemberRemoteDataSource {
-    suspend fun getUserInfo(token: String?): Result<NetworkResult<UserInfoResponse>>
+    suspend fun getUserInfo(): Result<NetworkResult<UserInfoResponse>>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/MemberRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/MemberRemoteDataSourceImpl.kt
@@ -11,9 +11,9 @@ class MemberRemoteDataSourceImpl(
     private val memberService: MemberService,
     private val errorResponseHandler: ErrorResponseHandler,
 ) : MemberRemoteDataSource {
-    override suspend fun getUserInfo(token: String?): Result<NetworkResult<UserInfoResponse>> =
+    override suspend fun getUserInfo(): Result<NetworkResult<UserInfoResponse>> =
         handleApiCall(
-            apiCall = { memberService.getUserInfo(token) },
+            apiCall = { memberService.getUserInfo() },
             transform = { response ->
                 response.body() ?: throw IllegalStateException(ERROR_RESPONSE_BODY_NULL_MESSAGE)
             },

--- a/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
@@ -16,13 +16,7 @@ class BookmarkRepositoryImpl(
             bookmarkResponse.content.map { it.toDomain() }
         }
 
-    override suspend fun addBookmark(
-        token: String?,
-        hearitId: Long,
-    ): Result<Long> = bookmarkDataSource.addBookmark(token, hearitId).mapOrThrowDomain { it.id }
+    override suspend fun addBookmark(hearitId: Long): Result<Long> = bookmarkDataSource.addBookmark(hearitId).mapOrThrowDomain { it.id }
 
-    override suspend fun deleteBookmark(
-        token: String?,
-        bookmarkId: Long,
-    ): Result<Unit> = runCatching { bookmarkDataSource.deleteBookmark(token, bookmarkId) }
+    override suspend fun deleteBookmark(bookmarkId: Long): Result<Unit> = runCatching { bookmarkDataSource.deleteBookmark(bookmarkId) }
 }

--- a/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
@@ -18,5 +18,5 @@ class BookmarkRepositoryImpl(
 
     override suspend fun addBookmark(hearitId: Long): Result<Long> = bookmarkDataSource.addBookmark(hearitId).mapOrThrowDomain { it.id }
 
-    override suspend fun deleteBookmark(bookmarkId: Long): Result<Unit> = runCatching { bookmarkDataSource.deleteBookmark(bookmarkId) }
+    override suspend fun deleteBookmark(bookmarkId: Long): Result<Unit> = bookmarkDataSource.deleteBookmark(bookmarkId).mapOrThrowDomain { }
 }

--- a/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
@@ -9,11 +9,10 @@ class BookmarkRepositoryImpl(
     private val bookmarkDataSource: BookmarkRemoteDataSource,
 ) : BookmarkRepository {
     override suspend fun getBookmarks(
-        token: String?,
         page: Int?,
         size: Int?,
     ): Result<List<Bookmark>> =
-        bookmarkDataSource.getBookmarks(token, page, size).mapOrThrowDomain { bookmarkResponse ->
+        bookmarkDataSource.getBookmarks(page, size).mapOrThrowDomain { bookmarkResponse ->
             bookmarkResponse.content.map { it.toDomain() }
         }
 

--- a/android/app/src/main/java/com/onair/hearit/data/repository/HearitRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/HearitRepositoryImpl.kt
@@ -14,21 +14,18 @@ import com.onair.hearit.domain.repository.HearitRepository
 class HearitRepositoryImpl(
     private val hearitRemoteDataSource: HearitRemoteDataSource,
 ) : HearitRepository {
-    override suspend fun getHearit(
-        token: String?,
-        hearitId: Long,
-    ): Result<SingleHearit> = hearitRemoteDataSource.getHearit(token, hearitId).mapOrThrowDomain { it.toDomain() }
+    override suspend fun getHearit(hearitId: Long): Result<SingleHearit> =
+        hearitRemoteDataSource.getHearit(hearitId).mapOrThrowDomain { it.toDomain() }
 
     override suspend fun getRecommendHearits(): Result<List<RecommendHearit>> =
         hearitRemoteDataSource.getRecommendHearits().mapListOrThrowDomain { it.toDomain() }
 
     override suspend fun getRandomHearits(
-        token: String?,
         cursorId: Long?,
         size: Int?,
     ): Result<CursorResult<RandomHearit>> =
         hearitRemoteDataSource
-            .getRandomHearits(token, cursorId, size)
+            .getRandomHearits(cursorId, size)
             .mapOrThrowDomain { it.toDomain() }
 
     override suspend fun getSearchHearits(
@@ -40,6 +37,6 @@ class HearitRepositoryImpl(
             .getSearchHearits(searchTerm, page, size)
             .mapOrThrowDomain { it.toDomain() }
 
-    override suspend fun getCategoryHearits(token: String?): Result<List<GroupedCategory>> =
-        hearitRemoteDataSource.getCategoryHearits(token).mapListOrThrowDomain { it.toDomain() }
+    override suspend fun getCategoryHearits(): Result<List<GroupedCategory>> =
+        hearitRemoteDataSource.getCategoryHearits().mapListOrThrowDomain { it.toDomain() }
 }

--- a/android/app/src/main/java/com/onair/hearit/data/repository/MemberRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/MemberRepositoryImpl.kt
@@ -8,6 +8,5 @@ import com.onair.hearit.domain.repository.MemberRepository
 class MemberRepositoryImpl(
     private val memberRemoteDataSource: MemberRemoteDataSource,
 ) : MemberRepository {
-    override suspend fun getUserInfo(token: String?): Result<UserInfo> =
-        memberRemoteDataSource.getUserInfo(token).mapOrThrowDomain { it.toDomain() }
+    override suspend fun getUserInfo(): Result<UserInfo> = memberRemoteDataSource.getUserInfo().mapOrThrowDomain { it.toDomain() }
 }

--- a/android/app/src/main/java/com/onair/hearit/di/NetworkProvider.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/NetworkProvider.kt
@@ -27,6 +27,7 @@ object NetworkProvider {
         OkHttpClient
             .Builder()
             .addInterceptor(LoggingInterceptorProvider.provide())
+            .addInterceptor(TokenInterceptorProvider.provide())
             .build()
 
     private val retrofit: Retrofit by lazy {

--- a/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
@@ -1,0 +1,41 @@
+package com.onair.hearit.di
+
+import okhttp3.Interceptor
+
+object TokenInterceptorProvider {
+    const val NO_AUTH_KEY = "No-Auth"
+    const val AUTH_HEADER_NAME = "Authorization"
+
+    private var accessToken: String? = null
+
+    fun provide() =
+        Interceptor { chain ->
+            val originalRequest = chain.request()
+
+            if (originalRequest.header(NO_AUTH_KEY) != null) {
+                val newRequest =
+                    originalRequest
+                        .newBuilder()
+                        .removeHeader(NO_AUTH_KEY)
+                        .build()
+                chain.proceed(newRequest)
+            } else {
+                val token = accessToken
+                val newRequest =
+                    if (token != null) {
+                        originalRequest
+                            .newBuilder()
+                            .addHeader(AUTH_HEADER_NAME, token)
+                            .build()
+                    } else {
+                        originalRequest
+                    }
+                chain.proceed(newRequest)
+            }
+        }
+
+    // 앱에서 토큰 업데이트 시 호출 (예: 로그인/토큰 갱신 후)
+    fun setAccessToken(token: String?) {
+        accessToken = token
+    }
+}

--- a/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
@@ -6,13 +6,13 @@ object TokenInterceptorProvider {
     const val NO_AUTH_KEY = "No-Auth"
     const val AUTH_HEADER_NAME = "Authorization"
 
+    @Volatile
     private var accessToken: String? = null
 
     fun provide(): Interceptor =
         Interceptor { chain ->
             val originalRequest = chain.request()
 
-            // No-Auth 헤더가 있으면 인증 헤더 없이 요청 진행
             if (originalRequest.header(NO_AUTH_KEY) != null) {
                 val newRequest =
                     originalRequest
@@ -22,7 +22,6 @@ object TokenInterceptorProvider {
                 return@Interceptor chain.proceed(newRequest)
             }
 
-            // 토큰이 있으면 Authorization 헤더 추가, 없으면 원본 요청 그대로 진행
             accessToken?.let { token ->
                 val newRequest =
                     originalRequest
@@ -33,7 +32,6 @@ object TokenInterceptorProvider {
             } ?: chain.proceed(originalRequest)
         }
 
-    // 앱에서 토큰 업데이트 시 호출 (예: 로그인/토큰 갱신 후)
     fun setAccessToken(token: String?) {
         accessToken = token
     }

--- a/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
@@ -3,8 +3,9 @@ package com.onair.hearit.di
 import okhttp3.Interceptor
 
 object TokenInterceptorProvider {
-    const val NO_AUTH_KEY = "No-Auth"
-    const val AUTH_HEADER_NAME = "Authorization"
+    private const val NO_AUTH_KEY = "No-Auth"
+    private const val AUTH_HEADER_NAME = "Authorization"
+    private const val BEARER_PREFIX = "Bearer "
 
     @Volatile
     private var accessToken: String? = null
@@ -26,7 +27,7 @@ object TokenInterceptorProvider {
                 val newRequest =
                     originalRequest
                         .newBuilder()
-                        .addHeader(AUTH_HEADER_NAME, "Bearer $token")
+                        .addHeader(AUTH_HEADER_NAME, "$BEARER_PREFIX$token")
                         .build()
                 chain.proceed(newRequest)
             } ?: chain.proceed(originalRequest)

--- a/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
@@ -8,30 +8,29 @@ object TokenInterceptorProvider {
 
     private var accessToken: String? = null
 
-    fun provide() =
+    fun provide(): Interceptor =
         Interceptor { chain ->
             val originalRequest = chain.request()
 
+            // No-Auth 헤더가 있으면 인증 헤더 없이 요청 진행
             if (originalRequest.header(NO_AUTH_KEY) != null) {
                 val newRequest =
                     originalRequest
                         .newBuilder()
                         .removeHeader(NO_AUTH_KEY)
                         .build()
-                chain.proceed(newRequest)
-            } else {
-                val token = accessToken
-                val newRequest =
-                    if (token != null) {
-                        originalRequest
-                            .newBuilder()
-                            .addHeader(AUTH_HEADER_NAME, token)
-                            .build()
-                    } else {
-                        originalRequest
-                    }
-                chain.proceed(newRequest)
+                return@Interceptor chain.proceed(newRequest)
             }
+
+            // 토큰이 있으면 Authorization 헤더 추가, 없으면 원본 요청 그대로 진행
+            accessToken?.let { token ->
+                val newRequest =
+                    originalRequest
+                        .newBuilder()
+                        .addHeader(AUTH_HEADER_NAME, "Bearer $token")
+                        .build()
+                chain.proceed(newRequest)
+            } ?: chain.proceed(originalRequest)
         }
 
     // 앱에서 토큰 업데이트 시 호출 (예: 로그인/토큰 갱신 후)

--- a/android/app/src/main/java/com/onair/hearit/di/UseCaseProvider.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/UseCaseProvider.kt
@@ -8,7 +8,6 @@ import com.onair.hearit.domain.usecase.GetShortsHearitUseCase
 object UseCaseProvider {
     val getHearitUseCase: GetHearitUseCase by lazy {
         GetHearitUseCase(
-            dataStoreRepository = RepositoryProvider.dataStoreRepository,
             hearitRepository = RepositoryProvider.hearitRepository,
             mediaFileRepository = RepositoryProvider.mediaFileRepository,
         )
@@ -16,7 +15,6 @@ object UseCaseProvider {
 
     val getPlaybackInfoUseCase: GetPlaybackInfoUseCase by lazy {
         GetPlaybackInfoUseCase(
-            dataStoreRepository = RepositoryProvider.dataStoreRepository,
             hearitRepository = RepositoryProvider.hearitRepository,
             mediaFileRepository = RepositoryProvider.mediaFileRepository,
             recentHearitRepository = RepositoryProvider.recentHearitRepository,

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/BookmarkRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/BookmarkRepository.kt
@@ -4,7 +4,6 @@ import com.onair.hearit.domain.model.Bookmark
 
 interface BookmarkRepository {
     suspend fun getBookmarks(
-        token: String?,
         page: Int?,
         size: Int?,
     ): Result<List<Bookmark>>

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/BookmarkRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/BookmarkRepository.kt
@@ -8,13 +8,7 @@ interface BookmarkRepository {
         size: Int?,
     ): Result<List<Bookmark>>
 
-    suspend fun addBookmark(
-        token: String?,
-        hearitId: Long,
-    ): Result<Long>
+    suspend fun addBookmark(hearitId: Long): Result<Long>
 
-    suspend fun deleteBookmark(
-        token: String?,
-        bookmarkId: Long,
-    ): Result<Unit>
+    suspend fun deleteBookmark(bookmarkId: Long): Result<Unit>
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/HearitRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/HearitRepository.kt
@@ -9,15 +9,11 @@ import com.onair.hearit.domain.model.SearchedHearit
 import com.onair.hearit.domain.model.SingleHearit
 
 interface HearitRepository {
-    suspend fun getHearit(
-        token: String?,
-        hearitId: Long,
-    ): Result<SingleHearit>
+    suspend fun getHearit(hearitId: Long): Result<SingleHearit>
 
     suspend fun getRecommendHearits(): Result<List<RecommendHearit>>
 
     suspend fun getRandomHearits(
-        token: String?,
         cursorId: Long? = null,
         size: Int? = null,
     ): Result<CursorResult<RandomHearit>>
@@ -28,5 +24,5 @@ interface HearitRepository {
         size: Int? = null,
     ): Result<PageResult<SearchedHearit>>
 
-    suspend fun getCategoryHearits(token: String?): Result<List<GroupedCategory>>
+    suspend fun getCategoryHearits(): Result<List<GroupedCategory>>
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/MemberRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/MemberRepository.kt
@@ -3,5 +3,5 @@ package com.onair.hearit.domain.repository
 import com.onair.hearit.domain.model.UserInfo
 
 interface MemberRepository {
-    suspend fun getUserInfo(token: String?): Result<UserInfo>
+    suspend fun getUserInfo(): Result<UserInfo>
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/usecase/GetHearitUseCase.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/usecase/GetHearitUseCase.kt
@@ -1,22 +1,18 @@
 package com.onair.hearit.domain.usecase
 
 import com.onair.hearit.domain.model.Hearit
-import com.onair.hearit.domain.repository.DataStoreRepository
 import com.onair.hearit.domain.repository.HearitRepository
 import com.onair.hearit.domain.repository.MediaFileRepository
 import com.onair.hearit.domain.toHearit
-import com.onair.hearit.presentation.toBearerToken
 
 class GetHearitUseCase(
-    private val dataStoreRepository: DataStoreRepository,
     private val hearitRepository: HearitRepository,
     private val mediaFileRepository: MediaFileRepository,
 ) {
     suspend operator fun invoke(hearitId: Long): Result<Hearit> =
         runCatching {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
             val hearitInfo =
-                hearitRepository.getHearit(token?.toBearerToken(), hearitId).getOrThrow()
+                hearitRepository.getHearit(hearitId).getOrThrow()
             val audioUrl = mediaFileRepository.getOriginalAudioUrl(hearitId).getOrThrow().url
             val script = mediaFileRepository.getScriptLines(hearitId).getOrThrow()
 

--- a/android/app/src/main/java/com/onair/hearit/domain/usecase/GetPlaybackInfoUseCase.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/usecase/GetPlaybackInfoUseCase.kt
@@ -1,24 +1,20 @@
 package com.onair.hearit.domain.usecase
 
 import com.onair.hearit.domain.model.PlaybackInfo
-import com.onair.hearit.domain.repository.DataStoreRepository
 import com.onair.hearit.domain.repository.HearitRepository
 import com.onair.hearit.domain.repository.MediaFileRepository
 import com.onair.hearit.domain.repository.RecentHearitRepository
 import com.onair.hearit.domain.toPlaybackInfo
-import com.onair.hearit.presentation.toBearerToken
 
 class GetPlaybackInfoUseCase(
-    private val dataStoreRepository: DataStoreRepository,
     private val hearitRepository: HearitRepository,
     private val mediaFileRepository: MediaFileRepository,
     private val recentHearitRepository: RecentHearitRepository,
 ) {
     suspend operator fun invoke(hearitId: Long): Result<PlaybackInfo> =
         runCatching {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
             val hearitInfo =
-                hearitRepository.getHearit(token?.toBearerToken(), hearitId).getOrThrow()
+                hearitRepository.getHearit(hearitId).getOrThrow()
             val audioUrl = mediaFileRepository.getOriginalAudioUrl(hearitId).getOrThrow().url
             val recentHearit = recentHearitRepository.getRecentHearit().getOrThrow()
             val lastPosition = recentHearit?.lastPosition ?: 0L

--- a/android/app/src/main/java/com/onair/hearit/presentation/MainViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/MainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kakao.sdk.user.UserApiClient
 import com.onair.hearit.R
+import com.onair.hearit.di.TokenInterceptorProvider
 import com.onair.hearit.domain.model.RecentHearit
 import com.onair.hearit.domain.repository.AuthRepository
 import com.onair.hearit.domain.repository.DataStoreRepository
@@ -52,6 +53,7 @@ class MainViewModel(
                 _toastMessage.value = R.string.logout_fail
             } else {
                 clearAccessToken()
+                TokenInterceptorProvider.setAccessToken(null)
                 _toastMessage.value = R.string.logout_success
             }
         }

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.onair.hearit.R
-import com.onair.hearit.di.RepositoryProvider.dataStoreRepository
 import com.onair.hearit.domain.UserNotRegisteredException
 import com.onair.hearit.domain.model.Hearit
 import com.onair.hearit.domain.model.RecentHearit
@@ -13,7 +12,6 @@ import com.onair.hearit.domain.repository.BookmarkRepository
 import com.onair.hearit.domain.repository.RecentHearitRepository
 import com.onair.hearit.domain.usecase.GetHearitUseCase
 import com.onair.hearit.presentation.SingleLiveData
-import com.onair.hearit.presentation.toBearerToken
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -50,10 +48,8 @@ class PlayerDetailViewModel(
     private fun deleteBookmark() {
         val id = _bookmarkId.value ?: return
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             bookmarkRepository
-                .deleteBookmark(token?.toBearerToken(), id)
+                .deleteBookmark(id)
                 .onSuccess {
                     _bookmarkId.value = null
                 }.onFailure { throwable ->
@@ -79,10 +75,8 @@ class PlayerDetailViewModel(
 
     private fun addBookmark() {
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             bookmarkRepository
-                .addBookmark(token?.toBearerToken(), hearitId)
+                .addBookmark(hearitId)
                 .onSuccess { bookmarkId ->
                     _bookmarkId.value = bookmarkId
                 }.onFailure { throwable ->

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.onair.hearit.R
-import com.onair.hearit.di.RepositoryProvider.dataStoreRepository
 import com.onair.hearit.domain.UserNotRegisteredException
 import com.onair.hearit.domain.model.CursorInfo
 import com.onair.hearit.domain.model.CursorResult
@@ -16,7 +15,6 @@ import com.onair.hearit.domain.repository.ExploreDataStoreRepository
 import com.onair.hearit.domain.repository.HearitRepository
 import com.onair.hearit.domain.usecase.GetShortsHearitUseCase
 import com.onair.hearit.presentation.SingleLiveData
-import com.onair.hearit.presentation.toBearerToken
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -93,11 +91,9 @@ class ExploreViewModel(
         isLoading = true
 
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             try {
                 val result =
-                    hearitRepository.getRandomHearits(token?.toBearerToken(), cursorId)
+                    hearitRepository.getRandomHearits(cursorId)
                 result
                     .onSuccess { randomItems ->
                         cursorInfo = randomItems.cursorInfo
@@ -121,10 +117,8 @@ class ExploreViewModel(
         onFinished: (bookmarkId: Long?) -> Unit,
     ) {
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             bookmarkRepository
-                .addBookmark(token?.toBearerToken(), hearitId)
+                .addBookmark(hearitId)
                 .onSuccess { newBookmarkId ->
                     updateBookmarkState(hearitId, newBookmarkId)
                     onFinished(newBookmarkId)
@@ -151,10 +145,8 @@ class ExploreViewModel(
         onFinished: (bookmarkId: Long?) -> Unit,
     ) {
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             bookmarkRepository
-                .deleteBookmark(token?.toBearerToken(), bookmarkId)
+                .deleteBookmark(bookmarkId)
                 .onSuccess {
                     updateBookmarkState(hearitId, null)
                     onFinished(bookmarkId)

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -9,16 +9,13 @@ import com.onair.hearit.domain.UserNotRegisteredException
 import com.onair.hearit.domain.model.GroupedCategory
 import com.onair.hearit.domain.model.RecommendHearit
 import com.onair.hearit.domain.model.UserInfo
-import com.onair.hearit.domain.repository.DataStoreRepository
 import com.onair.hearit.domain.repository.HearitRepository
 import com.onair.hearit.domain.repository.MemberRepository
 import com.onair.hearit.presentation.SingleLiveData
-import com.onair.hearit.presentation.toBearerToken
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class HomeViewModel(
-    private val dataStoreRepository: DataStoreRepository,
     private val hearitRepository: HearitRepository,
     private val memberRepository: MemberRepository,
 ) : ViewModel() {
@@ -55,10 +52,8 @@ class HomeViewModel(
         }
 
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             hearitRepository
-                .getCategoryHearits(token?.toBearerToken())
+                .getCategoryHearits()
                 .onSuccess { groupedCategory ->
                     _groupedCategory.value = groupedCategory
                 }.onFailure { throwable ->
@@ -70,10 +65,8 @@ class HomeViewModel(
 
     private fun fetchUserInfo() {
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             memberRepository
-                .getUserInfo(token?.toBearerToken())
+                .getUserInfo()
                 .onSuccess { userInfo ->
                     _userInfo.value = userInfo
                     _isLoggedIn.value = true

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModelFactory.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModelFactory.kt
@@ -7,11 +7,9 @@ import com.onair.hearit.di.RepositoryProvider
 @Suppress("UNCHECKED_CAST")
 class HomeViewModelFactory : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
-        val dataStoreRepository = RepositoryProvider.dataStoreRepository
         val hearitRepository = RepositoryProvider.hearitRepository
         val memberRepository = RepositoryProvider.memberRepository
         return HomeViewModel(
-            dataStoreRepository,
             hearitRepository,
             memberRepository,
         ) as T

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -9,16 +9,13 @@ import com.onair.hearit.domain.UserNotRegisteredException
 import com.onair.hearit.domain.model.Bookmark
 import com.onair.hearit.domain.model.UserInfo
 import com.onair.hearit.domain.repository.BookmarkRepository
-import com.onair.hearit.domain.repository.DataStoreRepository
 import com.onair.hearit.domain.repository.MemberRepository
 import com.onair.hearit.presentation.SingleLiveData
-import com.onair.hearit.presentation.toBearerToken
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class LibraryViewModel(
     private val bookmarkRepository: BookmarkRepository,
-    private val dataStoreRepository: DataStoreRepository,
     private val memberRepository: MemberRepository,
 ) : ViewModel() {
     private val _bookmarks: MutableLiveData<List<Bookmark>> = MutableLiveData()
@@ -64,10 +61,8 @@ class LibraryViewModel(
 
     fun deleteBookmark(bookmarkId: Long) {
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             bookmarkRepository
-                .deleteBookmark(token?.toBearerToken(), bookmarkId)
+                .deleteBookmark(bookmarkId)
                 .onSuccess {
                     _bookmarks.value =
                         _bookmarks.value?.filterNot { it.bookmarkId == bookmarkId }
@@ -79,10 +74,8 @@ class LibraryViewModel(
 
     private fun getUserInfo() {
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             memberRepository
-                .getUserInfo(token?.toBearerToken())
+                .getUserInfo()
                 .onSuccess { userInfo ->
                     _uiState.value = BookmarkUiState.LoggedIn
                     _userInfo.value = userInfo

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -40,10 +40,8 @@ class LibraryViewModel(
 
     fun fetchData(page: Int) {
         viewModelScope.launch {
-            val token = dataStoreRepository.getAccessToken().getOrNull()
-
             bookmarkRepository
-                .getBookmarks(token?.toBearerToken(), page = page, size = null)
+                .getBookmarks(page = page, size = null)
                 .onSuccess {
                     _uiState.value = BookmarkUiState.LoggedIn
                     _bookmarks.value = it

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModelFactory.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModelFactory.kt
@@ -8,11 +8,9 @@ import com.onair.hearit.di.RepositoryProvider
 class LibraryViewModelFactory : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         val bookmarkRepository = RepositoryProvider.bookmarkRepository
-        val dataStoreRepository = RepositoryProvider.dataStoreRepository
         val memberRepository = RepositoryProvider.memberRepository
         return LibraryViewModel(
             bookmarkRepository,
-            dataStoreRepository,
             memberRepository,
         ) as T
     }

--- a/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.onair.hearit.R
+import com.onair.hearit.di.TokenInterceptorProvider
 import com.onair.hearit.domain.repository.AuthRepository
 import com.onair.hearit.domain.repository.DataStoreRepository
 import com.onair.hearit.presentation.SingleLiveData
@@ -27,6 +28,7 @@ class LoginViewModel(
                 .kakaoLogin(accessToken)
                 .onSuccess { appToken ->
                     saveToken(appToken.accessToken, appToken.refreshToken)
+                    TokenInterceptorProvider.setAccessToken(appToken.toString())
                 }.onFailure { throwable ->
                     Timber.w(throwable)
                     _toastMessage.value = R.string.login_toast_kakao_login_fail

--- a/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
@@ -28,7 +28,7 @@ class LoginViewModel(
                 .kakaoLogin(accessToken)
                 .onSuccess { appToken ->
                     saveToken(appToken.accessToken, appToken.refreshToken)
-                    TokenInterceptorProvider.setAccessToken(appToken.toString())
+                    TokenInterceptorProvider.setAccessToken(appToken.accessToken)
                 }.onFailure { throwable ->
                     Timber.w(throwable)
                     _toastMessage.value = R.string.login_toast_kakao_login_fail

--- a/android/app/src/main/java/com/onair/hearit/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/setting/SettingViewModel.kt
@@ -11,7 +11,6 @@ import com.onair.hearit.domain.model.UserInfo
 import com.onair.hearit.domain.repository.DataStoreRepository
 import com.onair.hearit.domain.repository.MemberRepository
 import com.onair.hearit.presentation.SingleLiveData
-import com.onair.hearit.presentation.toBearerToken
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -40,7 +39,7 @@ class SettingViewModel(
             }
 
             memberRepository
-                .getUserInfo(token.toBearerToken())
+                .getUserInfo()
                 .onSuccess { userInfo ->
                     _userInfo.value = userInfo
                 }.onFailure { throwable ->

--- a/android/app/src/main/java/com/onair/hearit/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/splash/SplashViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.onair.hearit.R
+import com.onair.hearit.di.TokenInterceptorProvider
 import com.onair.hearit.domain.UserNotRegisteredException
 import com.onair.hearit.domain.repository.AuthRepository
 import com.onair.hearit.domain.repository.DataStoreRepository
@@ -43,6 +44,7 @@ class SplashViewModel(
             result
                 .onSuccess {
                     _checkToken.value = true
+                    TokenInterceptorProvider.setAccessToken(accessToken)
                 }.onFailure { throwable ->
                     when (throwable) {
                         is UserNotRegisteredException -> {

--- a/android/app/src/test/java/com/onair/hearit/HearitRepositoryImplTest.kt
+++ b/android/app/src/test/java/com/onair/hearit/HearitRepositoryImplTest.kt
@@ -41,10 +41,10 @@ class HearitRepositoryImplTest {
             val mockDto = createFakeHearit(hearitId)
             val expectedDomainModel = mockDto.toDomain()
 
-            coEvery { mockHearitRemoteDataSource.getHearit(null, hearitId) } returns
+            coEvery { mockHearitRemoteDataSource.getHearit(hearitId) } returns
                 Result.success(NetworkResult.Success(mockDto))
 
-            val result = hearitRepository.getHearit(null, hearitId)
+            val result = hearitRepository.getHearit(hearitId)
 
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrNull()).isEqualTo(expectedDomainModel)
@@ -56,10 +56,10 @@ class HearitRepositoryImplTest {
             val hearitId = 1L
             val expectedException = RuntimeException("네트워크 오류")
 
-            coEvery { mockHearitRemoteDataSource.getHearit(null, hearitId) } returns
+            coEvery { mockHearitRemoteDataSource.getHearit(hearitId) } returns
                 Result.failure(expectedException)
 
-            val result = hearitRepository.getHearit(null, hearitId)
+            val result = hearitRepository.getHearit(hearitId)
 
             assertThat(result.isFailure).isTrue()
             assertThat(result.exceptionOrNull()).isEqualTo(expectedException)
@@ -100,10 +100,10 @@ class HearitRepositoryImplTest {
             val mockPageResultDto = createFakeRandomHearit()
             val expectedDomainResult = mockPageResultDto.toDomain()
 
-            coEvery { mockHearitRemoteDataSource.getRandomHearits(null, 1, 10) } returns
+            coEvery { mockHearitRemoteDataSource.getRandomHearits(1, 10) } returns
                 Result.success(NetworkResult.Success(mockPageResultDto))
 
-            val result = hearitRepository.getRandomHearits(null, 1, 10)
+            val result = hearitRepository.getRandomHearits(1, 10)
 
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrNull()).isEqualTo(expectedDomainResult)
@@ -114,10 +114,10 @@ class HearitRepositoryImplTest {
         runTest {
             val expectedException = RuntimeException("랜덤 데이터 오류")
 
-            coEvery { mockHearitRemoteDataSource.getRandomHearits(null, 1, 10) } returns
+            coEvery { mockHearitRemoteDataSource.getRandomHearits(1, 10) } returns
                 Result.failure(expectedException)
 
-            val result = hearitRepository.getRandomHearits(null, 1, 10)
+            val result = hearitRepository.getRandomHearits(1, 10)
 
             assertThat(result.isFailure).isTrue()
             assertThat(result.exceptionOrNull()).isEqualTo(expectedException)
@@ -160,10 +160,10 @@ class HearitRepositoryImplTest {
             val mockDtoList = listOf(createGroupedCategory())
             val expectedDomainList = mockDtoList.map { it.toDomain() }
 
-            coEvery { mockHearitRemoteDataSource.getCategoryHearits(null) } returns
+            coEvery { mockHearitRemoteDataSource.getCategoryHearits() } returns
                 Result.success(NetworkResult.Success(mockDtoList))
 
-            val result = hearitRepository.getCategoryHearits(null)
+            val result = hearitRepository.getCategoryHearits()
 
             assertThat(result.isSuccess).isTrue()
             assertThat(result.getOrNull()).isEqualTo(expectedDomainList)
@@ -174,10 +174,10 @@ class HearitRepositoryImplTest {
         runTest {
             val expectedException = RuntimeException("카테고리 오류")
 
-            coEvery { mockHearitRemoteDataSource.getCategoryHearits(null) } returns
+            coEvery { mockHearitRemoteDataSource.getCategoryHearits() } returns
                 Result.failure(expectedException)
 
-            val result = hearitRepository.getCategoryHearits(null)
+            val result = hearitRepository.getCategoryHearits()
 
             assertThat(result.isFailure).isTrue()
             assertThat(result.exceptionOrNull()).isEqualTo(expectedException)


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 토큰 interceptor에서 넣도록 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#341 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 요청에 자동으로 인증 토큰을 적용하는 인터셉터와 공개 요청용 No-Auth 헤더 지원을 추가했습니다.

* **개선사항**
  * 북마크·헤어릿·회원 관련 API 호출에서 토큰 전달이 내부로 통합되어 호출부가 간결해졌습니다.
  * 로그인·토큰 검증·로그아웃 시 토큰 상태가 즉시 반영되어 세션 동기화가 향상되었습니다.

* **테스트**
  * 관련 단위테스트가 변경된 호출 방식에 맞춰 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->