### PR TITLE
[AN] bug: 북마크 삭제 시 목록 비었을 때 북마크 없음 화면 표시 #382

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -90,8 +90,13 @@ class LibraryViewModel(
             bookmarkRepository
                 .deleteBookmark(bookmarkId)
                 .onSuccess {
-                    _bookmarks.value =
-                        _bookmarks.value?.filterNot { it.bookmarkId == bookmarkId }
+                    val updatedList =
+                        _bookmarks.value?.filterNot { it.bookmarkId == bookmarkId }.orEmpty()
+                    _bookmarks.value = updatedList
+
+                    if (updatedList.isEmpty()) {
+                        _uiState.value = NoBookmarks
+                    }
                 }.onFailure {
                     _toastMessage.value = R.string.all_toast_delete_bookmark_fail
                 }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 라이브러리 화면에서 마지막 북마크를 지우면 바로 북마크 없음 화면이 뜨도록 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#382 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 북마크 삭제 후 목록이 갱신되지 않거나 오류가 발생할 수 있던 문제를 해결했습니다.
  * 마지막 북마크 삭제 시 즉시 ‘북마크 없음’ 상태가 표시되도록 개선했습니다.
  * 삭제 이후 목록 동기화를 안정화해 예외 상황을 줄이고 UI 일관성을 높였습니다.
  * 전반적인 삭제 흐름의 응답성과 사용자 피드백 표시가 더 매끄럽게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->