### PR TITLE
[AN] fix: 라이브러리 화면 진입 시 북마크 없음 UI 잠깐 표시 수정 

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.onair.hearit"
         minSdk = 29
         targetSdk = 35
-        versionCode = 1010
-        versionName = "1.0.10"
+        versionCode = 1012
+        versionName = "1.0.12"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryViewModel.kt
@@ -11,9 +11,6 @@ import com.onair.hearit.domain.model.UserInfo
 import com.onair.hearit.domain.repository.BookmarkRepository
 import com.onair.hearit.domain.repository.MemberRepository
 import com.onair.hearit.presentation.SingleLiveData
-import com.onair.hearit.presentation.library.BookmarkUiState.LoggedIn
-import com.onair.hearit.presentation.library.BookmarkUiState.NoBookmarks
-import com.onair.hearit.presentation.library.BookmarkUiState.NotLoggedIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -33,7 +30,7 @@ class LibraryViewModel(
     private val _toastMessage = SingleLiveData<Int>()
     val toastMessage: LiveData<Int> = _toastMessage
 
-    private val _isLoading = MutableLiveData<Boolean>(false)
+    private val _isLoading = MutableLiveData(false)
     val isLoading: LiveData<Boolean> = _isLoading
 
     private var nextPage: Int? = 0
@@ -54,7 +51,7 @@ class LibraryViewModel(
     }
 
     private fun fetchData(page: Int) {
-        if (_isLoading.value == true || nextPage == null) return
+        if (isLoading.value == true || nextPage == null) return
 
         _isLoading.value = true
         viewModelScope.launch {
@@ -62,19 +59,14 @@ class LibraryViewModel(
                 .getBookmarks(page = page, size = null)
                 .onSuccess { pageResult ->
                     val currentList = _bookmarks.value.orEmpty()
-                    _bookmarks.value = currentList + pageResult.items
-
-                    _uiState.value = if (_bookmarks.value.isNullOrEmpty()) NoBookmarks else LoggedIn
-
-                    nextPage =
-                        if (!pageResult.paging.isLast) {
-                            pageResult.paging.page + 1
-                        } else {
-                            null
-                        }
+                    val newList = currentList + pageResult.items
+                    _bookmarks.value = newList
+                    _uiState.value =
+                        if (newList.isEmpty()) BookmarkUiState.NoBookmarks else BookmarkUiState.LoggedIn
+                    nextPage = if (!pageResult.paging.isLast) pageResult.paging.page + 1 else null
                 }.onFailure { throwable ->
                     when (throwable) {
-                        is UserNotRegistered -> _uiState.value = NotLoggedIn
+                        is UserNotRegistered -> _uiState.value = BookmarkUiState.NotLoggedIn
                         else -> {
                             Timber.w(throwable)
                             _toastMessage.value = R.string.library_toast_bookmark_load_fail
@@ -95,7 +87,7 @@ class LibraryViewModel(
                     _bookmarks.value = updatedList
 
                     if (updatedList.isEmpty()) {
-                        _uiState.value = NoBookmarks
+                        _uiState.value = BookmarkUiState.NoBookmarks
                     }
                 }.onFailure {
                     _toastMessage.value = R.string.all_toast_delete_bookmark_fail
@@ -109,11 +101,10 @@ class LibraryViewModel(
                 .getUserInfo()
                 .onSuccess { userInfo ->
                     _userInfo.value = userInfo
-                    _uiState.value = if (_bookmarks.value.isNullOrEmpty()) NoBookmarks else LoggedIn
                 }.onFailure { throwable ->
                     when (throwable) {
                         is UserNotRegistered -> {
-                            _uiState.value = NotLoggedIn
+                            _uiState.value = BookmarkUiState.NotLoggedIn
                         }
 
                         else -> {


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 라이브러리 화면 진입 시 '북마크 없음' UI 잠깐 표시

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#387 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 북마크 목록 로딩 중 중복 요청을 방지하여 오류/깜빡임 감소.
  - 로그인되지 않은 상태와 북마크 없음 상태를 정확히 표시.
  - 페이지네이션 시 항목 누락·중복 없이 목록이 안정적으로 갱신.
  - 북마크 삭제 후 빈 상태가 즉시 반영.

- 작업
  - Android 앱 버전을 1.0.12로 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->