### PR TITLE
[AN] 라이브러리 화면 및 북마크 리팩터링

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/mapper/BookmarkMapper.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/mapper/BookmarkMapper.kt
@@ -2,6 +2,8 @@ package com.onair.hearit.data.mapper
 
 import com.onair.hearit.data.dto.BookmarkResponse
 import com.onair.hearit.domain.model.Bookmark
+import com.onair.hearit.domain.model.PageResult
+import com.onair.hearit.domain.model.Paging
 
 fun BookmarkResponse.Content.toDomain(): Bookmark =
     Bookmark(
@@ -10,4 +12,17 @@ fun BookmarkResponse.Content.toDomain(): Bookmark =
         title = title,
         summary = summary,
         playTime = playTime,
+    )
+
+fun BookmarkResponse.toDomain(): PageResult<Bookmark> =
+    PageResult(
+        items = content.map { it.toDomain() },
+        paging =
+            Paging(
+                page = page,
+                size = size,
+                totalPages = totalPages,
+                isFirst = isFirst,
+                isLast = isLast,
+            ),
     )

--- a/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/BookmarkRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.onair.hearit.data.repository
 import com.onair.hearit.data.datasource.remote.BookmarkRemoteDataSource
 import com.onair.hearit.data.mapper.toDomain
 import com.onair.hearit.domain.model.Bookmark
