### PR TITLE
[AN] Merge 'develop-an' into 'develop'

### DIFF
--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Upload a Build APK Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hearit-debug.apk
-          path: android/app/build/outputs/apk/debug/hearit-debug.apk
+          name: hEARit-debug.apk
+          path: android/app/build/outputs/apk/debug/hEARit-debug.apk
           overwrite: 'true'
 
       - name: Upload APK to Firebase App Distribution
@@ -58,4 +58,4 @@ jobs:
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: hearit-test
           releaseNotesFile: android/app/whatsnew/whatsnew-ko-KR
-          file: android/app/build/outputs/apk/debug/hearit-debug.apk
+          file: android/app/build/outputs/apk/debug/hEARit-debug.apk

--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Upload a Build APK Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hearit-debug.apk
-          path: android/app/build/outputs/apk/debug/hearit-debug.apk
+          name: app-debug.apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk
           overwrite: 'true'
 
       - name: Upload APK to Firebase App Distribution
@@ -55,4 +55,4 @@ jobs:
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: hearit-test
           releaseNotesFile: android/app/whatsnew/whatsnew-ko-KR
-          file: android/app/build/outputs/apk/debug/hearit-debug.apk
+          file: android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Upload a Build APK Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-debug.apk
-          path: android/app/build/outputs/apk/debug/app-debug.apk
+          name: hearit-debug.apk
+          path: android/app/build/outputs/apk/debug/hearit-debug.apk
           overwrite: 'true'
 
       - name: Upload APK to Firebase App Distribution
@@ -58,4 +58,4 @@ jobs:
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: hearit-test
           releaseNotesFile: android/app/whatsnew/whatsnew-ko-KR
-          file: android/app/build/outputs/apk/debug/app-debug.apk
+          file: android/app/build/outputs/apk/debug/hearit-debug.apk

--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -39,7 +39,10 @@ jobs:
           echo "$GOOGLE_SERVICES_JSON" > ./app/google-services.json
 
       - name: Build Debug apk
-        run: ./gradlew assembleDebug
+        run: ./gradlew clean assembleDebug
+
+      - name: Check APK files
+        run: ls -l android/app/build/outputs/apk/debug/
 
       - name: Upload a Build APK Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -38,24 +38,24 @@ jobs:
         run:
           echo "$GOOGLE_SERVICES_JSON" > ./app/google-services.json
 
-      - name: Build Debug apk
-        run: ./gradlew clean assembleDebug
-
-      - name: Check APK files
-        run: ls -l android/app/build/outputs/apk/debug/
-
-      - name: Upload a Build APK Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: hEARit-debug.apk
-          path: android/app/build/outputs/apk/debug/hEARit-debug.apk
-          overwrite: 'true'
-
-      - name: Upload APK to Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@v1.7.1
-        with:
-          appId: ${{ secrets.FIREBASE_APP_ID }}
-          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
-          groups: hearit-test
-          releaseNotesFile: android/app/whatsnew/whatsnew-ko-KR
-          file: android/app/build/outputs/apk/debug/hEARit-debug.apk
+#      - name: Build Debug apk
+#        run: ./gradlew clean assembleDebug
+#
+#      - name: Check APK files
+#        run: ls -l android/app/build/outputs/apk/debug/
+#
+#      - name: Upload a Build APK Artifact
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: hEARit-debug.apk
+#          path: android/app/build/outputs/apk/debug/hEARit-debug.apk
+#          overwrite: 'true'
+#
+#      - name: Upload APK to Firebase App Distribution
+#        uses: wzieba/Firebase-Distribution-Github-Action@v1.7.1
+#        with:
+#          appId: ${{ secrets.FIREBASE_APP_ID }}
+#          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+#          groups: hearit-test
+#          releaseNotesFile: android/app/whatsnew/whatsnew-ko-KR
+#          file: android/app/build/outputs/apk/debug/hEARit-debug.apk

--- a/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.onair.hearit.data.repository
 
-import com.onair.hearit.data.datasource.local.PreferencesLocalDataSource
 import com.onair.hearit.data.datasource.remote.BookmarkRemoteDataSource
 import com.onair.hearit.data.mapper.toDomain
 import com.onair.hearit.domain.model.Bookmark
@@ -8,7 +7,6 @@ import com.onair.hearit.domain.repository.BookmarkRepository
 
 class BookmarkRepositoryImpl(
     private val bookmarkDataSource: BookmarkRemoteDataSource,
-    private val preferencesLocalDataSource: PreferencesLocalDataSource,
 ) : BookmarkRepository {
     override suspend fun getBookmarks(
         page: Int?,

--- a/android/app/src/main/java/com/onair/hearit/di/RepositoryProvider.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/RepositoryProvider.kt
@@ -37,7 +37,6 @@ object RepositoryProvider {
     val bookmarkRepository: BookmarkRepository by lazy {
         BookmarkRepositoryImpl(
             bookmarkDataSource = DataSourceProvider.bookmarkRemoteDataSource,
-            preferencesLocalDataSource = DataSourceProvider.preferencesLocalDataSource,
         )
     }
 


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능: 해당 없음
- 리팩터링
  - 북마크 저장소의 내부 의존성을 간소화하여 구성과 초기화를 정리했습니다. 북마크 조회/추가/삭제 동작은 기존과 동일하게 유지됩니다.
- 작업(Chores)
  - 의존성 주입 구성을 단순화해 생성자 호출을 정리했습니다.
  - CI 설정에 빌드·아티팩트 관련 단계가 주석으로 정리되어 배포 스크립트 참조가 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->