### PR TITLE
[AN] refactor: PlaybackService 및 미디어 알림 리팩토링

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/domain/Mapper.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/Mapper.kt
@@ -46,14 +46,14 @@ fun SingleHearit.toPlaybackInfo(
     audioUrl: String,
     title: String,
     startPosition: Long = 0L,
-    duration: Long,
+    source: String,
 ): PlaybackInfo =
     PlaybackInfo(
         hearitId = this.id,
         audioUrl = audioUrl,
         title = title,
         lastPosition = startPosition,
-        duration = duration,
+        source = source,
     )
 
 fun SearchInput.term(): String =

--- a/android/app/src/main/java/com/onair/hearit/domain/model/PlaybackInfo.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/model/PlaybackInfo.kt
@@ -5,5 +5,5 @@ data class PlaybackInfo(
     val audioUrl: String,
     val title: String,
     val lastPosition: Long = 0L,
-    val duration: Long,
+    val source: String,
 )

--- a/android/app/src/main/java/com/onair/hearit/domain/usecase/GetPlaybackInfoUseCase.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/usecase/GetPlaybackInfoUseCase.kt
@@ -17,8 +17,8 @@ class GetPlaybackInfoUseCase(
             val audioUrl = mediaFileRepository.getOriginalAudioUrl(hearitId).getOrThrow().url
             val recentHearit = recentHearitRepository.getRecentHearit().getOrThrow()
             val lastPosition = recentHearit?.lastPosition ?: 0L
-            val duration = hearitInfo.playTime * 1000L
+            val source = hearitInfo.sources.first().name
 
-            hearitInfo.toPlaybackInfo(audioUrl, hearitInfo.title, lastPosition, duration)
+            hearitInfo.toPlaybackInfo(audioUrl, hearitInfo.title, lastPosition, source)
         }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
@@ -37,15 +37,19 @@ class BottomPlayerView
             binding.exoPlay.setOnClickListener { togglePlayPause() }
         }
 
+        // 제대로 Player를 끊었다가 다시 연결해서 문제가 없도록 하기 위함.
+        // 새로운 플레이어에 리스너를 달아주고,프로그레스바 연결
         fun setPlayer(newPlayer: Player): BottomPlayerView =
             apply {
                 detachPlayer()
                 player = newPlayer
                 listener = PlayerListener().also { newPlayer.addListener(it) }
                 refresh()
+                // post를 이용해서 UI가 완전히 그려진 후에 연결되도록 함.
                 post { updateProgress() }
             }
 
+        // marquee로 길이가 긴경우에는 돌아가도록 하기 위해서 선택된 상태를 줌.
         fun setTitle(title: String) {
             binding.tvBottomPlayerTitle.isSelected = true
             binding.tvBottomPlayerTitle.text = title
@@ -156,6 +160,9 @@ class BottomPlayerView
             player = null
         }
 
+        // onDetachedFromWindow()는 뷰(View)가 화면에서 분리될 때 호출되는 안드로이드 생명주기 메서드
+        // remove와 같은 정리 작업을 하는 경우에 사용됨.
+        // detachPlayer()는 Player 객체와의 연결을 해제하는 함수
         override fun onDetachedFromWindow() {
             super.onDetachedFromWindow()
             removeCallbacks(progressRunnable)

--- a/android/app/src/main/java/com/onair/hearit/presentation/MainActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/MainActivity.kt
@@ -243,6 +243,7 @@ class MainActivity :
         binding.drawerLayout.openDrawer(GravityCompat.END)
     }
 
