### PR TITLE
[BE] feat: 내 라이브러리 응답에 Category ColorCode 추가 #391

### DIFF
--- a/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/application/BookmarkService.java
@@ -34,7 +34,7 @@ public class BookmarkService {
             PagingRequest pagingRequest) {
         Member member = getMemberByUserContext(userContext);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
-        Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByCreatedAtDesc(member, pageable);
+        Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(member, pageable);
         Page<BookmarkHearitResponse> bookmarkHearits = bookmarks.map(
                 bookmark -> BookmarkHearitResponse.of(bookmark, bookmark.getHearit()));
         return PagedResponse.from(bookmarkHearits);

--- a/backend/src/main/java/com/onair/hearit/application/explore/score/BookmarkScoreFactor.java
+++ b/backend/src/main/java/com/onair/hearit/application/explore/score/BookmarkScoreFactor.java
@@ -31,7 +31,7 @@ public class BookmarkScoreFactor implements ScoreFactor {
     }
 
     private Map<Long, Long> getBookmarkCountsByCategory(Long memberId) {
-        return bookmarkRepository.countBookmarksByCategoryId(memberId).stream()
+        return bookmarkRepository.countMemberBookmarksByCategoryId(memberId).stream()
                 .collect(Collectors.toMap(
                         CategoryBookmarkCount::getCategoryId,
                         CategoryBookmarkCount::getCount

--- a/backend/src/main/java/com/onair/hearit/dto/response/BookmarkHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/dto/response/BookmarkHearitResponse.java
@@ -8,7 +8,8 @@ public record BookmarkHearitResponse(
         Long bookmarkId,
         String title,
         String summary,
-        Integer playTime
+        Integer playTime,
+        String categoryColor
 ) {
     public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit) {
         return new BookmarkHearitResponse(
@@ -16,6 +17,7 @@ public record BookmarkHearitResponse(
                 bookmark.getId(),
                 hearit.getTitle(),
                 hearit.getSummary(),
-                hearit.getPlayTime());
+                hearit.getPlayTime(),
+                hearit.getCategory().getColorCode());
     }
 }

--- a/backend/src/main/java/com/onair/hearit/infrastructure/BookmarkRepository.java
+++ b/backend/src/main/java/com/onair/hearit/infrastructure/BookmarkRepository.java
@@ -13,7 +13,15 @@ import org.springframework.data.repository.query.Param;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
-    Page<Bookmark> findAllByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+    @Query("""
+                SELECT b
+                FROM Bookmark b
+                JOIN FETCH b.hearit
+                JOIN FETCH b.hearit.category
+                WHERE b.member = :member
+                ORDER BY b.createdAt DESC
+            """)
+    Page<Bookmark> findAllByMemberOrderByRecent(@Param("member") Member member, Pageable pageable);
 
     Optional<Bookmark> findByHearitAndMember(Hearit hearit, Member member);
 
@@ -23,7 +31,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
                 WHERE b.member.id = :memberId
                 GROUP BY b.hearit.category.id
             """)
-    List<CategoryBookmarkCount> countBookmarksByCategoryId(@Param("memberId") Long memberId);
+    List<CategoryBookmarkCount> countMemberBookmarksByCategoryId(@Param("memberId") Long memberId);
 
     boolean existsByHearitAndMember(Hearit hearit, Member member);
 }

--- a/backend/src/test/java/com/onair/hearit/infrastructure/BookmarkRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/infrastructure/BookmarkRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.onair.hearit.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.config.TestJpaAuditingConfig;
+import com.onair.hearit.domain.Bookmark;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({DbHelper.class, TestJpaAuditingConfig.class})
+@ActiveProfiles("fake-test")
+class BookmarkRepositoryTest {
+
+    @Autowired
+    private BookmarkRepository bookmarkRepository;
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Test
+    @DisplayName("멤버의 북마크를 최신 순으로 조회한다.")
+    void findAllByMemberOrderByRecentTest() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        Bookmark oldestBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit1));
+        Bookmark mideumBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit2));
+        Bookmark newestBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit3));
+
+        // when
+        Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(member,
+                PageRequest.of(0, 5));
+
+        // then
+        assertAll(() -> {
+            assertThat(bookmarks.getContent().get(0)).isEqualTo(newestBookmark);
+            assertThat(bookmarks.getContent().get(1)).isEqualTo(mideumBookmark);
+            assertThat(bookmarks.getContent().get(2)).isEqualTo(oldestBookmark);
+        });
+    }
+
+    @Test
+    @DisplayName("멤버가 특정 카테고리에 북마크한 히어릿의 개수를 조회한다.")
+    void countMemberBookmarksByCategoryIdTest() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit1));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit2));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit3));
+
+        // when
+        List<CategoryBookmarkCount> categoryBookmarkCounts = bookmarkRepository.countMemberBookmarksByCategoryId(
+                member.getId());
+
+        // then
+        assertThat(categoryBookmarkCounts.getFirst().getCount()).isEqualTo(3);
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/presentation/BookmarkControllerTest.java
@@ -69,7 +69,9 @@ class BookmarkControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].bookmarkId").description("북마크 ID"),
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].summary").description("히어릿 요약"),
-                                                        fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)")
+                                                        fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
+                                                        fieldWithPath("content[].categoryColor").description(
+                                                                "해당 히어릿 카테고리 ColoCode")
                                                 }),
                                                 Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields())
                                         ).toArray(FieldDescriptor[]::new)


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

BookmarkController.readBookmarkHearits 응답에 categoryColor 추가
repository에서 category, hearit fetch join하도록 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

BookmarkRepository 테스트
BookmarkControllerTest.readBookmarkHearitsTest 테스트

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->

close #391 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 북마크 목록에 카테고리 색상 정보가 추가되어 색상 기반 구분/표시가 가능합니다.
- 개선
  - 내 북마크 목록이 최신 활동 순으로 정렬되어 더 직관적으로 확인할 수 있습니다.
- 문서
  - API 문서에 categoryColor 응답 필드가 반영되었습니다.
- 테스트
  - 북마크 정렬 및 카테고리별 집계에 대한 리포지토리/컨트롤러 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->