### PR TITLE
[AN] refactor: 홈, 검색화면 리팩터링

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -11,6 +11,7 @@ env:
   KEYSTORE_PROPERTIES: ${{ secrets.KEYSTORE_PROPERTIES }}
   BASE_URL: ${{ secrets.BASE_URL }}
   GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+  KAKAO_NATIVE_KEY: ${{ secrets.KAKAO_NATIVE_KEY }}
 
 jobs:
   build:
@@ -36,9 +37,13 @@ jobs:
         run:
           echo "BASE_URL=$BASE_URL" > ./local.properties
 
-      - name: Get Google Services JSON
+      - name: Add Google Services JSON
         run:
           echo "$GOOGLE_SERVICES_JSON" > ./app/google-services.json
+
+      - name: Add Kakao Native Key
+        run:
+          echo "KAKAO_NATIVE_KEY=$KAKAO_NATIVE_KEY" > ./local.properties
 
       - name: Create KeyStore File and Properties
         run: |
@@ -46,7 +51,6 @@ jobs:
           echo "$KEYSTORE_JKS" | base64 --decode > ./app/signing/hearit_keystore.jks
           echo "$KEYSTORE_PROPERTIES" > ./keystore.properties
 
-      # AAB 파일 추출 후 Play Console에 업로드
       - name: Build Release AAB
         run: ./gradlew bundleRelease
 
@@ -54,15 +58,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-release.aab
-          path: ./app/build/outputs/bundle/release/app-release.aab
+          path: .android/app/build/outputs/bundle/release/app-release.aab
           overwrite: 'true'
 
-      - name: Deploy AAB On Google Play Console
-        uses: r0adkll/upload-google-play@v1.1.3
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
-          packageName: com.onair.hearit
-          releaseFiles: ./android/app/build/outputs/bundle/release/app-release.aab
-          track: alpha
-          whatsNewDirectory: ./android/app/whatsnew
-          
+#      - name: Deploy AAB On Google Play Console
+#        uses: r0adkll/upload-google-play@v1.1.3
+#        with:
+#          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+#          packageName: com.onair.hearit
+#          releaseFiles: ./android/app/build/outputs/bundle/release/app-release.aab
+#          track: alpha
+#          whatsNewDirectory: ./android/app/whatsnew

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("com.google.gms.google-services")
     id("org.jlleitschuh.gradle.ktlint")
     id("com.google.firebase.crashlytics")
