### PR TITLE
[BE] feat: 실행 환경 로깅 추가 #395

### DIFF
--- a/backend/src/main/resources/log4j2/log4j2.xml
+++ b/backend/src/main/resources/log4j2/log4j2.xml
@@ -26,6 +26,9 @@
 
         <!-- 로그 파일 저장되는 디렉토리(상대경로) -->
         <Property name="logDir">log</Property>
+
+        <!-- APP_ENV 환경변수 바인딩 -->
+        <Property name="env">${spring:ENV}</Property>
     </Properties>
 
     <Appenders>
@@ -47,7 +50,9 @@
                 compact="true"
                 eventEol="true"
                 objectMessageAsJsonObject="true"
-                charset="UTF-8"/>
+                charset="UTF-8">
+                <KeyValuePair key="env" value="${env}"/>
+            </JsonLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
             </Policies>
@@ -65,7 +70,9 @@
                         compact="true"
                         eventEol="true"
                         objectMessageAsJsonObject="true"
-                        includeStacktrace="true"/>
+                        includeStacktrace="true">
+                <KeyValuePair key="env" value="${env}"/>
+            </JsonLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
             </Policies>


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유

### 변경 이유
현재 애플리케이션 로그에는 환경 구분(DEV/PROD 등) 정보가 없어, CloudWatch Metric Filter를 특정 환경에만 적용할 수 없음.

### 변경 내용

1. log4j2.xml
    - JSON 레이아웃에 env 필드 추가 (스프링 환경변수를 읽어오도록 함)

2.	환경 변수(.env / 배포 설정)
    - .env에 아래 라인 추가
        ```
        ENV=???
        ```

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부
<img width="1321" height="265" alt="image" src="https://github.com/user-attachments/assets/fc6a2ae4-387e-481a-a3d1-fe0e6b7b926a" />

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#395 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - JSON 파일 로그에 env 필드가 추가되어 배포 환경(APP_ENV/ENV)이 함께 기록됩니다. 정보 및 오류 롤링 로그 모두에 적용됩니다.

- **Chores**
  - 로깅 구성 업데이트로 환경 변수를 로깅 설정에 바인딩했습니다. 콘솔 로그 및 기타 설정에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->