### PR TITLE
[AN] feat: 스크립트 클릭 시 재생 위치 이동 기능 구현

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptAdapter.kt
@@ -7,6 +7,7 @@ import com.onair.hearit.domain.model.ScriptLine
 
 class ScriptAdapter : ListAdapter<ScriptLine, ScriptViewHolder>(DiffCallback) {
     private var highlightedId: Long? = null
+    var onItemClick: ((ScriptLine) -> Unit)? = null
 
     fun highlightScriptLine(id: Long?) {
         if (highlightedId == id) return
@@ -32,6 +33,10 @@ class ScriptAdapter : ListAdapter<ScriptLine, ScriptViewHolder>(DiffCallback) {
     ) {
         val item = getItem(position)
         holder.bind(item, item.id == highlightedId)
+
+        holder.itemView.setOnClickListener {
+            onItemClick?.invoke(item)
+        }
     }
 
     companion object {

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptAdapter.kt
@@ -5,9 +5,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.onair.hearit.domain.model.ScriptLine
 
-class ScriptAdapter : ListAdapter<ScriptLine, ScriptViewHolder>(DiffCallback) {
+class ScriptAdapter(
+    private val onItemClick: (ScriptLine) -> Unit,
+) : ListAdapter<ScriptLine, ScriptViewHolder>(DiffCallback) {
     private var highlightedId: Long? = null
-    var onItemClick: ((ScriptLine) -> Unit)? = null
 
     fun highlightScriptLine(id: Long?) {
         if (highlightedId == id) return
@@ -35,7 +36,7 @@ class ScriptAdapter : ListAdapter<ScriptLine, ScriptViewHolder>(DiffCallback) {
         holder.bind(item, item.id == highlightedId)
 
         holder.itemView.setOnClickListener {
-            onItemClick?.invoke(item)
+            onItemClick.invoke(item)
         }
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
@@ -188,7 +188,7 @@ class ScriptFragment : Fragment() {
 
     private fun startScriptSync(controller: Player) {
         scriptSyncJob =
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 while (isActive) {
                     val position = controller.currentPosition
                     val currentItem =
@@ -205,11 +205,14 @@ class ScriptFragment : Fragment() {
                     if (currentItem != null) adapter.highlightScriptLine(currentItem.id)
 
                     if (!isUserScrolling && currentItem != null) {
-                        val centerOffset = binding.rvScript.height / 2 - itemHeightPx / 2
-                        (binding.rvScript.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(
-                            currentIndex,
-                            centerOffset,
-                        )
+                        val scriptHeight = binding.rvScript.height
+                        if (scriptHeight > 0) {
+                            val centerOffset = binding.rvScript.height / 2 - itemHeightPx / 2
+                            (binding.rvScript.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(
+                                currentIndex,
+                                centerOffset,
+                            )
+                        }
                     }
                     delay(updateInterval)
                 }
@@ -245,6 +248,7 @@ class ScriptFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         scriptSyncJob?.cancel()
+        binding.playerView.player = null
         mediaController?.release()
         _binding = null
     }

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
@@ -43,7 +43,11 @@ class ScriptFragment : Fragment() {
     private var scriptSyncJob: Job? = null
     private var mediaController: MediaController? = null
 
-    private val adapter: ScriptAdapter by lazy { ScriptAdapter() }
+    private val adapter: ScriptAdapter by lazy {
+        ScriptAdapter({ item ->
+            mediaController?.seekTo(item.start)
+        })
+    }
 
     private val hearitId: Long by lazy {
         requireArguments().getLong(HEARIT_ID)
@@ -90,10 +94,6 @@ class ScriptFragment : Fragment() {
 
     private fun setupRecyclerView() {
         binding.rvScript.adapter = adapter
-
-        adapter.onItemClick = { item ->
-            mediaController?.seekTo(item.start)
-        }
 
         binding.rvScript.addOnScrollListener(
             object : RecyclerView.OnScrollListener() {

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
@@ -40,8 +40,7 @@ class ScriptFragment : Fragment() {
     private var lastUserScrollTime = 0L
 
     private var scriptSyncJob: Job? = null
-
-    private lateinit var mediaController: MediaController
+    private var mediaController: MediaController? = null
 
     private val adapter by lazy { ScriptAdapter() }
 
@@ -168,10 +167,12 @@ class ScriptFragment : Fragment() {
             mediaController =
                 MediaController.Builder(requireContext(), sessionToken).buildAsync().await()
 
-            binding.playerView.player = mediaController
-            binding.baseController.setPlayer(mediaController)
+            mediaController?.let { controller ->
+                binding.playerView.player = controller
+                binding.baseController.setPlayer(controller)
 
-            startScriptSync(mediaController)
+                startScriptSync(controller)
+            }
         }
     }
 
@@ -234,9 +235,7 @@ class ScriptFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         scriptSyncJob?.cancel()
-        if (::mediaController.isInitialized) {
-            mediaController.release()
-        }
+        mediaController?.release()
         _binding = null
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
@@ -3,8 +3,6 @@ package com.onair.hearit.presentation.detail.script
 import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -28,6 +26,9 @@ import com.onair.hearit.presentation.detail.PlayerDetailViewModel
 import com.onair.hearit.presentation.detail.PlayerDetailViewModelFactory
 import com.onair.hearit.presentation.login.LoginActivity
 import com.onair.hearit.service.PlaybackService
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 class ScriptFragment : Fragment() {
@@ -38,8 +39,9 @@ class ScriptFragment : Fragment() {
     private var isUserScrolling = false
     private var lastUserScrollTime = 0L
 
+    private var scriptSyncJob: Job? = null
+
     private lateinit var mediaController: MediaController
-    private lateinit var updateRunnable: Runnable
 
     private val adapter by lazy { ScriptAdapter() }
 
@@ -50,7 +52,6 @@ class ScriptFragment : Fragment() {
         PlayerDetailViewModelFactory(hearitId)
     }
 
-    private val handler = Handler(Looper.getMainLooper())
     private val updateInterval = 300L
 
     private val itemHeightPx by lazy {
@@ -175,42 +176,33 @@ class ScriptFragment : Fragment() {
     }
 
     private fun startScriptSync(controller: Player) {
-        updateRunnable =
-            object : Runnable {
-                override fun run() {
-                    val now = System.currentTimeMillis()
-
-                    val pos = controller.currentPosition
+        scriptSyncJob =
+            lifecycleScope.launch {
+                while (isActive) {
+                    val position = controller.currentPosition
                     val currentItem =
-                        adapter.currentList.firstOrNull { pos in it.start until it.end }
+                        adapter.currentList.firstOrNull { position in it.start until it.end }
                     val currentIndex = adapter.currentList.indexOf(currentItem)
 
-                    // 사용자가 스크롤을 멈춘 시점을 체크함
-                    // 사용자가 스크롤을 멈춤 + 하이라이트 부분을 보고 있을 때 3초 후에 다시 포커싱함
+                    val now = System.currentTimeMillis()
+
                     if (isUserScrolling) {
                         val isVisible = isItemVisible(currentIndex)
-
-                        if (now - lastUserScrollTime > 3000L && isVisible) {
-                            isUserScrolling = false
-                        }
+                        if (now - lastUserScrollTime > 3000L && isVisible) isUserScrolling = false
                     }
 
-                    // 하이라이트는 항상 진행하도록 함
-                    if (currentItem != null) {
-                        adapter.highlightScriptLine(currentItem.id)
-                    }
+                    if (currentItem != null) adapter.highlightScriptLine(currentItem.id)
 
-                    // 스크롤 이동은 사용자가 스크롤 중이 아닐 때만
                     if (!isUserScrolling && currentItem != null) {
                         val centerOffset = binding.rvScript.height / 2 - itemHeightPx / 2
-                        (binding.rvScript.layoutManager as LinearLayoutManager)
-                            .scrollToPositionWithOffset(currentIndex, centerOffset)
+                        (binding.rvScript.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(
+                            currentIndex,
+                            centerOffset,
+                        )
                     }
-
-                    handler.postDelayed(this, updateInterval)
+                    delay(updateInterval)
                 }
             }
-        handler.post(updateRunnable)
     }
 
     private fun isItemVisible(position: Int): Boolean {
@@ -241,7 +233,7 @@ class ScriptFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        handler.removeCallbacks(updateRunnable)
+        scriptSyncJob?.cancel()
         if (::mediaController.isInitialized) {
             mediaController.release()
         }

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
@@ -3,6 +3,7 @@ package com.onair.hearit.presentation.detail.script
 import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -53,9 +54,13 @@ class ScriptFragment : Fragment() {
 
     private val updateInterval = 300L
 
-    private val itemHeightPx by lazy {
-        val scale = resources.displayMetrics.density
-        (16 * scale + 0.5f).toInt()
+    private val itemHeightPx: Int by lazy {
+        TypedValue
+            .applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                16f,
+                resources.displayMetrics,
+            ).toInt()
     }
 
     override fun onCreateView(

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
@@ -3,7 +3,6 @@ package com.onair.hearit.presentation.detail.script
 import android.content.ComponentName
 import android.content.Intent
 import android.os.Bundle
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -25,6 +24,7 @@ import com.onair.hearit.presentation.LoginRequiredDialogFragment
 import com.onair.hearit.presentation.detail.PlayerDetailActivity.Companion.LOGIN_REQUIRED_DIALOG_ID
 import com.onair.hearit.presentation.detail.PlayerDetailViewModel
 import com.onair.hearit.presentation.detail.PlayerDetailViewModelFactory
+import com.onair.hearit.presentation.dpToPx
 import com.onair.hearit.presentation.login.LoginActivity
 import com.onair.hearit.service.PlaybackService
 import kotlinx.coroutines.Job
@@ -54,14 +54,7 @@ class ScriptFragment : Fragment() {
 
     private val updateInterval = SCRIPT_SYNC_INTERVAL_MS
 
-    private val itemHeightPx: Int by lazy {
-        TypedValue
-            .applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP,
-                SCRIPT_ITEM_HEIGHT_DP,
-                resources.displayMetrics,
-            ).toInt()
-    }
+    private val itemHeightPx: Int by lazy { SCRIPT_ITEM_HEIGHT_DP.dpToPx(requireContext()) }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -199,7 +192,10 @@ class ScriptFragment : Fragment() {
 
                     if (isUserScrolling) {
                         val isVisible = isItemVisible(currentIndex)
-                        if (now - lastUserScrollTime > 3000L && isVisible) isUserScrolling = false
+                        if (now - lastUserScrollTime > USER_SCROLL_IDLE_THRESHOLD_MS && isVisible) {
+                            isUserScrolling =
+                                false
+                        }
                     }
 
                     if (currentItem != null) adapter.highlightScriptLine(currentItem.id)
@@ -256,7 +252,8 @@ class ScriptFragment : Fragment() {
     companion object {
         private const val HEARIT_ID = "hearit_id"
         private const val SCRIPT_SYNC_INTERVAL_MS = 300L
-        private const val SCRIPT_ITEM_HEIGHT_DP = 16f
+        private const val USER_SCROLL_IDLE_THRESHOLD_MS = 3000L
+        private const val SCRIPT_ITEM_HEIGHT_DP = 16
 
         fun newInstance(hearitId: Long) =
             ScriptFragment().apply {

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
@@ -43,7 +43,7 @@ class ScriptFragment : Fragment() {
     private var scriptSyncJob: Job? = null
     private var mediaController: MediaController? = null
 
-    private val adapter by lazy { ScriptAdapter() }
+    private val adapter: ScriptAdapter by lazy { ScriptAdapter() }
 
     private val hearitId: Long by lazy {
         requireArguments().getLong(HEARIT_ID)
@@ -52,13 +52,13 @@ class ScriptFragment : Fragment() {
         PlayerDetailViewModelFactory(hearitId)
     }
 
-    private val updateInterval = 300L
+    private val updateInterval = SCRIPT_SYNC_INTERVAL_MS
 
     private val itemHeightPx: Int by lazy {
         TypedValue
             .applyDimension(
                 TypedValue.COMPLEX_UNIT_DIP,
-                16f,
+                SCRIPT_ITEM_HEIGHT_DP,
                 resources.displayMetrics,
             ).toInt()
     }
@@ -97,6 +97,11 @@ class ScriptFragment : Fragment() {
 
     private fun setupRecyclerView() {
         binding.rvScript.adapter = adapter
+
+        adapter.onItemClick = { item ->
+            mediaController?.seekTo(item.start)
+        }
+
         binding.rvScript.addOnScrollListener(
             object : RecyclerView.OnScrollListener() {
                 override fun onScrollStateChanged(
@@ -246,6 +251,8 @@ class ScriptFragment : Fragment() {
 
     companion object {
         private const val HEARIT_ID = "hearit_id"
+        private const val SCRIPT_SYNC_INTERVAL_MS = 300L
+        private const val SCRIPT_ITEM_HEIGHT_DP = 16f
 
         fun newInstance(hearitId: Long) =
             ScriptFragment().apply {


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 스크립트 클릭 시 재생 위치 이동 기능 구현

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#360 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 새 기능
  * 스크립트 항목을 탭하면 해당 대사 시작 시점으로 재생 위치가 즉시 이동합니다.

* 리팩터
  * 핸들러 기반 동기화를 코루틴 루프로 전환해 업데이트가 더 부드럽고 안정적입니다.
  * 하이라이트·자동 스크롤 동작을 개선하고, 사용자가 스크롤할 때 자동 스크롤을 일정 시간 일시 중지한 뒤 자연스럽게 재개합니다.
  * DP→px 변환으로 아이템 높이 계산을 정교화했습니다.
  * 화면 종료 시 동기화 작업을 취소하고 플레이어 연결을 안전하게 정리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->