+    id("com.google.android.gms.oss-licenses-plugin")
 }
 
 android {
@@ -180,4 +181,7 @@ dependencies {
 
     // in-app-update
     implementation(libs.app.update.ktx)
+
+    // open license
+    implementation(libs.play.services.oss.licenses)
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/MainActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/MainActivity.kt
@@ -73,6 +73,10 @@ class MainActivity :
         setupBottomControllerClick()
     }
 
+    fun selectTab(itemId: Int) {
+        binding.layoutBottomNavigation.selectedItemId = itemId
+    }
+
     private fun setupBackPressHandler() {
         onBackPressedDispatcher.addCallback(
             this,
@@ -97,10 +101,6 @@ class MainActivity :
             insets
         }
         WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = false
-    }
-
-    fun selectTab(itemId: Int) {
-        binding.layoutBottomNavigation.selectedItemId = itemId
     }
 
     private fun setupNavigation() {
@@ -144,7 +144,7 @@ class MainActivity :
             binding.drawerLayout.closeDrawer(GravityCompat.END)
         }
         binding.layoutDrawer.tvDrawerPrivacyPolicy.setOnClickListener { openUrl(PRIVACY_POLICY_URL) }
-        binding.layoutDrawer.tvOpenLicense.setOnClickListener { goOpenLicense() }
+        binding.layoutDrawer.tvOpenLicense.setOnClickListener { navigateToLicense() }
         binding.layoutDrawer.tvDrawerLogin.setOnClickListener { navigateToLogin() }
         binding.layoutDrawer.tvDrawerLogout.setOnClickListener {
             val stopIntent = PlaybackService.stopIntent(this)
@@ -154,17 +154,24 @@ class MainActivity :
         binding.layoutDrawer.tvDrawerWithdrawal.setOnClickListener { confirmAndWithdraw() }
     }
 
-    private fun setupBottomControllerClick() {
-        binding.layoutBottomPlayerController.setOnClickListener {
-            val mediaId = mediaController?.currentMediaItem?.mediaId?.toLongOrNull()
-            if (mediaId != null) {
-                navigateToDetail(mediaId)
-            } else {
-                mainViewModel.recentHearit.value
-                    ?.id
-                    ?.let { navigateToDetail(it) }
-            }
+    private fun attachController() {
+        if (mediaController != null) {
+            maybePreloadRecent()
+            return
         }
+        val token = SessionToken(this, ComponentName(this, PlaybackService::class.java))
+        val future = MediaController.Builder(this, token).buildAsync()
+        future.addListener(
+            {
+                mediaController = future.get()
+                mediaController?.let { controller ->
+                    binding.layoutBottomPlayerController.setPlayer(controller)
+                    setPlayerControlViewVisibility()
+                    maybePreloadRecent()
+                }
+            },
+            ContextCompat.getMainExecutor(this),
+        )
     }
 
     private fun observeViewModel() {
@@ -192,6 +199,19 @@ class MainActivity :
 
         mainViewModel.toastMessage.observe(this) { resId ->
             showToast(getString(resId))
+        }
+    }
+
+    private fun setupBottomControllerClick() {
+        binding.layoutBottomPlayerController.setOnClickListener {
+            val mediaId = mediaController?.currentMediaItem?.mediaId?.toLongOrNull()
+            if (mediaId != null) {
+                navigateToDetail(mediaId)
+            } else {
+                mainViewModel.recentHearit.value
+                    ?.id
+                    ?.let { navigateToDetail(it) }
+            }
         }
     }
 
@@ -240,30 +260,6 @@ class MainActivity :
         loadingDialog = null
     }
 
-    override fun openDrawer() {
-        binding.drawerLayout.openDrawer(GravityCompat.END)
-    }
-
-    private fun attachController() {
-        if (mediaController != null) {
-            maybePreloadRecent()
-            return
-        }
-        val token = SessionToken(this, ComponentName(this, PlaybackService::class.java))
-        val future = MediaController.Builder(this, token).buildAsync()
-        future.addListener(
-            {
-                mediaController = future.get()
-                mediaController?.let { controller ->
-                    binding.layoutBottomPlayerController.setPlayer(controller)
-                    setPlayerControlViewVisibility()
-                    maybePreloadRecent()
-                }
-            },
-            ContextCompat.getMainExecutor(this),
-        )
-    }
-
     private fun maybePreloadRecent() {
         val controller = mediaController ?: return
         if (hasSentPreload) return
@@ -310,6 +306,25 @@ class MainActivity :
 
     private fun showToast(message: String?) {
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun navigateToSplash() {
+        val intent =
+            Intent(this, SplashActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+        startActivity(intent)
+        finish()
+    }
+
+    private fun navigateToLicense() {
+        OssLicensesMenuActivity.setActivityTitle(HEARIT_OPEN_LICENSE_TITLE)
+        val intent = Intent(this, OssLicensesMenuActivity::class.java)
+        startActivity(intent)
+    }
+
+    override fun openDrawer() {
+        binding.drawerLayout.openDrawer(GravityCompat.END)
     }
 
     override fun showPlayerControlView() {
@@ -375,22 +390,8 @@ class MainActivity :
         super.onNewIntent(intent)
     }
 
-    private fun navigateToSplash() {
-        val intent =
-            Intent(this, SplashActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            }
-        startActivity(intent)
-        finish()
-    }
-
-    private fun goOpenLicense() {
-        OssLicensesMenuActivity.setActivityTitle("hEARit Open Source Licenses")
-        val intent = Intent(this, OssLicensesMenuActivity::class.java)
-        startActivity(intent)
-    }
-
     companion object {
+        private const val HEARIT_OPEN_LICENSE_TITLE = "hEARit Open Source Licenses"
         private const val PRIVACY_POLICY_URL =
             "https://glistening-eclipse-58b.notion.site/231d39b9c3c3809b9f92ec3e812ea24b?source=copy_link"
         private const val TERMS_OF_USE_URL =

--- a/android/app/src/main/java/com/onair/hearit/presentation/MainActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import com.onair.hearit.R
 import com.onair.hearit.databinding.ActivityMainBinding
 import com.onair.hearit.presentation.detail.PlayerDetailActivity
@@ -143,7 +144,7 @@ class MainActivity :
             binding.drawerLayout.closeDrawer(GravityCompat.END)
         }
         binding.layoutDrawer.tvDrawerPrivacyPolicy.setOnClickListener { openUrl(PRIVACY_POLICY_URL) }
-        binding.layoutDrawer.tvDrawerTermsOfUse.setOnClickListener { openUrl(TERMS_OF_USE_URL) }
+        binding.layoutDrawer.tvOpenLicense.setOnClickListener { goOpenLicense() }
         binding.layoutDrawer.tvDrawerLogin.setOnClickListener { navigateToLogin() }
         binding.layoutDrawer.tvDrawerLogout.setOnClickListener {
             val stopIntent = PlaybackService.stopIntent(this)
@@ -381,6 +382,12 @@ class MainActivity :
             }
         startActivity(intent)
         finish()
+    }
+
+    private fun goOpenLicense() {
+        OssLicensesMenuActivity.setActivityTitle("hEARit Open Source Licenses")
+        val intent = Intent(this, OssLicensesMenuActivity::class.java)
+        startActivity(intent)
     }
 
     companion object {

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
@@ -53,9 +53,9 @@ class PlayerDetailActivity :
     AppCompatActivity(),
     PlayerDetailClickListener {
     private lateinit var binding: ActivityPlayerDetailBinding
-    private val keywordAdapter by lazy { PlayerDetailKeywordAdapter() }
-    private val scriptAdapter by lazy { PlayerDetailScriptAdapter() }
-    private val sourceAdapter by lazy { PlayerDetailSourceAdapter(this) }
+    private val keywordAdapter: PlayerDetailKeywordAdapter by lazy { PlayerDetailKeywordAdapter() }
+    private val scriptAdapter: PlayerDetailScriptAdapter by lazy { PlayerDetailScriptAdapter() }
+    private val sourceAdapter: PlayerDetailSourceAdapter by lazy { PlayerDetailSourceAdapter(this) }
 
     private var mediaController: MediaController? = null
     private var scriptSyncJob: Job? = null

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -179,10 +179,8 @@ class ExploreFragment :
         }
 
         viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
-            if (isLoading) {
-                binding.frExploreSkeleton.startShimmer()
-            } else {
-                binding.frExploreSkeleton.stopShimmer()
+            binding.frExploreSkeleton.apply {
+                if (isLoading) startShimmer() else stopShimmer()
             }
         }
     }
@@ -236,10 +234,8 @@ class ExploreFragment :
         val intent = LoginActivity.newIntent(requireContext())
         startActivity(intent)
 
-        // PlaybackService 종료
         requireContext().stopService(PlaybackService.stopIntent(requireContext()))
 
-        // 현재 프래그먼트 종료
         parentFragmentManager
             .beginTransaction()
             .remove(this)

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -120,10 +120,8 @@ class HomeFragment :
 
     private fun observeViewModel() {
         viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
-            if (isLoading) {
-                binding.frHomeSkeleton.startShimmer()
-            } else {
-                binding.frHomeSkeleton.stopShimmer()
+            binding.frHomeSkeleton.apply {
+                if (isLoading) startShimmer() else stopShimmer()
             }
         }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -19,6 +19,7 @@ import com.onair.hearit.analytics.AnalyticsScreenInfo
 import com.onair.hearit.databinding.FragmentHomeBinding
 import com.onair.hearit.di.AnalyticsProvider
 import com.onair.hearit.domain.model.Direction
+import com.onair.hearit.domain.model.RecommendHearit
 import com.onair.hearit.domain.model.RecommendHearits
 import com.onair.hearit.domain.model.SearchInput.Companion.CATEGORY_ID_KEY
 import com.onair.hearit.domain.model.SearchInput.Companion.CATEGORY_KEY
@@ -135,17 +136,7 @@ class HomeFragment :
         }
 
         viewModel.recommendHearits.observe(viewLifecycleOwner) { recommendItems ->
-            val contentItems = recommendItems.map { RecommendHearits.Content(it) }
-            val items =
-                buildList {
-                    add(RecommendHearits.NavigateItem(direction = Direction.LEFT))
-                    addAll(contentItems)
-                    add(RecommendHearits.NavigateItem(direction = Direction.RIGHT))
-                }
-            recommendAdapter.submitList(items) {
-                scrollToMiddlePosition()
-                setupIndicator(contentItems.size)
-            }
+            submitRecommendItems(recommendItems)
         }
 
         viewModel.groupedCategory.observe(viewLifecycleOwner) { groupedCategory ->
@@ -154,6 +145,20 @@ class HomeFragment :
 
         viewModel.toastMessage.observe(viewLifecycleOwner) { resId ->
             showToast(getString(resId))
+        }
+    }
+
+    private fun submitRecommendItems(recommendItems: List<RecommendHearit>) {
+        val contentItems = recommendItems.map { RecommendHearits.Content(it) }
+        val items =
+            buildList {
+                add(RecommendHearits.NavigateItem(Direction.LEFT))
+                addAll(contentItems)
+                add(RecommendHearits.NavigateItem(Direction.RIGHT))
+            }
+        recommendAdapter.submitList(items) {
+            scrollToMiddlePosition()
+            setupIndicator(contentItems.size)
         }
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -74,8 +74,7 @@ class HomeFragment :
         binding.viewModel = viewModel
         setupWindowInsets()
         setupListeners()
-        setupRecommendRecyclerView()
-        setupCategoryRecyclerView()
+        setupRecyclerView()
         observeViewModel()
     }
 
@@ -101,7 +100,7 @@ class HomeFragment :
         }
     }
 
-    private fun setupRecommendRecyclerView() {
+    private fun setupRecyclerView() {
         centerScrollListener =
             CenterScrollListener(snapHelper) { position ->
                 updateIndicator(position)
@@ -112,9 +111,7 @@ class HomeFragment :
             snapHelper.attachToRecyclerView(this)
             centerScrollListener?.let { addOnScrollListener(it) }
         }
-    }
 
-    private fun setupCategoryRecyclerView() {
         binding.rvHomeGroupedCategory.adapter = groupedCategoryAdapter
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -45,30 +45,27 @@ class HomeViewModel(
 
     private fun fetchData() {
         _isLoading.value = true
+
         viewModelScope.launch {
             val recommendDeferred = async { hearitRepository.getRecommendHearits() }
             val groupedDeferred = async { hearitRepository.getCategoryHearits() }
 
-            val recommendHearitsResult = recommendDeferred.await()
-            val groupedCategoryResult = groupedDeferred.await()
+            val recommendResult = recommendDeferred.await()
+            val groupedResult = groupedDeferred.await()
 
-            val bothSuccess = recommendHearitsResult.isSuccess && groupedCategoryResult.isSuccess
-
-            if (bothSuccess) {
-                _recommendHearits.value = recommendHearitsResult.getOrThrow()
-                _groupedCategory.value = groupedCategoryResult.getOrThrow()
-                _isLoading.value = false
-            } else {
-                _isLoading.value = true
-                if (recommendHearitsResult.isFailure) {
-                    _toastMessage.value =
-                        R.string.home_toast_recommend_load_fail
-                }
-                if (groupedCategoryResult.isFailure) {
-                    _toastMessage.value =
-                        R.string.home_toast_grouped_category_load_fail
-                }
+            recommendResult.onFailure { throwable ->
+                Timber.w(throwable)
+                _toastMessage.value = R.string.home_toast_recommend_load_fail
             }
+            groupedResult.onFailure { throwable ->
+                Timber.w(throwable)
+                _toastMessage.value = R.string.home_toast_grouped_category_load_fail
+            }
+
+            recommendResult.onSuccess { _recommendHearits.value = it }
+            groupedResult.onSuccess { _groupedCategory.value = it }
+
+            _isLoading.value = false
         }
     }
 
@@ -80,14 +77,12 @@ class HomeViewModel(
                     _userInfo.value = userInfo
                     _isLoggedIn.value = true
                 }.onFailure { throwable ->
+                    _isLoggedIn.value = false
+
                     when (throwable) {
-                        is UserNotRegistered -> {
-                            _userInfo.value = UserInfo.default()
-                            _isLoggedIn.value = false
-                        }
+                        is UserNotRegistered -> _userInfo.value = UserInfo.default()
 
                         else -> {
-                            _isLoggedIn.value = false
                             Timber.w(throwable)
                             _toastMessage.value = R.string.all_toast_user_info_load_fail
                         }

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
@@ -27,7 +27,7 @@ class LibraryFragment :
     private val binding get() = _binding!!
 
     private val viewModel: LibraryViewModel by viewModels { LibraryViewModelFactory() }
-    private val adapter by lazy { BookmarkAdapter(this) }
+    private val bookmarkAdapter: BookmarkAdapter by lazy { BookmarkAdapter(this) }
 
     private val playerDetailLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -43,7 +43,7 @@ class LibraryFragment :
     ): View {
         _binding = FragmentLibraryBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
-        binding.rvBookmark.adapter = adapter
+        binding.rvBookmark.adapter = bookmarkAdapter
         return binding.root
     }
 
@@ -83,8 +83,7 @@ class LibraryFragment :
 
     private fun observeViewModel() {
         viewModel.bookmarks.observe(viewLifecycleOwner) { bookmarks ->
-            adapter.submitList(bookmarks)
-
+            bookmarkAdapter.submitList(bookmarks)
             binding.layoutLibraryWhenNoBookmark.isVisible = bookmarks.isEmpty()
         }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
@@ -28,7 +28,7 @@ class LibraryFragment :
     private val binding get() = _binding!!
 
     private val viewModel: LibraryViewModel by viewModels { LibraryViewModelFactory() }
-    private val adapter: BookmarkAdapter by lazy { BookmarkAdapter(this) }
+    private val bookmarkAdapter: BookmarkAdapter by lazy { BookmarkAdapter(this) }
 
     private val playerDetailLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -44,8 +44,7 @@ class LibraryFragment :
     ): View {
         _binding = FragmentLibraryBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
-        binding.rvBookmark.adapter = adapter
-        binding.rvBookmark.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvBookmark.adapter = bookmarkAdapter
         return binding.root
     }
 
@@ -84,7 +83,7 @@ class LibraryFragment :
 
     private fun observeViewModel() {
         viewModel.bookmarks.observe(viewLifecycleOwner) { bookmarks ->
-            adapter.submitList(bookmarks)
+            bookmarkAdapter.submitList(bookmarks)
         }
 
         viewModel.toastMessage.observe(viewLifecycleOwner) { resId ->

--- a/android/app/src/main/java/com/onair/hearit/presentation/login/KakaoLoginHelper.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/login/KakaoLoginHelper.kt
@@ -31,27 +31,25 @@ class KakaoLoginHelper(
         UserApiClient.instance.loginWithKakaoAccount(activity, callback = kakaoCallback())
     }
 
-    private fun kakaoCallback(): (OAuthToken?, Throwable?) -> Unit {
-        return callback@{ token, error ->
+    private fun kakaoCallback(): (OAuthToken?, Throwable?) -> Unit =
+        { token, error ->
             when {
-                token != null -> {
-                    onSuccess(token)
-                }
+                token != null -> onSuccess(token)
 
-                error != null -> {
-                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) return@callback
-                    if (isKakaoTalkLogin) {
-                        isKakaoTalkLogin = false
-                        loginWithKakaoAccount()
-                    } else {
-                        onError(error)
-                    }
-                }
+                error != null -> handleKakaoError(error)
 
-                else -> {
-                    onError(null)
-                }
+                else -> onError(null)
             }
+        }
+
+    private fun handleKakaoError(error: Throwable) {
+        if (error is ClientError && error.reason == ClientErrorCause.Cancelled) return
+
+        if (isKakaoTalkLogin) {
+            isKakaoTalkLogin = false
+            loginWithKakaoAccount()
+        } else {
+            onError(error)
         }
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/login/LoginActivity.kt
@@ -81,7 +81,7 @@ class LoginActivity : AppCompatActivity() {
 
     private fun observeViewModel() {
         viewModel.loginState.observe(this) { isLoggedIn ->
-            if (isLoggedIn) navigateToMain()
+            if (isLoggedIn == true) navigateToMain()
         }
 
         viewModel.toastMessage.observe(this) { resId ->

--- a/android/app/src/main/java/com/onair/hearit/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/login/LoginActivity.kt
@@ -81,10 +81,9 @@ class LoginActivity : AppCompatActivity() {
 
     private fun observeViewModel() {
         viewModel.loginState.observe(this) { isLoggedIn ->
-            if (isLoggedIn == true) {
-                navigateToMain()
-            }
+            if (isLoggedIn) navigateToMain()
         }
+
         viewModel.toastMessage.observe(this) { resId ->
             showToast(getString(resId))
         }

--- a/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
@@ -43,10 +43,12 @@ class LoginViewModel(
     ) {
         viewModelScope.launch {
             val result =
-                runCatching {
-                    preferencesLocalDataSource.saveAccessToken(accessToken).getOrThrow()
-                    preferencesLocalDataSource.saveRefreshToken(refreshToken).getOrThrow()
-                }
+                preferencesLocalDataSource
+                    .saveAccessToken(accessToken)
+                    .fold(
+                        onSuccess = { preferencesLocalDataSource.saveRefreshToken(refreshToken) },
+                        onFailure = { Result.failure(it) },
+                    )
 
             result
                 .onSuccess {

--- a/android/app/src/main/java/com/onair/hearit/presentation/search/SearchFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/search/SearchFragment.kt
@@ -91,7 +91,8 @@ class SearchFragment : Fragment() {
     private fun performSearchFromInput() {
         binding.etSearch.text
             ?.toString()
-            ?.takeIf { it.isNotBlank() }
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
             ?.let { searchTerm ->
                 navigateToSearchResult(SearchInput.Keyword(searchTerm))
                 hideKeyboard()

--- a/android/app/src/main/java/com/onair/hearit/presentation/search/SearchFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/search/SearchFragment.kt
@@ -14,6 +14,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.onair.hearit.R
 import com.onair.hearit.analytics.AnalyticsScreenInfo
 import com.onair.hearit.databinding.FragmentSearchBinding
@@ -27,6 +28,7 @@ import com.onair.hearit.domain.term
 import com.onair.hearit.presentation.search.category.SearchCategoryFragment
 import com.onair.hearit.presentation.search.recent.SearchRecentFragment
 import com.onair.hearit.presentation.search.result.SearchResultFragment
+import kotlinx.coroutines.launch
 
 class SearchFragment : Fragment() {
     @Suppress("ktlint:standard:backing-property-naming")
@@ -59,6 +61,14 @@ class SearchFragment : Fragment() {
         updateAppBarUIOnBackStackChanged()
     }
 
+    override fun onResume() {
+        super.onResume()
+        AnalyticsProvider.get().logScreenView(
+            screenName = AnalyticsScreenInfo.Search.NAME,
+            screenClass = AnalyticsScreenInfo.Search.CLASS,
+        )
+    }
+
     @SuppressLint("ClickableViewAccessibility")
     private fun setupSearchInput() {
         binding.etSearch.setOnEditorActionListener { _, actionId, _ ->
@@ -79,15 +89,13 @@ class SearchFragment : Fragment() {
     }
 
     private fun performSearchFromInput() {
-        val searchTerm =
-            binding.etSearch.text
-                ?.toString()
-                ?.trim()
-                .orEmpty()
-        if (searchTerm.isNotBlank()) {
-            navigateToSearchResult(SearchInput.Keyword(searchTerm))
-            hideKeyboard()
-        }
+        binding.etSearch.text
+            ?.toString()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { searchTerm ->
+                navigateToSearchResult(SearchInput.Keyword(searchTerm))
+                hideKeyboard()
+            }
     }
 
     private fun setupFragmentResultListeners() {
@@ -97,7 +105,7 @@ class SearchFragment : Fragment() {
         ) { _, bundle ->
             val id = bundle.getLong(CATEGORY_ID_KEY)
             val name = bundle.getString(CATEGORY_NAME_KEY).orEmpty()
-            binding.root.post {
+            viewLifecycleOwner.lifecycleScope.launch {
                 navigateToSearchResult(SearchInput.Category(id, name))
             }
         }
@@ -187,14 +195,6 @@ class SearchFragment : Fragment() {
             .replace(R.id.fl_search_container, fragment, tag)
             .addToBackStack(tag)
             .commit()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        AnalyticsProvider.get().logScreenView(
-            screenName = AnalyticsScreenInfo.Search.NAME,
-            screenClass = AnalyticsScreenInfo.Search.CLASS,
-        )
     }
 
     private fun setupWindowInsets() {

--- a/android/app/src/main/java/com/onair/hearit/presentation/search/category/SearchCategoryFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/search/category/SearchCategoryFragment.kt
@@ -27,7 +27,7 @@ class SearchCategoryFragment :
     @Suppress("ktlint:standard:backing-property-naming")
     private var _binding: FragmentSearchCategoryBinding? = null
     private val binding get() = _binding!!
-    private val categoryAdapter by lazy { CategoryAdapter(this) }
+    private val categoryAdapter: CategoryAdapter by lazy { CategoryAdapter(this) }
 
     private val viewModel: SearchViewModel by viewModels({ requireParentFragment() }) {
         SearchViewModelFactory()

--- a/android/app/src/main/java/com/onair/hearit/presentation/search/recent/SearchRecentFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/search/recent/SearchRecentFragment.kt
@@ -23,7 +23,7 @@ class SearchRecentFragment :
     private var _binding: FragmentSearchRecentBinding? = null
     private val binding get() = _binding!!
 
-    private val recentSearchAdapter by lazy { RecentSearchAdapter(this) }
+    private val recentSearchAdapter: RecentSearchAdapter by lazy { RecentSearchAdapter(this) }
 
     private val viewModel: SearchViewModel by viewModels({ requireParentFragment() }) {
         SearchViewModelFactory()

--- a/android/app/src/main/java/com/onair/hearit/presentation/search/result/SearchResultFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/search/result/SearchResultFragment.kt
@@ -33,7 +33,7 @@ class SearchResultFragment :
     private val viewModel: SearchResultViewModel by viewModels {
         SearchResultViewModelFactory(searchedTerm)
     }
-    private val adapter by lazy { SearchedHearitAdapter(this) }
+    private val searchedAdapter by lazy { SearchedHearitAdapter(this) }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -69,29 +69,35 @@ class SearchResultFragment :
     }
 
     private fun setupRecyclerView() {
-        binding.rvSearchedHearit.adapter = adapter
-        binding.rvSearchedHearit.addOnScrollListener(
-            object : RecyclerView.OnScrollListener() {
-                override fun onScrolled(
-                    rv: RecyclerView,
-                    dx: Int,
-                    dy: Int,
-                ) {
-                    val lm = rv.layoutManager as? LinearLayoutManager ?: return
-                    val total = lm.itemCount
-                    val last = lm.findLastVisibleItemPosition()
+        binding.rvSearchedHearit.apply {
+            adapter = searchedAdapter
+            addOnScrollListener(
+                object : RecyclerView.OnScrollListener() {
+                    override fun onScrolled(
+                        rv: RecyclerView,
+                        dx: Int,
+                        dy: Int,
+                    ) {
+                        val lm = rv.layoutManager as? LinearLayoutManager ?: return
+                        val total = lm.itemCount
+                        val last = lm.findLastVisibleItemPosition()
 
-                    if (last >= total - 3) viewModel.loadNextPageIfPossible()
-                }
-            },
-        )
+                        if (last >= total - 3) viewModel.loadNextPageIfPossible()
+                    }
+                },
+            )
+        }
     }
 
     private fun observeViewModel() {
-        viewModel.uiState.observe(viewLifecycleOwner) { binding.uiState = it }
-        viewModel.searchedHearits.observe(viewLifecycleOwner) { adapter.submitList(it) }
-        viewModel.toastMessage.observe(viewLifecycleOwner) {
-            showToast(getString(it))
+        viewModel.uiState.observe(viewLifecycleOwner) { state ->
+            binding.uiState = state
+        }
+        viewModel.searchedHearits.observe(viewLifecycleOwner) { searchedHearits ->
+            searchedAdapter.submitList(searchedHearits)
+        }
+        viewModel.toastMessage.observe(viewLifecycleOwner) { resId ->
+            showToast(getString(resId))
         }
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/search/result/SearchResultFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/search/result/SearchResultFragment.kt
@@ -74,15 +74,16 @@ class SearchResultFragment :
             addOnScrollListener(
                 object : RecyclerView.OnScrollListener() {
                     override fun onScrolled(
-                        rv: RecyclerView,
+                        recyclerView: RecyclerView,
                         dx: Int,
                         dy: Int,
                     ) {
-                        val lm = rv.layoutManager as? LinearLayoutManager ?: return
-                        val total = lm.itemCount
-                        val last = lm.findLastVisibleItemPosition()
+                        val layoutManager =
+                            recyclerView.layoutManager as? LinearLayoutManager ?: return
+                        val threshold = layoutManager.itemCount - REFRESH_THRESHOLD
+                        val last = layoutManager.findLastVisibleItemPosition()
 
-                        if (last >= total - 3) viewModel.loadNextPageIfPossible()
+                        if (last >= threshold) viewModel.loadNextPageIfPossible()
                     }
                 },
             )
@@ -123,6 +124,8 @@ class SearchResultFragment :
     }
 
     companion object {
+        private const val REFRESH_THRESHOLD = 3
+
         fun newInstance(input: SearchInput): SearchResultFragment =
             SearchResultFragment().apply {
                 arguments = input.toBundle()

--- a/android/app/src/main/java/com/onair/hearit/presentation/search/result/SearchResultFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/search/result/SearchResultFragment.kt
@@ -33,7 +33,7 @@ class SearchResultFragment :
     private val viewModel: SearchResultViewModel by viewModels {
         SearchResultViewModelFactory(searchedTerm)
     }
-    private val searchedAdapter by lazy { SearchedHearitAdapter(this) }
+    private val searchedAdapter: SearchedHearitAdapter by lazy { SearchedHearitAdapter(this) }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/android/app/src/main/java/com/onair/hearit/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/splash/SplashActivity.kt
@@ -77,7 +77,7 @@ class SplashActivity : AppCompatActivity() {
                     checkTokenAndNavigate()
                 }
             }.addOnFailureListener {
-                finish()
+                checkTokenAndNavigate()
             }
     }
 

--- a/android/app/src/main/res/layout/layout_drawer.xml
+++ b/android/app/src/main/res/layout/layout_drawer.xml
@@ -39,14 +39,13 @@
             app:layout_constraintTop_toBottomOf="@id/tv_drawer_account_info" />
 
         <TextView
-            android:id="@+id/tv_drawer_terms_of_use"
+            android:id="@+id/tv_open_license"
             style="@style/pretendard_drawer"
             android:layout_width="match_parent"
             android:layout_height="72dp"
             android:gravity="center_vertical"
             android:paddingHorizontal="24dp"
-            android:text="@string/all_terms_of_use"
-            android:visibility="gone"
+            android:text="@string/all_open_license"
             app:layout_constraintTop_toBottomOf="@id/tv_drawer_privacy_policy" />
 
         <com.google.android.material.divider.MaterialDivider
@@ -55,7 +54,7 @@
             android:layout_height="1dp"
             android:layout_marginTop="4dp"
             app:dividerColor="@color/hearit_gray4"
-            app:layout_constraintTop_toBottomOf="@id/tv_drawer_terms_of_use" />
+            app:layout_constraintTop_toBottomOf="@id/tv_open_license" />
 
         <TextView
             android:id="@+id/tv_drawer_login"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="all_cancel">취소</string>
     <string name="all_privacy_policy">개인정보처리방침</string>
     <string name="all_terms_of_use">이용 약관</string>
+    <string name="all_open_license">오픈 라이선스</string>
     <string name="all_account_info">설정 및 계정 정보</string>
     <string name="all_login_button_text">로그인 하러가기</string>
     <string name="all_toast_categories_load_fail">카테고리 조회에 실패했습니다.</string>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     id("com.google.gms.google-services") version "4.4.3" apply false
     id("org.jlleitschuh.gradle.ktlint") version "13.0.0" apply false
     id("com.google.firebase.crashlytics") version "3.0.5" apply false
+    id("com.google.android.gms.oss-licenses-plugin") version "0.10.7" apply false
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ constraintlayout = "2.2.1"
 media3 = "1.7.1"
 mockk = "1.13.5"
 okhttp = "4.12.0"
+playServicesOssLicenses = "17.2.1"
 retrofit = "3.0.0"
 retrofit2-kotlinx-serialization-converter = "1.0.0"
 kotlinx-serialization-json = "1.8.1"
@@ -70,6 +71,7 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofit2-kotlinx-serialization-converter = { module = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter", version.ref = "retrofit2-kotlinx-serialization-converter" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 홈, 검색화면 리팩터링
- 코드 리팩터링 및 메서드 위치 이동, 메서드 분리
- 오픈 라이선스 추가, 인앱 업데이트 버그 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 오픈 소스 라이선스 화면 추가 및 드로어에 ‘오픈 라이선스’ 항목 노출/이동 지원
  - 하단 플레이어 컨트롤러 비동기 바인딩 및 클릭 동작 개선으로 최근 항목 접근·상세 이동 원활화
  - 검색 화면에 화면 분석(Analytics) 로그 추가

- Bug Fixes
  - 스플래시에서 업데이트 정보 조회 실패 시 앱이 종료되지 않고 토큰 검증 후 정상 이동

- Refactor
  - 홈/검색/탐색/라이브러리/로그인 화면 로직 정리 및 중복 제거로 가독성·안정성 개선

- Chores
  - 빌드 설정·의존성(OSS 라이선스) 추가, CI 워크플로우 환경 변수·출력 경로 조정, 문자열 리소스 및 레이아웃 ID 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->