### PR TITLE
[AN] bug: 하단 재생바 및 서비스 관련 오류 수정

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
@@ -180,6 +180,7 @@ class BottomPlayerView
                     events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED) ||
                     events.contains(Player.EVENT_IS_PLAYING_CHANGED)
                 ) {
+                    updateTitle(player)
                     updatePlayPauseButton(player)
                     updateProgress()
                 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
@@ -84,7 +84,22 @@ class BottomPlayerView
             player?.let {
                 updateTimeline(it)
                 updatePlayPauseButton(it)
+                updateTitle(it)
             }
+        }
+
+        private fun updateTitle(player: Player) {
+            val title =
+                listOf(
+                    player.currentMediaItem
+                        ?.mediaMetadata
+                        ?.title
+                        ?.toString(),
+                    player.mediaMetadata.title?.toString(),
+                    player.currentMediaItem?.mediaId,
+                ).firstOrNull { !it.isNullOrBlank() } ?: ""
+
+            setTitle(title)
         }
 
         private fun updateTimeline(player: Player) {
@@ -101,16 +116,16 @@ class BottomPlayerView
 
         private fun updateProgress() {
             if (!isAttachedToWindow) return
-            val p = player ?: return
+            val currentPlayer = player ?: return
 
             removeCallbacks(progressRunnable)
 
-            if (p.playbackState == Player.STATE_READY) {
-                binding.exoProgress.setPosition(p.currentPosition)
-                binding.exoProgress.setBufferedPosition(p.bufferedPosition)
+            if (currentPlayer.playbackState == Player.STATE_READY) {
+                binding.exoProgress.setPosition(currentPlayer.currentPosition)
+                binding.exoProgress.setBufferedPosition(currentPlayer.bufferedPosition)
             }
 
-            if (p.playWhenReady && p.playbackState == Player.STATE_READY) {
+            if (currentPlayer.playWhenReady && currentPlayer.playbackState == Player.STATE_READY) {
                 postDelayed(progressRunnable, binding.exoProgress.preferredUpdateDelay)
             }
         }
@@ -152,11 +167,11 @@ class BottomPlayerView
                 player: Player,
                 events: Player.Events,
             ) {
-                if (events.contains(Player.EVENT_MEDIA_METADATA_CHANGED)) {
-                    player.mediaMetadata.title
-                        ?.toString()
-                        ?.takeIf { it.isNotBlank() }
-                        ?.let { setTitle(it) }
+                if (events.contains(Player.EVENT_MEDIA_METADATA_CHANGED) ||
+                    events.contains(Player.EVENT_MEDIA_ITEM_TRANSITION) ||
+                    events.contains(Player.EVENT_TIMELINE_CHANGED)
+                ) {
+                    updateTitle(player)
                 }
                 if (events.contains(Player.EVENT_TIMELINE_CHANGED)) {
                     updateTimeline(player)

--- a/android/app/src/main/java/com/onair/hearit/presentation/MainActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/MainActivity.kt
@@ -66,15 +66,10 @@ class MainActivity :
         setupWindowInsets()
         setupNavigation()
         setupDrawer()
+        attachController()
         observeViewModel()
         showFragment(HomeFragment())
         setupBottomControllerClick()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        attachController()
-        setPlayerControlViewVisibility()
     }
 
     private fun setupBackPressHandler() {
@@ -150,7 +145,11 @@ class MainActivity :
         binding.layoutDrawer.tvDrawerPrivacyPolicy.setOnClickListener { openUrl(PRIVACY_POLICY_URL) }
         binding.layoutDrawer.tvDrawerTermsOfUse.setOnClickListener { openUrl(TERMS_OF_USE_URL) }
         binding.layoutDrawer.tvDrawerLogin.setOnClickListener { navigateToLogin() }
-        binding.layoutDrawer.tvDrawerLogout.setOnClickListener { mainViewModel.performLogout() }
+        binding.layoutDrawer.tvDrawerLogout.setOnClickListener {
+            val stopIntent = PlaybackService.stopIntent(this)
+            stopService(stopIntent)
+            mainViewModel.performLogout()
+        }
         binding.layoutDrawer.tvDrawerWithdrawal.setOnClickListener { confirmAndWithdraw() }
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
@@ -165,8 +165,6 @@ class PlayerDetailActivity :
             val playingId = controller.currentMediaItem?.mediaId?.toLongOrNull()
             val isDifferentHearit = playingId != hearitId
 
-            binding.hearit?.let { handlePlayback(it) }
-
             if (isDifferentHearit) {
                 controller.addListener(
                     object : Player.Listener {

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
@@ -165,6 +165,8 @@ class PlayerDetailActivity :
             val playingId = controller.currentMediaItem?.mediaId?.toLongOrNull()
             val isDifferentHearit = playingId != hearitId
 
+            binding.hearit?.let { handlePlayback(it) }
+
             if (isDifferentHearit) {
                 controller.addListener(
                     object : Player.Listener {
@@ -324,7 +326,7 @@ class PlayerDetailActivity :
                 hearitId = hearitId,
                 startPosition = startPosition,
             )
-        startService(serviceIntent)
+        startForegroundService(serviceIntent)
     }
 
     private fun navigateToLogin() {

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -237,7 +237,7 @@ class ExploreFragment :
         startActivity(intent)
 
         // PlaybackService 종료
-        requireContext().startService(PlaybackService.stopIntent(requireContext()))
+        requireContext().stopService(PlaybackService.stopIntent(requireContext()))
 
         // 현재 프래그먼트 종료
         parentFragmentManager

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -4,7 +4,6 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ObjectAnimator
 import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -46,13 +45,8 @@ class ExploreFragment :
     private val snapHelper = PagerSnapHelper()
     private var isFirstLoad = true
 
-    private val animator: ObjectAnimator by lazy {
-        ObjectAnimator.ofFloat(binding.rvExplore, "translationY", 0f, -100f, 0f).apply {
-            duration = 1300
-            repeatCount = 1
-            repeatMode = ObjectAnimator.RESTART
-        }
-    }
+    private var animator: ObjectAnimator? = null
+    private var playbackListener: Player.Listener? = null
 
     private val playerDetailLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -95,15 +89,12 @@ class ExploreFragment :
 
         (activity as? PlayerControllerView)?.pause()
 
-        player.addListener(
+        playbackListener =
             object : Player.Listener {
                 override fun onPlaybackStateChanged(state: Int) {
-                    if (state == Player.STATE_ENDED) {
-                        scrollToNextItem()
-                    }
+                    if (state == Player.STATE_ENDED) scrollToNextItem()
                 }
-            },
-        )
+            }.also { player.addListener(it) }
     }
 
     override fun onResume() {
@@ -198,17 +189,20 @@ class ExploreFragment :
 
     private fun startSwipeAnimation() {
         binding.lavExploreSwipeUp.visibility = View.VISIBLE
-
-        animator.addListener(
-            object : AnimatorListenerAdapter() {
-                override fun onAnimationEnd(animation: Animator) {
-                    super.onAnimationEnd(animation)
-                    binding.lavExploreSwipeUp.visibility = View.INVISIBLE
-                }
-            },
-        )
-
-        animator.start()
+        animator =
+            ObjectAnimator.ofFloat(binding.rvExplore, "translationY", 0f, -100f, 0f).apply {
+                duration = 1300
+                repeatCount = 1
+                repeatMode = ObjectAnimator.RESTART
+                addListener(
+                    object : AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: Animator) {
+                            binding.lavExploreSwipeUp.visibility = View.INVISIBLE
+                        }
+                    },
+                )
+                start()
+            }
     }
 
     private fun checkAndLoadNextPage(position: Int) {
@@ -242,9 +236,8 @@ class ExploreFragment :
         val intent = LoginActivity.newIntent(requireContext())
         startActivity(intent)
 
-        // PlaybackService 종료 (선택)
-        val serviceIntent = Intent(requireContext(), PlaybackService::class.java)
-        requireContext().stopService(serviceIntent)
+        // PlaybackService 종료
+        requireContext().startService(PlaybackService.stopIntent(requireContext()))
 
         // 현재 프래그먼트 종료
         parentFragmentManager
@@ -300,7 +293,18 @@ class ExploreFragment :
 
     override fun onDestroyView() {
         super.onDestroyView()
-        animator.end()
+
+        playbackListener?.let { player.removeListener(it) }
+        playbackListener = null
+
+        animator?.cancel()
+        animator?.removeAllListeners()
+        animator?.setTarget(null)
+
+        binding.rvExplore.clearOnScrollListeners()
+        snapHelper.attachToRecyclerView(null)
+        binding.rvExplore.adapter = null
+
         _binding = null
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -59,7 +59,7 @@ class HomeViewModel(
                 _groupedCategory.value = groupedCategoryResult.getOrThrow()
                 _isLoading.value = false
             } else {
-                _isLoading.value = false
+                _isLoading.value = true
                 if (recommendHearitsResult.isFailure) {
                     _toastMessage.value =
                         R.string.home_toast_recommend_load_fail

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
@@ -22,14 +22,14 @@ class PlaybackService : MediaSessionService() {
     private lateinit var player: ExoPlayer
     private lateinit var mediaSession: MediaSession
     private lateinit var stateSaver: PlaybackStateSaver
-    private lateinit var notificationManager: NotificationManager
+    private lateinit var playerNotificationManager: PlayerNotificationManager
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
     private var isServiceStarted = false
 
     override fun onCreate() {
         super.onCreate()
-        notificationManager = NotificationManager(this)
+        playerNotificationManager = PlayerNotificationManager(this)
         initializePlayer()
         initializeMediaSession()
         stateSaver = PlaybackStateSaver(player, serviceScope, this)
@@ -119,7 +119,7 @@ class PlaybackService : MediaSessionService() {
 
     private fun initializeAndStartForeground() {
         if (!isServiceStarted) {
-            val notification = notificationManager.buildForegroundNotification()
+            val notification = playerNotificationManager.buildForegroundNotification()
             startForeground(NOTIFICATION_ID, notification)
             isServiceStarted = true
         }

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
@@ -32,30 +32,45 @@ class PlaybackService : MediaSessionService() {
         notificationManager = NotificationManager(this)
         initializePlayer()
         initializeMediaSession()
-        initializeAndStartForeground()
-        stateSaver = PlaybackStateSaver(player, serviceScope)
+        stateSaver = PlaybackStateSaver(player, serviceScope, this)
         player.addListener(stateSaver.listener)
     }
 
-    // startService나 startForegroundService와 같은 메서드를 사용해서, 서비스가 명시적으로 시작되는 경우,
+    // startForegroundService와 같은 메서드를 사용해서, 서비스가 명시적으로 시작되는 경우,
     // 외부 컴포넌트가 서비스를 시작하도록 요청할 때 호출됨
     override fun onStartCommand(
         intent: Intent?,
         flags: Int,
         startId: Int,
     ): Int {
+        if (intent?.action == ACTION_STOP_SERVICE) {
+            runCatching {
+                player.pause()
+                player.clearMediaItems()
+            }
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
         super.onStartCommand(intent, flags, startId)
+
         val audioUrl = intent?.getStringExtra(EXTRA_AUDIO_URL)
         val title = intent?.getStringExtra(EXTRA_TITLE) ?: "hearit"
         val hearitId = intent?.getLongExtra(EXTRA_HEARIT_ID, -1L) ?: -1L
         val startPosition = intent?.getLongExtra(EXTRA_START_POSITION, 0L) ?: 0L
 
-        if (!audioUrl.isNullOrEmpty() && hearitId != -1L) {
-            player.setMediaItem(createMediaItem(audioUrl, title, hearitId))
-            player.prepare()
-            player.seekTo(startPosition.coerceAtLeast(0L))
-            player.play()
+        if (audioUrl.isNullOrEmpty() || hearitId == -1L) {
+            stopSelf()
+            return START_NOT_STICKY
         }
+
+        initializeAndStartForeground()
+
+        val item = createMediaItem(audioUrl, title, hearitId)
+        player.setMediaItems(listOf(item), 0, startPosition.coerceAtLeast(0L))
+        player.prepare()
+        player.play()
+
         return START_STICKY
     }
 
@@ -103,10 +118,11 @@ class PlaybackService : MediaSessionService() {
             ).build()
 
     private fun initializeAndStartForeground() {
-        if (isServiceStarted) return
-        val notification = notificationManager.buildForegroundNotification()
-        startForeground(NOTIFICATION_ID, notification)
-        isServiceStarted = true
+        if (!isServiceStarted) {
+            val notification = notificationManager.buildForegroundNotification()
+            startForeground(NOTIFICATION_ID, notification)
+            isServiceStarted = true
+        }
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession = mediaSession
@@ -128,6 +144,8 @@ class PlaybackService : MediaSessionService() {
         private const val EXTRA_HEARIT_ID = "HEARIT_ID"
         private const val EXTRA_START_POSITION = "START_POSITION"
 
+        const val ACTION_STOP_SERVICE = "hearit.ACTION_STOP_SERVICE"
+
         fun newIntent(
             context: Context,
             audioUrl: String,
@@ -140,5 +158,10 @@ class PlaybackService : MediaSessionService() {
             putExtra(EXTRA_HEARIT_ID, hearitId)
             putExtra(EXTRA_START_POSITION, startPosition)
         }
+
+        fun stopIntent(context: Context) =
+            Intent(context, PlaybackService::class.java).apply {
+                action = ACTION_STOP_SERVICE
+            }
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
@@ -53,6 +53,7 @@ class PlaybackService : MediaSessionService() {
         }
 
         super.onStartCommand(intent, flags, startId)
+        initializeAndStartForeground()
 
         val audioUrl = intent?.getStringExtra(EXTRA_AUDIO_URL)
         val title = intent?.getStringExtra(EXTRA_TITLE) ?: "hearit"
@@ -63,8 +64,6 @@ class PlaybackService : MediaSessionService() {
             stopSelf()
             return START_NOT_STICKY
         }
-
-        initializeAndStartForeground()
 
         val item = createMediaItem(audioUrl, title, hearitId)
         player.setMediaItems(listOf(item), 0, startPosition.coerceAtLeast(0L))

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackStateSaver.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackStateSaver.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withContext
 class PlaybackStateSaver(
     private val player: Player,
     private val serviceScope: CoroutineScope,
-    private val service: PlaybackService,
+    private var service: PlaybackService?,
 ) {
     private var saveJob: Job? = null
 
@@ -43,7 +43,7 @@ class PlaybackStateSaver(
             override fun onPlaybackStateChanged(state: Int) {
                 if (state == Player.STATE_ENDED) {
                     stopSavingPosition(finished = true)
-                    service.stopSelf()
+                    service?.stopSelf()
                 }
             }
 
@@ -80,7 +80,9 @@ class PlaybackStateSaver(
 
     fun release() {
         saveJob?.cancel()
+        service?.let { player.removeListener(listener) }
         savePlaybackPosition()
+        service = null
     }
 
     @OptIn(UnstableApi::class)

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackStateSaver.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackStateSaver.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.withContext
 class PlaybackStateSaver(
     private val player: Player,
     private val serviceScope: CoroutineScope,
+    private val service: PlaybackService,
 ) {
     private var saveJob: Job? = null
 
@@ -42,6 +43,7 @@ class PlaybackStateSaver(
             override fun onPlaybackStateChanged(state: Int) {
                 if (state == Player.STATE_ENDED) {
                     stopSavingPosition(finished = true)
+                    service.stopSelf()
                 }
             }
 

--- a/android/app/src/main/java/com/onair/hearit/service/PlayerNotificationManager.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlayerNotificationManager.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import androidx.core.app.NotificationCompat
 import com.onair.hearit.R
 
-class NotificationManager(
+class PlayerNotificationManager(
     private val context: Context,
 ) {
     private val notificationManager: NotificationManager =

--- a/android/app/src/main/res/layout/item_home_skeleton.xml
+++ b/android/app/src/main/res/layout/item_home_skeleton.xml
@@ -19,7 +19,6 @@
             android:layout_marginStart="20dp"
             android:layout_marginTop="16dp"
             android:text="@string/app_name"
-            android:textSize="28sp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 특정 상황에서 하단 재생바의 제목이 제대로 UI에 표시나지 않는 오류 발견
- Crashlytics에서 playbackservice 관련 오류 발생
- 로그아웃 시에 서비스도 동시에 멈추도록 구현
- ExploreFragment 내에서 발생하는 메모리 릭 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#356 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새 기능
  - 로그아웃 시 재생 완전 종료 버튼/동작 지원으로 세션 정리 향상.
- 버그 수정
  - 하단 플레이어가 올바른 트랙 제목을 더 안정적으로 표시·갱신.
  - 앱 시작 시 재생 컨트롤 연결 시점 개선으로 초기 제어 신뢰성 향상.
  - 포그라운드 재생 시작 및 알림 동작 안정화.
  - 재생 종료 시 서비스가 자동 종료되어 배터리 소모 감소.
  - 탐색 화면 스와이프 힌트 애니메이션 및 리스너 정리로 끊김·누수 완화.
  - 끝에 가까울 때 다음 콘텐츠 로드가 더 민첩하게 동작.
- 스타일
  - 홈 스켈레톤 로고 텍스트 크기 일관성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->