### PR TITLE
[AN] feat: 탐색화면 이어서 보기 구현

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/repository/ExploreDataStoreRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/ExploreDataStoreRepositoryImpl.kt
@@ -36,7 +36,22 @@ class ExploreDataStoreRepositoryImpl(
             true
         }
 
+    override suspend fun shouldShowAnimation(): Result<Boolean> =
+        runCatching {
+            var shouldShow = false
+
+            exploreDataStore.edit { preferences ->
+                val current = preferences[EXPLORE_COUNT] ?: 0
+                shouldShow = current < MAX_ANIMATION_COUNT
+                if (shouldShow) {
+                    preferences[EXPLORE_COUNT] = current + 1
+                }
+            }
+            shouldShow
+        }
+
     companion object {
         private val EXPLORE_COUNT = intPreferencesKey("explore_count")
+        private const val MAX_ANIMATION_COUNT = 2
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/ExploreDataStoreRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/ExploreDataStoreRepository.kt
@@ -6,4 +6,6 @@ interface ExploreDataStoreRepository {
     suspend fun updateExploreCount(count: Int): Result<Boolean>
 
     suspend fun clearExploreCount(): Result<Boolean>
+
+    suspend fun shouldShowAnimation(): Result<Boolean>
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -14,9 +14,8 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.media3.common.MediaItem
+import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.PagerSnapHelper
 import androidx.recyclerview.widget.RecyclerView
@@ -40,12 +39,13 @@ class ExploreFragment :
     private val binding get() = _binding!!
     private val viewModel: ExploreViewModel by activityViewModels { ExploreViewModelFactory() }
 
-    private val player by lazy { ExoPlayer.Builder(requireContext()).build() }
+    private lateinit var playerManager: ExplorePlayerManager
+    private val player get() = playerManager.player
+
     private val adapter by lazy { ShortsAdapter(player, this) }
     private val snapHelper = PagerSnapHelper()
 
     private var animator: ObjectAnimator? = null
-    private var playbackListener: Player.Listener? = null
 
     private val playerDetailLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
@@ -81,19 +81,20 @@ class ExploreFragment :
         super.onViewCreated(view, savedInstanceState)
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
-
         setupWindowInsets()
+
+        playerManager =
+            ExplorePlayerManager(
+                context = requireContext().applicationContext,
+                lifecycleScope = viewLifecycleOwner.lifecycleScope,
+                onPlaybackEnded = { scrollToNextItem() },
+                onPositionUpdated = { position -> highlightScript(position) },
+            )
+
         setupRecyclerView()
         observeViewModel()
 
         (activity as? PlayerControllerView)?.pause()
-
-        playbackListener =
-            object : Player.Listener {
-                override fun onPlaybackStateChanged(state: Int) {
-                    if (state == Player.STATE_ENDED) scrollToNextItem()
-                }
-            }.also { player.addListener(it) }
     }
 
     override fun onResume() {
@@ -102,6 +103,7 @@ class ExploreFragment :
             screenName = AnalyticsScreenInfo.Explore.NAME,
             screenClass = AnalyticsScreenInfo.Explore.CLASS,
         )
+        val player = playerManager.player
         if (!player.isPlaying && player.playbackState == Player.STATE_READY) {
             player.play()
         }
@@ -123,11 +125,19 @@ class ExploreFragment :
         return layoutManager.getPosition(snapView)
     }
 