+import com.onair.hearit.domain.model.PageResult
 import com.onair.hearit.domain.repository.BookmarkRepository
 
 class BookmarkRepositoryImpl(
@@ -11,10 +12,7 @@ class BookmarkRepositoryImpl(
     override suspend fun getBookmarks(
         page: Int?,
         size: Int?,
-    ): Result<List<Bookmark>> =
-        bookmarkDataSource.getBookmarks(page, size).mapOrThrowDomain { bookmarkResponse ->
-            bookmarkResponse.content.map { it.toDomain() }
-        }
+    ): Result<PageResult<Bookmark>> = bookmarkDataSource.getBookmarks(page, size).mapOrThrowDomain { it.toDomain() }
 
     override suspend fun addBookmark(hearitId: Long): Result<Long> = bookmarkDataSource.addBookmark(hearitId).mapOrThrowDomain { it.id }
 

--- a/android/app/src/main/java/com/onair/hearit/domain/DomainException.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/DomainException.kt
@@ -1,13 +1,7 @@
 package com.onair.hearit.domain
 
-sealed class DomainException(
-    message: String? = null,
-) : Exception(message) {
+sealed class DomainException : Exception() {
     data object NetworkConnection : DomainException()
 
     data object UserNotRegistered : DomainException()
-
-    data class NoBookmark(
-        val reason: String,
-    ) : DomainException(reason)
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/BookmarkRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/BookmarkRepository.kt
@@ -1,12 +1,13 @@
 package com.onair.hearit.domain.repository
 
 import com.onair.hearit.domain.model.Bookmark
+import com.onair.hearit.domain.model.PageResult
 
 interface BookmarkRepository {
     suspend fun getBookmarks(
         page: Int?,
         size: Int?,
-    ): Result<List<Bookmark>>
+    ): Result<PageResult<Bookmark>>
 
     suspend fun addBookmark(hearitId: Long): Result<Long>
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/BindingAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/BindingAdapter.kt
@@ -125,6 +125,14 @@ fun setBookmarkVisibleIfNotLogin(
     view.isVisible = state is BookmarkUiState.NotLoggedIn
 }
 
+@BindingAdapter("visibleBookmarkIfNoBookmarks")
+fun setBookmarkIfNoBookmarks(
+    view: View,
+    state: BookmarkUiState?,
+) {
+    view.isVisible = state is BookmarkUiState.NoBookmarks
+}
+
 @BindingAdapter("backgroundColor")
 fun setBackgroundColor(
     view: View,

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/BaseControllerView.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/BaseControllerView.kt
@@ -113,8 +113,8 @@ class BaseControllerView
             val duration = player.duration
 
             binding.exoPosition.text = Util.getStringForTime(formatBuilder, formatter, pos)
-            binding.exoDuration.text =
-                "-${Util.getStringForTime(formatBuilder, formatter, duration - pos)}"
+            val remaining = maxOf(duration - pos, 0L)
+            binding.exoDuration.text = "-${Util.getStringForTime(formatBuilder, formatter, remaining)}"
 
             binding.exoProgress.setPosition(pos)
             binding.exoProgress.setBufferedPosition(buf)

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
@@ -198,13 +198,6 @@ class PlayerDetailActivity :
                             .commit()
                         return true
                     }
-
-                    override fun onScroll(
-                        e1: MotionEvent?,
-                        e2: MotionEvent,
-                        distanceX: Float,
-                        distanceY: Float,
-                    ): Boolean = false
                 },
             )
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/script/ScriptFragment.kt
@@ -11,7 +11,9 @@ import androidx.concurrent.futures.await
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
@@ -27,7 +29,6 @@ import com.onair.hearit.presentation.detail.PlayerDetailViewModelFactory
 import com.onair.hearit.presentation.dpToPx
 import com.onair.hearit.presentation.login.LoginActivity
 import com.onair.hearit.service.PlaybackService
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -40,7 +41,6 @@ class ScriptFragment : Fragment() {
     private var isUserScrolling = false
     private var lastUserScrollTime = 0L
 
-    private var scriptSyncJob: Job? = null
     private var mediaController: MediaController? = null
 
     private val adapter: ScriptAdapter by lazy {
@@ -179,13 +179,15 @@ class ScriptFragment : Fragment() {
         }
     }
 
+    @UnstableApi
     private fun startScriptSync(controller: Player) {
-        scriptSyncJob =
-            viewLifecycleOwner.lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 while (isActive) {
                     val position = controller.currentPosition
                     val currentItem =
-                        adapter.currentList.firstOrNull { position in it.start until it.end }
+                        adapter.currentList
+                            .firstOrNull { position in it.start until it.end }
                     val currentIndex = adapter.currentList.indexOf(currentItem)
 
                     val now = System.currentTimeMillis()
@@ -193,26 +195,25 @@ class ScriptFragment : Fragment() {
                     if (isUserScrolling) {
                         val isVisible = isItemVisible(currentIndex)
                         if (now - lastUserScrollTime > USER_SCROLL_IDLE_THRESHOLD_MS && isVisible) {
-                            isUserScrolling =
-                                false
+                            isUserScrolling = false
                         }
                     }
 
-                    if (currentItem != null) adapter.highlightScriptLine(currentItem.id)
+                    currentItem?.let { adapter.highlightScriptLine(it.id) }
 
                     if (!isUserScrolling && currentItem != null) {
                         val scriptHeight = binding.rvScript.height
                         if (scriptHeight > 0) {
-                            val centerOffset = binding.rvScript.height / 2 - itemHeightPx / 2
-                            (binding.rvScript.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(
-                                currentIndex,
-                                centerOffset,
-                            )
+                            val centerOffset = scriptHeight / 2 - itemHeightPx / 2
+                            (binding.rvScript.layoutManager as? LinearLayoutManager)
+                                ?.scrollToPositionWithOffset(currentIndex, centerOffset)
                         }
                     }
+
                     delay(updateInterval)
                 }
             }
+        }
     }
 
     private fun isItemVisible(position: Int): Boolean {
@@ -243,7 +244,6 @@ class ScriptFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        scriptSyncJob?.cancel()
         binding.playerView.player = null
         mediaController?.release()
         _binding = null

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/BookmarkUiState.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/BookmarkUiState.kt
@@ -1,15 +1,9 @@
 package com.onair.hearit.presentation.library
 
-import com.onair.hearit.domain.model.Bookmark
-
 sealed class BookmarkUiState {
     data object LoggedIn : BookmarkUiState()
 
     data object NotLoggedIn : BookmarkUiState()
 
     data object NoBookmarks : BookmarkUiState()
-
-    data class BookmarksExist(
-        val bookmarks: List<Bookmark>,
-    ) : BookmarkUiState()
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
@@ -115,7 +115,7 @@ class LibraryFragment :
                     val lastVisibleItem = layoutManager.findLastVisibleItemPosition()
                     val totalItemCount = layoutManager.itemCount
 
-                    if (lastVisibleItem >= totalItemCount - 3 && viewModel.isLoading.value != true) {
+                    if (lastVisibleItem >= totalItemCount - LOAD_MORE_THRESHOLD && viewModel.isLoading.value != true) {
                         viewModel.loadNextPage()
                     }
                 }
@@ -136,5 +136,9 @@ class LibraryFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    companion object {
+        private const val LOAD_MORE_THRESHOLD = 3
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
@@ -33,7 +33,7 @@ class LibraryFragment :
     private val playerDetailLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
-                viewModel.loadNextPage()
+                viewModel.refreshBookmarks()
             }
         }
 
@@ -45,6 +45,7 @@ class LibraryFragment :
         _binding = FragmentLibraryBinding.inflate(inflater, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.rvBookmark.adapter = adapter
+        binding.rvBookmark.layoutManager = LinearLayoutManager(requireContext())
         return binding.root
     }
 
@@ -100,7 +101,7 @@ class LibraryFragment :
     }
 
     private fun setupInfiniteScroll() {
-        val layoutManager = binding.rvBookmark.layoutManager
+        val layoutManager = binding.rvBookmark.layoutManager as? LinearLayoutManager ?: return
         binding.rvBookmark.addOnScrollListener(
             object : RecyclerView.OnScrollListener() {
                 override fun onScrolled(
@@ -111,13 +112,10 @@ class LibraryFragment :
                     super.onScrolled(recyclerView, dx, dy)
                     if (dy <= 0) return
 
-                    val lastVisibleItemPosition =
-                        (layoutManager as? LinearLayoutManager)?.findLastVisibleItemPosition()
-                            ?: return
+                    val lastVisibleItem = layoutManager.findLastVisibleItemPosition()
                     val totalItemCount = layoutManager.itemCount
 
-                    // 마지막 3개 아이템에 도달하면 다음 페이지 로드
-                    if (lastVisibleItemPosition >= totalItemCount - 3 && viewModel.isLoading.value == false) {
+                    if (lastVisibleItem >= totalItemCount - 3 && viewModel.isLoading.value != true) {
                         viewModel.loadNextPage()
                     }
                 }
@@ -133,5 +131,10 @@ class LibraryFragment :
     override fun onClickBookmarkedHearit(hearitId: Long) {
         val intent = PlayerDetailActivity.newIntent(requireActivity(), hearitId)
         playerDetailLauncher.launch(intent)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
@@ -10,7 +10,6 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.onair.hearit.analytics.AnalyticsScreenInfo
@@ -84,8 +83,6 @@ class LibraryFragment :
     private fun observeViewModel() {
         viewModel.bookmarks.observe(viewLifecycleOwner) { bookmarks ->
             adapter.submitList(bookmarks)
-
-            binding.layoutLibraryWhenNoBookmark.isVisible = bookmarks.isEmpty()
         }
 
         viewModel.toastMessage.observe(viewLifecycleOwner) { resId ->

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
@@ -12,6 +12,8 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.onair.hearit.analytics.AnalyticsScreenInfo
 import com.onair.hearit.databinding.FragmentLibraryBinding
 import com.onair.hearit.di.AnalyticsProvider
@@ -26,12 +28,12 @@ class LibraryFragment :
     private val binding get() = _binding!!
 
     private val viewModel: LibraryViewModel by viewModels { LibraryViewModelFactory() }
-    private val adapter by lazy { BookmarkAdapter(this) }
+    private val adapter: BookmarkAdapter by lazy { BookmarkAdapter(this) }
 
     private val playerDetailLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == Activity.RESULT_OK) {
-                viewModel.fetchData(page = 0)
+                viewModel.loadNextPage()
             }
         }
 
@@ -54,6 +56,7 @@ class LibraryFragment :
 
         setupWindowInsets()
         observeViewModel()
+        setupInfiniteScroll()
     }
 
     override fun onResume() {
@@ -70,8 +73,6 @@ class LibraryFragment :
             v.setPadding(0, systemBars.top, 0, 0)
             insets
         }
-
-        observeViewModel()
 
         binding.layoutLibraryWhenNoLogin.btnLibraryLogin.setOnClickListener {
             val intent = Intent(requireContext(), LoginActivity::class.java)
@@ -96,6 +97,32 @@ class LibraryFragment :
         viewModel.userInfo.observe(viewLifecycleOwner) { userInfo ->
             binding.userInfo = userInfo
         }
+    }
+
+    private fun setupInfiniteScroll() {
+        val layoutManager = binding.rvBookmark.layoutManager
+        binding.rvBookmark.addOnScrollListener(
+            object : RecyclerView.OnScrollListener() {
+                override fun onScrolled(
+                    recyclerView: RecyclerView,
+                    dx: Int,
+                    dy: Int,
+                ) {
+                    super.onScrolled(recyclerView, dx, dy)
+                    if (dy <= 0) return
+
+                    val lastVisibleItemPosition =
+                        (layoutManager as? LinearLayoutManager)?.findLastVisibleItemPosition()
+                            ?: return
+                    val totalItemCount = layoutManager.itemCount
+
+                    // 마지막 3개 아이템에 도달하면 다음 페이지 로드
+                    if (lastVisibleItemPosition >= totalItemCount - 3 && viewModel.isLoading.value == false) {
+                        viewModel.loadNextPage()
+                    }
+                }
+            },
+        )
     }
 
     override fun onClickOption(bookmarkId: Long) {

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -39,8 +39,14 @@ class LibraryViewModel(
     private var nextPage: Int? = 0
 
     init {
-        fetchData(page = 0)
+        refreshBookmarks()
         getUserInfo()
+    }
+
+    fun refreshBookmarks() {
+        nextPage = 0
+        _bookmarks.value = emptyList()
+        fetchData(page = 0)
     }
 
     fun loadNextPage() {

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -39,8 +39,8 @@ class LibraryViewModel(
     private var nextPage: Int? = 0
 
     init {
-        refreshBookmarks()
         getUserInfo()
+        refreshBookmarks()
     }
 
     fun refreshBookmarks() {
@@ -103,8 +103,8 @@ class LibraryViewModel(
             memberRepository
                 .getUserInfo()
                 .onSuccess { userInfo ->
-                    _uiState.value = LoggedIn
                     _userInfo.value = userInfo
+                    _uiState.value = if (_bookmarks.value.isNullOrEmpty()) NoBookmarks else LoggedIn
                 }.onFailure { throwable ->
                     when (throwable) {
                         is UserNotRegistered -> {

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -11,6 +11,9 @@ import com.onair.hearit.domain.model.UserInfo
 import com.onair.hearit.domain.repository.BookmarkRepository
 import com.onair.hearit.domain.repository.MemberRepository
 import com.onair.hearit.presentation.SingleLiveData
+import com.onair.hearit.presentation.library.BookmarkUiState.LoggedIn
+import com.onair.hearit.presentation.library.BookmarkUiState.NoBookmarks
+import com.onair.hearit.presentation.library.BookmarkUiState.NotLoggedIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -30,37 +33,49 @@ class LibraryViewModel(
     private val _toastMessage = SingleLiveData<Int>()
     val toastMessage: LiveData<Int> = _toastMessage
 
+    private val _isLoading = MutableLiveData<Boolean>(false)
+    val isLoading: LiveData<Boolean> = _isLoading
+
+    private var nextPage: Int? = 0
+
     init {
         fetchData(page = 0)
         getUserInfo()
     }
 
-    fun fetchData(page: Int) {
+    fun loadNextPage() {
+        nextPage?.let { fetchData(it) }
+    }
+
+    private fun fetchData(page: Int) {
+        if (_isLoading.value == true || nextPage == null) return
+
+        _isLoading.value = true
         viewModelScope.launch {
             bookmarkRepository
                 .getBookmarks(page = page, size = null)
-                .onSuccess { bookmarks ->
-                    _bookmarks.value = bookmarks
-                    _uiState.value =
-                        if (bookmarks.isEmpty()) {
-                            BookmarkUiState.NoBookmarks
+                .onSuccess { pageResult ->
+                    val currentList = _bookmarks.value.orEmpty()
+                    _bookmarks.value = currentList + pageResult.items
+
+                    _uiState.value = if (_bookmarks.value.isNullOrEmpty()) NoBookmarks else LoggedIn
+
+                    nextPage =
+                        if (!pageResult.paging.isLast) {
+                            pageResult.paging.page + 1
                         } else {
-                            BookmarkUiState.LoggedIn
+                            null
                         }
                 }.onFailure { throwable ->
                     when (throwable) {
-                        is UserNotRegistered -> {
-                            _uiState.value = BookmarkUiState.NotLoggedIn
-                        }
-
+                        is UserNotRegistered -> _uiState.value = NotLoggedIn
                         else -> {
                             Timber.w(throwable)
                             _toastMessage.value = R.string.library_toast_bookmark_load_fail
                         }
                     }
-                    val defaultUserInfo = UserInfo(-1, "hEARit", null)
-                    _userInfo.value = defaultUserInfo
                 }
+            _isLoading.value = false
         }
     }
 
@@ -82,12 +97,12 @@ class LibraryViewModel(
             memberRepository
                 .getUserInfo()
                 .onSuccess { userInfo ->
-                    _uiState.value = BookmarkUiState.LoggedIn
+                    _uiState.value = LoggedIn
                     _userInfo.value = userInfo
                 }.onFailure { throwable ->
                     when (throwable) {
                         is UserNotRegistered -> {
-                            _uiState.value = BookmarkUiState.NotLoggedIn
+                            _uiState.value = NotLoggedIn
                         }
 
                         else -> {

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -39,9 +39,14 @@ class LibraryViewModel(
         viewModelScope.launch {
             bookmarkRepository
                 .getBookmarks(page = page, size = null)
-                .onSuccess {
-                    _uiState.value = BookmarkUiState.LoggedIn
-                    _bookmarks.value = it
+                .onSuccess { bookmarks ->
+                    _bookmarks.value = bookmarks
+                    _uiState.value =
+                        if (bookmarks.isEmpty()) {
+                            BookmarkUiState.NoBookmarks
+                        } else {
+                            BookmarkUiState.LoggedIn
+                        }
                 }.onFailure { throwable ->
                     when (throwable) {
                         is UserNotRegistered -> {

--- a/android/app/src/main/res/drawable/bg_gray1_radius_16dp.xml
+++ b/android/app/src/main/res/drawable/bg_gray1_radius_16dp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <solid android:color="@color/hearit_gray1" />
-    <corners android:radius="24dp" />
+    <corners android:radius="16dp" />
 
 </shape>

--- a/android/app/src/main/res/drawable/bg_gray2_radius_8dp.xml
+++ b/android/app/src/main/res/drawable/bg_gray2_radius_8dp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/hearit_gray1" />
+    <solid android:color="@color/hearit_dark_gray" />
     <corners android:radius="8dp" />
 
 </shape>

--- a/android/app/src/main/res/layout/dialog_login_required.xml
+++ b/android/app/src/main/res/layout/dialog_login_required.xml
@@ -5,7 +5,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/bg_gray2_radius_24dp">
+        android:background="@drawable/bg_gray1_radius_16dp">
 
         <TextView
             android:id="@+id/tv_dialog_message"
@@ -14,6 +14,7 @@
             android:layout_height="140dp"
             android:gravity="center"
             android:text="@string/all_login_dialog_message_body"
+            android:textColor="@color/hearit_gray3"
             android:textSize="16sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -23,28 +24,32 @@
             android:id="@+id/tv_dialog_cancel"
             style="@style/pretendard_sub_title"
             android:layout_width="0dp"
-            android:layout_height="60dp"
+            android:layout_height="50dp"
+            android:layout_marginBottom="20dp"
+            android:background="@drawable/bg_gray2_radius_8dp"
             android:clickable="true"
-            android:foreground="?attr/selectableItemBackground"
             android:gravity="center"
             android:text="@string/all_dialog_cancel"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_dialog_login_positive"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_dialog_message"
-            app:layout_constraintWidth_percent="0.5" />
+            app:layout_constraintWidth_percent="0.4" />
 
         <TextView
             android:id="@+id/tv_dialog_login_positive"
             style="@style/pretendard_sub_title"
             android:layout_width="0dp"
-            android:layout_height="60dp"
+            android:layout_height="50dp"
+            android:layout_marginBottom="20dp"
+            android:background="@drawable/bg_purple3_radius_8dp"
             android:clickable="true"
-            android:foreground="?attr/selectableItemBackground"
             android:gravity="center"
             android:text="@string/all_dialog_login_positive"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/tv_dialog_cancel"
-            app:layout_constraintWidth_percent="0.5" />
+            app:layout_constraintWidth_percent="0.4" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/app/src/main/res/layout/fragment_library.xml
+++ b/android/app/src/main/res/layout/fragment_library.xml
@@ -82,6 +82,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_marginTop="28dp"
+                android:layout_marginBottom="64dp"
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toBottomOf="@id/tv_bookmarked_hearit_title"
                 app:visibleBookmarkIfLogin="@{uiState}"

--- a/android/app/src/main/res/layout/fragment_library.xml
+++ b/android/app/src/main/res/layout/fragment_library.xml
@@ -19,17 +19,6 @@
         android:layout_height="match_parent"
         android:background="@drawable/bg_gradient_vertical">
 
-        <include
-            android:id="@+id/layout_library_when_no_bookmark"
-            layout="@layout/layout_library_when_no_bookmark"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/tv_bookmarked_hearit_title" />
-
         <TextView
             android:id="@+id/tv_nickname"
             style="@style/pretendard_nickname"
@@ -73,6 +62,15 @@
             <include
                 android:id="@+id/layout_library_when_no_login"
                 layout="@layout/layout_library_when_no_login"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_gravity="center"
+                android:layout_marginHorizontal="12dp"
+                app:loginState="@{uiState}" />
+
+            <include
+                android:id="@+id/layout_library_when_no_bookmark"
+                layout="@layout/layout_library_when_no_bookmark"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_gravity="center"

--- a/android/app/src/main/res/layout/layout_controller.xml
+++ b/android/app/src/main/res/layout/layout_controller.xml
@@ -32,6 +32,7 @@
 
             <TextView
                 android:id="@+id/exo_position"
+                style="@style/pretendard_body"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="6dp"
@@ -43,6 +44,7 @@
 
             <TextView
                 android:id="@+id/exo_duration"
+                style="@style/pretendard_body"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="6dp"
@@ -114,6 +116,7 @@
 
             <TextView
                 android:id="@+id/play_speed"
+                style="@style/pretendard_sub_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="28dp"

--- a/android/app/src/main/res/layout/layout_library_when_no_bookmark.xml
+++ b/android/app/src/main/res/layout/layout_library_when_no_bookmark.xml
@@ -1,17 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/hearit_black1">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <TextView
-        style="@style/pretendard_main_title"
+    <data>
+
+        <variable
+            name="loginState"
+            type="com.onair.hearit.presentation.library.BookmarkUiState" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:text="@string/library_guide_when_no_bookmark"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:layout_height="match_parent"
+        android:background="@color/hearit_black1"
+        app:visibleBookmarkIfNoBookmarks="@{loginState}">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            style="@style/pretendard_main_title"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginBottom="64dp"
+            android:gravity="center"
+            android:text="@string/library_guide_when_no_bookmark"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 라이브러리 화면 무한스크롤 구현
- 로그인 안 했을 때 북마크 다이얼로그 디자인 수정
- 라이브러리 화면 북마크 없을 때 분기처리
- 상세 화면 팟캐스트 재생 끝나면 --00:00로 오류나는 부분 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부
<img width="240" alt="Screenshot_20250814_174219" src="https://github.com/user-attachments/assets/792c5fd4-2672-4c43-b5c9-0845ef942556" />
<img width="240" alt="Screenshot_20250814_174041" src="https://github.com/user-attachments/assets/faf2b938-fa31-452c-839c-2d15eb769f7b" />
<img width="240" alt="Screenshot_20250814_174031" src="https://github.com/user-attachments/assets/d3c73c07-e5d2-4585-a33f-e5ef039682e7" />



## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#369 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 북마크 목록에 페이징 기반 무한 스크롤과 로딩 상태 표시 추가
  - 로그인/무북마크 상태의 데이터 바인딩 표시 강화(빈 상태 자동 토글)
- 버그 수정
  - 플레이어에서 음수로 보이던 남은 시간 표시 방지
- 리팩터링
  - 스크립트 동기화를 생명주기 기반으로 안정화하여 취소/재시작 개선
- 스타일
  - 로그인 필요 다이얼로그 버튼/배경 스타일 및 크기 조정
  - 컨트롤러 텍스트에 공통 글꼴 스타일 적용
  - 둥근 모서리 반경 조정 및 어두운 회색 배경 추가, 라이브러리 하단 여백 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->