+    // 제일 먼저 여기서 호출함 ->
     private fun attachController() {
         if (mediaController != null) {
             maybePreloadRecent()
@@ -345,11 +346,13 @@ class MainActivity :
 
     override fun startPlayback() {
         val controller = mediaController
+        // 컨트롤러 연결되어있으면 바로 즉시 재생하도록
         if (controller != null) {
             controller.play()
             return
         }
 
+        // 컨트롤러가 연결되어있지 않으면, 세션 토큰을 이용해서 PlaybackService를 연결할 수 있도록 함.
         val token = SessionToken(this, ComponentName(this, PlaybackService::class.java))
         val future = MediaController.Builder(this, token).buildAsync()
         future.addListener(

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
@@ -287,9 +287,10 @@ class PlayerDetailActivity :
         val isDifferentHearit = currentlyPlayingId != hearit.id
         val shouldResume = intent.hasExtra(LAST_POSITION) && lastPosition > 0L
         val startPosition = if (shouldResume) lastPosition else 0L
+        val source = hearit.sources.first().name
 
         if (isDifferentHearit) {
-            startPlaybackService(hearit.audioUrl, hearit.title, startPosition)
+            startPlaybackService(hearit.audioUrl, hearit.title, startPosition, source)
         } else {
             if (!controller.isPlaying) controller.play()
             if (shouldResume && abs(controller.currentPosition - startPosition) > 1000) {
@@ -308,6 +309,7 @@ class PlayerDetailActivity :
         audioUrl: String,
         title: String,
         startPosition: Long = 0L,
+        source: String,
     ) {
         val serviceIntent =
             PlaybackService.newIntent(
@@ -316,6 +318,7 @@ class PlayerDetailActivity :
                 title = title,
                 hearitId = hearitId,
                 startPosition = startPosition,
+                source = source,
             )
         startForegroundService(serviceIntent)
     }

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackMediaItemManager.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackMediaItemManager.kt
@@ -19,6 +19,7 @@ class PlaybackMediaItemManager {
                 MediaMetadata
                     .Builder()
                     .setTitle(info.title)
+                    .setArtist(info.source)
                     .build(),
             ).build()
 

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
@@ -56,16 +56,17 @@ class PlaybackService : MediaSessionService() {
         initializeAndStartForeground()
 
         val audioUrl = intent?.getStringExtra(EXTRA_AUDIO_URL)
-        val title = intent?.getStringExtra(EXTRA_TITLE) ?: "hearit"
+        val title = intent?.getStringExtra(EXTRA_TITLE) ?: "hEARit"
         val hearitId = intent?.getLongExtra(EXTRA_HEARIT_ID, -1L) ?: -1L
         val startPosition = intent?.getLongExtra(EXTRA_START_POSITION, 0L) ?: 0L
+        val source = intent?.getStringExtra(EXTRA_SOURCE) ?: "hEARit"
 
         if (audioUrl.isNullOrEmpty() || hearitId == -1L) {
             stopSelf()
             return START_NOT_STICKY
         }
 
-        val item = createMediaItem(audioUrl, title, hearitId)
+        val item = createMediaItem(audioUrl, title, hearitId, source)
         player.setMediaItems(listOf(item), 0, startPosition.coerceAtLeast(0L))
         player.prepare()
         player.play()
@@ -104,6 +105,7 @@ class PlaybackService : MediaSessionService() {
         url: String,
         title: String,
         id: Long,
+        source: String,
     ): MediaItem =
         MediaItem
             .Builder()
@@ -113,6 +115,7 @@ class PlaybackService : MediaSessionService() {
                 MediaMetadata
                     .Builder()
                     .setTitle(title)
+                    .setArtist(source)
                     .build(),
             ).build()
 
@@ -142,6 +145,7 @@ class PlaybackService : MediaSessionService() {
         private const val EXTRA_TITLE = "TITLE"
         private const val EXTRA_HEARIT_ID = "HEARIT_ID"
         private const val EXTRA_START_POSITION = "START_POSITION"
+        private const val EXTRA_SOURCE = "SOURCE"
 
         const val ACTION_STOP_SERVICE = "hearit.ACTION_STOP_SERVICE"
 
@@ -151,11 +155,13 @@ class PlaybackService : MediaSessionService() {
             title: String,
             hearitId: Long,
             startPosition: Long,
+            source: String,
         ) = Intent(context, PlaybackService::class.java).apply {
             putExtra(EXTRA_AUDIO_URL, audioUrl)
             putExtra(EXTRA_TITLE, title)
             putExtra(EXTRA_HEARIT_ID, hearitId)
             putExtra(EXTRA_START_POSITION, startPosition)
+            putExtra(EXTRA_SOURCE, source)
         }
 
         fun stopIntent(context: Context) =

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackSessionCallback.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackSessionCallback.kt
@@ -6,7 +6,6 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
-import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
 import com.google.common.util.concurrent.ListenableFuture
 import com.onair.hearit.di.RepositoryProvider
@@ -70,8 +69,8 @@ class PlaybackSessionCallback(
                             prepareIfNeeded(info)
                         }
                         completer.set(SessionResult(SessionResult.RESULT_SUCCESS))
-                    } catch (_: Exception) {
-                        completer.set(SessionResult(SessionError.ERROR_UNKNOWN))
+                    } catch (e: Exception) {
+                        completer.setException(e)
                     }
                 }
             completer.addCancellationListener({ job.cancel() }, Runnable::run)

--- a/android/app/src/main/java/com/onair/hearit/service/PlayerNotificationManager.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlayerNotificationManager.kt
@@ -12,6 +12,7 @@ class PlayerNotificationManager(
     private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
+    // PlayerNotificationManager는 서비스가 안정적으로 시작되고 포그라운드 상태를 유지하기 위해 필요한 알림을 제공하는 역할을 합니다.
     init {
         createNotificationChannel()
     }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- PlaybackService 및 미디어 알림을 리팩토링 한다.

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부
<img width="260" alt="android1" src="https://github.com/user-attachments/assets/044dee0e-397d-48c7-852f-c49dacd910b4" />

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#370 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 플레이어/알림 메타데이터에 아티스트 정보로 콘텐츠 출처가 표시됩니다.
* 개선
  * 재생 시작 시 컨트롤러 준비가 완료되면 자동으로 즉시 재생이 시작됩니다.
  * 기본 제목이 “hEARit”로 표기됩니다.
* 문서
  * 서비스 유지와 알림 동작 관련 주석이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->