-    private fun playAudioAtIndex(index: Int) {
+    private fun highlightScript(positionMs: Long) {
+        val index = currentIndex()
+        if (index == RecyclerView.NO_POSITION) return
+        val holder = binding.rvExplore.findViewHolderForAdapterPosition(index) as? ShortsViewHolder
+        holder?.highlightScriptLine(positionMs)
+    }
+
+    private fun playAudioAtIndex(
+        index: Int,
+        startPosition: Long = 0L,
+    ) {
         val item = adapter.currentList.getOrNull(index) ?: return
-        player.setMediaItem(MediaItem.fromUri(item.audioUrl))
-        player.prepare()
-        player.play()
+        playerManager.playAudio(item.audioUrl, startPosition)
     }
 
     private fun switchTo(newPosition: Int) {
@@ -136,28 +146,13 @@ class ExploreFragment :
         val lastPosition = viewModel.getLastPlayerPosition()
         viewModel.onPageSnapped(newPosition)
 
-        playAudioAtIndex(newPosition)
-
-        if (lastPosition > 0) {
-            player.addListener(
-                object : Player.Listener {
-                    override fun onPlaybackStateChanged(state: Int) {
-                        if (state == Player.STATE_READY) {
-                            player.seekTo(lastPosition)
-                            player.removeListener(this)
-                        }
-                    }
-                },
-            )
-        }
-
+        playAudioAtIndex(newPosition, lastPosition)
         checkAndLoadNextPage(newPosition)
     }
 
     private fun scrollToNextItem() {
         val currentPosition = currentIndex()
         val nextPosition = currentPosition + 1
-
         if (nextPosition < adapter.itemCount) {
             binding.rvExplore.smoothScrollToPosition(nextPosition)
         }
@@ -201,9 +196,7 @@ class ExploreFragment :
         }
 
         viewModel.shouldPlayAnimation.observe(viewLifecycleOwner) { isEnabled ->
-            if (isEnabled) {
-                startSwipeAnimation()
-            }
+            if (isEnabled) startSwipeAnimation()
         }
 
         viewModel.toastMessage.observe(viewLifecycleOwner) { resId ->
@@ -297,7 +290,7 @@ class ExploreFragment :
     }
 
     override fun onClickHearitInfo(hearitId: Long) {
-        val lastPosition = player.currentPosition
+        val lastPosition = playerManager.getCurrentPosition()
         AnalyticsProvider.get().logEvent(
             AnalyticsEventNames.EXPLORE_TO_DETAIL,
             mapOf(AnalyticsParamKeys.ITEM_ID to hearitId.toString()),
@@ -320,21 +313,18 @@ class ExploreFragment :
 
     override fun onPause() {
         val position = currentIndex()
-        viewModel.onPause(position, player.currentPosition, adapter.itemCount)
-        player.pause()
+        viewModel.onPause(position, playerManager.getCurrentPosition(), adapter.itemCount)
+        playerManager.pause()
         super.onPause()
     }
 
     override fun onStop() {
+        playerManager.stop()
         super.onStop()
-        player.stop()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-
-        playbackListener?.let { player.removeListener(it) }
-        playbackListener = null
 
         animator?.cancel()
         animator?.removeAllListeners()
@@ -349,7 +339,7 @@ class ExploreFragment :
 
     override fun onDestroy() {
         super.onDestroy()
-        player.release()
+        playerManager.release()
     }
 
     companion object {

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -312,15 +312,15 @@ class ExploreFragment :
     }
 
     override fun onPause() {
+        super.onPause()
         val position = currentIndex()
         viewModel.onPause(position, playerManager.getCurrentPosition(), adapter.itemCount)
         playerManager.pause()
-        super.onPause()
     }
 
     override fun onStop() {
-        playerManager.stop()
         super.onStop()
+        playerManager.stop()
     }
 
     override fun onDestroyView() {

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -13,7 +13,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
@@ -38,12 +38,11 @@ class ExploreFragment :
     @Suppress("ktlint:standard:backing-property-naming")
     private var _binding: FragmentExploreBinding? = null
     private val binding get() = _binding!!
-    private val viewModel: ExploreViewModel by viewModels { ExploreViewModelFactory() }
+    private val viewModel: ExploreViewModel by activityViewModels { ExploreViewModelFactory() }
 
     private val player by lazy { ExoPlayer.Builder(requireContext()).build() }
     private val adapter by lazy { ShortsAdapter(player, this) }
     private val snapHelper = PagerSnapHelper()
-    private var isFirstLoad = true
 
     private var animator: ObjectAnimator? = null
     private var playbackListener: Player.Listener? = null
@@ -116,12 +115,49 @@ class ExploreFragment :
         }
     }
 
-    private fun scrollToNextItem() {
-        val layoutManager = binding.rvExplore.layoutManager ?: return
-        val currentSnapView = snapHelper.findSnapView(layoutManager) ?: return
-        val currentPosition = layoutManager.getPosition(currentSnapView)
+    private fun currentIndex(): Int {
+        val layoutManager =
+            binding.rvExplore.layoutManager as? LinearLayoutManager
+                ?: return RecyclerView.NO_POSITION
+        val snapView = snapHelper.findSnapView(layoutManager) ?: return RecyclerView.NO_POSITION
+        return layoutManager.getPosition(snapView)
+    }
 
+    private fun playAudioAtIndex(index: Int) {
+        val item = adapter.currentList.getOrNull(index) ?: return
+        player.setMediaItem(MediaItem.fromUri(item.audioUrl))
+        player.prepare()
+        player.play()
+    }
+
+    private fun switchTo(newPosition: Int) {
+        if (newPosition == RecyclerView.NO_POSITION) return
+
+        val lastPosition = viewModel.getLastPlayerPosition()
+        viewModel.onPageSnapped(newPosition)
+
+        playAudioAtIndex(newPosition)
+
+        if (lastPosition > 0) {
+            player.addListener(
+                object : Player.Listener {
+                    override fun onPlaybackStateChanged(state: Int) {
+                        if (state == Player.STATE_READY) {
+                            player.seekTo(lastPosition)
+                            player.removeListener(this)
+                        }
+                    }
+                },
+            )
+        }
+
+        checkAndLoadNextPage(newPosition)
+    }
+
+    private fun scrollToNextItem() {
+        val currentPosition = currentIndex()
         val nextPosition = currentPosition + 1
+
         if (nextPosition < adapter.itemCount) {
             binding.rvExplore.smoothScrollToPosition(nextPosition)
         }
@@ -138,17 +174,7 @@ class ExploreFragment :
                     newState: Int,
                 ) {
                     if (newState == RecyclerView.SCROLL_STATE_IDLE) {
-                        val layoutManager =
-                            recyclerView.layoutManager as? LinearLayoutManager ?: return
-                        val snapView = snapHelper.findSnapView(layoutManager) ?: return
-                        val position = layoutManager.getPosition(snapView)
-                        val item = adapter.currentList.getOrNull(position) ?: return
-
-                        player.setMediaItem(MediaItem.fromUri(item.audioUrl))
-                        player.prepare()
-                        player.play()
-                        checkAndLoadNextPage(position)
-
+                        switchTo(currentIndex())
                         AnalyticsProvider.get().logEvent(AnalyticsEventNames.EXPLORE_SWIPE)
                     }
                 }
@@ -158,15 +184,25 @@ class ExploreFragment :
 
     private fun observeViewModel() {
         viewModel.shortsHearits.observe(viewLifecycleOwner) { shortsHearits ->
-            adapter.submitList(shortsHearits)
+            adapter.submitList(shortsHearits) {
+                _binding?.let { binding ->
+                    if (shortsHearits.isNotEmpty()) {
+                        val target = viewModel.currentIndex.value ?: 0
+                        val validTarget = target.coerceIn(0, shortsHearits.lastIndex)
 
-            if (isFirstLoad && shortsHearits.isNotEmpty()) {
-                viewModel.shouldPlayAnimation.observe(viewLifecycleOwner) { isEnabled ->
-                    if (isEnabled) {
-                        startSwipeAnimation()
-                        isFirstLoad = false
+                        (binding.rvExplore.layoutManager as? LinearLayoutManager)
+                            ?.scrollToPositionWithOffset(validTarget, 0)
+
+                        switchTo(validTarget)
+                        viewModel.loadAnimation()
                     }
                 }
+            }
+        }
+
+        viewModel.shouldPlayAnimation.observe(viewLifecycleOwner) { isEnabled ->
+            if (isEnabled) {
+                startSwipeAnimation()
             }
         }
 
@@ -236,10 +272,8 @@ class ExploreFragment :
         val intent = LoginActivity.newIntent(requireContext())
         startActivity(intent)
 
-        // PlaybackService 종료
         requireContext().stopService(PlaybackService.stopIntent(requireContext()))
 
-        // 현재 프래그먼트 종료
         parentFragmentManager
             .beginTransaction()
             .remove(this)
@@ -287,8 +321,15 @@ class ExploreFragment :
     }
 
     override fun onPause() {
-        super.onPause()
+        val position = currentIndex()
+        viewModel.onPause(position, player.currentPosition, adapter.itemCount)
         player.pause()
+        super.onPause()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        player.stop()
     }
 
     override fun onDestroyView() {

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExplorePlayerManager.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExplorePlayerManager.kt
@@ -1,0 +1,82 @@
+package com.onair.hearit.presentation.explore
+
+import android.content.Context
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+class ExplorePlayerManager(
+    private val context: Context,
+    private val lifecycleScope: LifecycleCoroutineScope,
+    private val onPlaybackEnded: () -> Unit,
+    private val onPositionUpdated: (Long) -> Unit,
+) {
+    val player by lazy {
+        ExoPlayer
+            .Builder(context)
+            .build()
+            .apply {
+                addListener(playbackListener)
+            }
+    }
+    private var scriptSyncJob: Job? = null
+
+    private val playbackListener =
+        object : Player.Listener {
+            override fun onPlaybackStateChanged(state: Int) {
+                if (state == Player.STATE_ENDED) {
+                    onPlaybackEnded()
+                }
+            }
+        }
+
+    fun playAudio(
+        audioUrl: String,
+        startPosition: Long = 0L,
+    ) {
+        val mediaItem = MediaItem.fromUri(audioUrl)
+        if (startPosition > 0) {
+            player.setMediaItem(mediaItem, startPosition)
+        } else {
+            player.setMediaItem(mediaItem)
+        }
+        player.prepare()
+        player.playWhenReady = true
+        startScriptSync()
+    }
+
+    fun pause() {
+        player.pause()
+    }
+
+    fun stop() {
+        player.stop()
+        scriptSyncJob?.cancel()
+    }
+
+    fun release() {
+        player.release()
+        scriptSyncJob?.cancel()
+        scriptSyncJob = null
+    }
+
+    fun getCurrentPosition(): Long = player.currentPosition
+
+    private fun startScriptSync() {
+        scriptSyncJob?.cancel()
+        scriptSyncJob =
+            lifecycleScope.launch {
+                while (isActive) {
+                    if (player.isPlaying && player.playbackState == Player.STATE_READY) {
+                        onPositionUpdated(player.currentPosition)
+                    }
+                    delay(200L)
+                }
+            }
+    }
+}

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
@@ -65,22 +65,6 @@ class ExploreViewModel(
         fetchData(cursorInfo.cursorId)
     }
 
-    private fun reFetchData() {
-        _shortsHearits.value?.lastOrNull()?.let { shortsLastItem ->
-            val lastBookmarkId = _bookmarkId.value?.get(shortsLastItem.id)
-            lastItem =
-                shortsLastItem.copy(
-                    bookmarkId = lastBookmarkId,
-                    isBookmarked = lastBookmarkId != null,
-                )
-        }
-
-        _currentIndex.value = 0
-        _bookmarkId.value = emptyMap()
-        _shortsHearits.value = emptyList()
-        fetchData(0)
-    }
-
     fun onPause(
         position: Int,
         lastPlayerPosition: Long,
@@ -161,6 +145,22 @@ class ExploreViewModel(
                 isFetchingData = false
             }
         }
+    }
+
+    private fun reFetchData() {
+        _shortsHearits.value?.lastOrNull()?.let { shortsLastItem ->
+            val lastBookmarkId = _bookmarkId.value?.get(shortsLastItem.id)
+            lastItem =
+                shortsLastItem.copy(
+                    bookmarkId = lastBookmarkId,
+                    isBookmarked = lastBookmarkId != null,
+                )
+        }
+
+        _currentIndex.value = 0
+        _bookmarkId.value = emptyMap()
+        _shortsHearits.value = emptyList()
+        fetchData(0)
     }
 
     private fun addBookmark(

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.recyclerview.widget.RecyclerView
 import com.onair.hearit.R
 import com.onair.hearit.domain.DomainException.UserNotRegistered
 import com.onair.hearit.domain.model.CursorInfo
@@ -48,15 +49,67 @@ class ExploreViewModel(
     private lateinit var cursorInfo: CursorInfo
     private var isFetchingData = false
 
+    private val _currentIndex = MutableLiveData<Int>(0)
+    val currentIndex: LiveData<Int> = _currentIndex
+
+    private var lastPlayerPosition: Long = 0L
+    private var lastItem: ShortsHearit? = null
+
     init {
         _isLoading.value = true
-        setAnimation()
-        fetchData(cursorId = 0)
+        fetchData(0)
     }
 
     fun fetchNextPage() {
-        if (cursorInfo.isEmpty || isFetchingData) return
+        if (isFetchingData || cursorInfo.isEmpty) return
         fetchData(cursorInfo.cursorId)
+    }
+
+    private fun reFetchData() {
+        _shortsHearits.value?.lastOrNull()?.let { shortsLastItem ->
+            val lastBookmarkId = _bookmarkId.value?.get(shortsLastItem.id)
+            lastItem =
+                shortsLastItem.copy(
+                    bookmarkId = lastBookmarkId,
+                    isBookmarked = lastBookmarkId != null,
+                )
+        }
+
+        _currentIndex.value = 0
+        _bookmarkId.value = emptyMap()
+        _shortsHearits.value = emptyList()
+        fetchData(0)
+    }
+
+    fun onPause(
+        position: Int,
+        lastPlayerPosition: Long,
+        itemCount: Int,
+    ) {
+        if (position == itemCount - 1) {
+            reFetchData()
+        } else {
+            if (position != RecyclerView.NO_POSITION) {
+                onPageSnapped(position)
+            }
+        }
+        saveLastPlayerPosition(lastPlayerPosition)
+    }
+
+    fun onPageSnapped(index: Int) {
+        if (_currentIndex.value != index) {
+            _currentIndex.value = index
+        }
+    }
+
+    fun saveLastPlayerPosition(position: Long) {
+        lastPlayerPosition = position
+    }
+
+    fun getLastPlayerPosition(): Long {
+        val position = lastPlayerPosition
+        lastPlayerPosition = 0L
+        return position
     }
 
     fun toggleBookmark(
@@ -71,20 +124,13 @@ class ExploreViewModel(
         }
     }
 
-    private fun setAnimation() {
+    fun loadAnimation() {
         viewModelScope.launch {
             exploreDataStoreRepository
-                .getExploreCount()
-                .onSuccess { currentCount ->
-                    if (currentCount < MAX_ANIMATION_COUNT) {
-                        val newCount = currentCount + 1
-                        exploreDataStoreRepository.updateExploreCount(newCount)
-                        _shouldPlayAnimation.value = true
-                    } else {
-                        _shouldPlayAnimation.value = false
-                    }
-                }.onFailure { throwable ->
-                    Timber.w(throwable)
+                .shouldShowAnimation()
+                .onSuccess { shouldShow ->
+                    _shouldPlayAnimation.value = shouldShow
+                }.onFailure {
                     _shouldPlayAnimation.value = false
                 }
         }
@@ -182,17 +228,17 @@ class ExploreViewModel(
         }
 
     private fun updateShortsHearit(newItems: List<ShortsHearit>) {
-        _shortsHearits.value = _shortsHearits.value.orEmpty() + newItems
-
-        _bookmarkId.value =
-            _bookmarkId.value.orEmpty().toMutableMap().apply {
-                newItems.forEach { item ->
-                    this[item.id] = item.bookmarkId
-                }
+        val combinedList =
+            if (lastItem != null) {
+                val uniqueNewItems = newItems.filter { it.id != lastItem?.id }
+                listOf(lastItem!!) + uniqueNewItems
+            } else {
+                _shortsHearits.value.orEmpty() + newItems
             }
-    }
 
-    companion object {
-        private const val MAX_ANIMATION_COUNT = 2
+        _shortsHearits.value = combinedList
+        _bookmarkId.value = combinedList.associate { it.id to it.bookmarkId }
+
+        lastItem = null
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ShortsAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ShortsAdapter.kt
@@ -24,6 +24,11 @@ class ShortsAdapter(
 
     override fun getItemCount(): Int = currentList.size
 
+    override fun onViewRecycled(holder: ShortsViewHolder) {
+        holder.onRecycled()
+        super.onViewRecycled(holder)
+    }
+
     companion object {
         private val DiffCallback =
             object : DiffUtil.ItemCallback<ShortsHearit>() {

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ShortsViewHolder.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ShortsViewHolder.kt
@@ -2,14 +2,11 @@ package com.onair.hearit.presentation.explore
 
 import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
-import android.os.Handler
-import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.animation.LinearInterpolator
 import androidx.annotation.OptIn
-import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -20,103 +17,75 @@ import com.onair.hearit.domain.model.ShortsHearit
 class ShortsViewHolder(
     private val binding: ItemShortsBinding,
     private val player: ExoPlayer,
-    private val shortsClickListener: ShortsClickListener,
-) : RecyclerView.ViewHolder(
-        binding.root,
-    ) {
-    private val handler = Handler(Looper.getMainLooper())
-    private var updateRunnable: Runnable? = null
-
-    private var shortsHearit: ShortsHearit? = null
-    private val exploreScriptAdapter = ExploreScriptAdapter()
-
+    private val listener: ShortsClickListener,
+) : RecyclerView.ViewHolder(binding.root) {
+    private val scriptAdapter = ExploreScriptAdapter()
     private var rotateAnimator: ObjectAnimator? = null
+    private var item: ShortsHearit? = null
 
     init {
-        binding.shortsClickListener = shortsClickListener
+        binding.shortsClickListener = listener
     }
 
     @OptIn(UnstableApi::class)
     fun bind(item: ShortsHearit) {
-        this.shortsHearit = item
+        this.item = item
         binding.hearitItem = item
-        binding.rvExploreItemScript.adapter = exploreScriptAdapter
-        exploreScriptAdapter.submitList(item.script)
+
+        binding.rvExploreItemScript.adapter = scriptAdapter
+        scriptAdapter.submitList(item.script)
 
         binding.layoutExplorePlayer.player = player
 
-        val mediaItem = MediaItem.fromUri(item.audioUrl)
-        player.setMediaItem(mediaItem)
-        player.prepare()
-        player.playWhenReady = true
+        binding.btnExploreItemBookmark.apply {
+            isSelected = item.isBookmarked
+            setOnClickListener {
+                listener.onClickBookmark(item.id) { id ->
+                    if (id != -1L) isSelected = !isSelected
+                }
+            }
+        }
 
-        val rotate =
+        startLpRotation()
+    }
+
+    fun highlightScriptLine(positionMs: Long) {
+        val item = item ?: return
+        val index = item.script.indexOfLast { script -> script.start <= positionMs }
+        val id = item.script.getOrNull(index)?.id
+
+        scriptAdapter.highlightSubtitle(id)
+        (binding.rvExploreItemScript.layoutManager as? LinearLayoutManager)
+            ?.scrollToPositionWithOffset(index, binding.rvExploreItemScript.height / 3)
+    }
+
+    private fun startLpRotation() {
+        rotateAnimator?.cancel()
+        rotateAnimator =
             ObjectAnimator.ofFloat(binding.imgExploreLp, View.ROTATION, 0f, 360f).apply {
                 duration = 3000L
                 repeatCount = ValueAnimator.INFINITE
                 interpolator = LinearInterpolator()
+                start()
             }
+    }
+
+    fun onRecycled() {
         rotateAnimator?.cancel()
-        rotateAnimator = rotate
-        rotate.start()
-
-        binding.btnExploreItemBookmark.setOnClickListener {
-            shortsClickListener.onClickBookmark(item.id) { bookmarkId ->
-                if (bookmarkId != -1L) {
-                    binding.btnExploreItemBookmark.isSelected =
-                        !binding.btnExploreItemBookmark.isSelected
-                }
-            }
-        }
-
-        binding.btnExploreItemBookmark.isSelected = item.isBookmarked
-
-        startSubtitleSync()
-    }
-
-    private fun startSubtitleSync() {
-        stopSubtitleSync()
-
-        updateRunnable =
-            object : Runnable {
-                override fun run() {
-                    updateSubtitleHighlight(player.currentPosition)
-                    handler.postDelayed(this, 500L)
-                }
-            }
-        handler.post(updateRunnable!!)
-    }
-
-    private fun stopSubtitleSync() {
-        updateRunnable?.let { handler.removeCallbacks(it) }
-        updateRunnable = null
-    }
-
-    private fun updateSubtitleHighlight(currentPositionMs: Long) {
-        val item = shortsHearit ?: return
-
-        val currentSubtitle = item.script.lastOrNull { it.start <= currentPositionMs }
-        val currentId = currentSubtitle?.id
-        val currentIndex = item.script.indexOfLast { it.start <= currentPositionMs }
-
-        exploreScriptAdapter.highlightSubtitle(currentId)
-
-        val layoutManager = binding.rvExploreItemScript.layoutManager as? LinearLayoutManager
-        layoutManager?.let {
-            val offset = binding.rvExploreItemScript.height / 3
-            it.scrollToPositionWithOffset(currentIndex, offset)
-        }
+        rotateAnimator = null
+        binding.rvExploreItemScript.adapter = null
+        item = null
     }
 
     companion object {
         fun create(
             parent: ViewGroup,
             player: ExoPlayer,
-            shortsClickListener: ShortsClickListener,
+            listener: ShortsClickListener,
         ): ShortsViewHolder {
-            val inflater = LayoutInflater.from(parent.context)
-            val binding = ItemShortsBinding.inflate(inflater, parent, false)
-            return ShortsViewHolder(binding, player, shortsClickListener)
+            val binding =
+                ItemShortsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            return ShortsViewHolder(binding, player, listener)
         }
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 탐색 화면을 나갔다가 돌아와도 보고 있던 화면을 그대로 볼 수 있도록 구현
- 탐색 화면을 나갔다가 돌아와도 보고 있던 화면을 다시 보고 싶다는 니즈가 있음

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

https://github.com/user-attachments/assets/340f2ee1-14f8-48cb-8a32-767b7376c2ea

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
- 탐색화면에 들어갔다가 나왔다가 다시 들어가도, 이전에 보던 화면이 유지됨
- 이전에 보던 화면 + 팟캐스트 재생 위치 유지
- 맨마지막까지 본 경우에는, 다시 나갔다가 들어왔을 때 해당 팟캐스트 + 새로운 9개가 보여짐

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#379 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 탐색 화면 스와이프 안내 애니메이션이 횟수 제한으로 표시되어 과도한 노출 방지.
  - 중앙화된 플레이어로 재생 복원, 자동 재생 전환 및 다음 항목 사전 로딩 지원으로 재생 경험 향상.
  - 재생 위치 기반 스크립트 하이라이트 및 해당 라인 자동 스크롤로 가사/대사 동기화 개선.

- 리팩터링
  - 뷰모델 범위 확대 및 재생 흐름 통합으로 상태 공유와 스크롤-재생 일관성 강화.

- 버그 수정/안정성
  - 뷰홀더 재활용 시 자원 정리·재생 중단 처리로 메모리 및 재생 안정성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->