### PR TITLE
[BE] release: bump version to 1.0.10-SNAPSHOT

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.onair'
-version = '1.0.09-SNAPSHOT'
+version = '1.0.10-SNAPSHOT'
 
 java {
     toolchain {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -92,7 +92,7 @@ swaggerSources {
 
 openapi3 {
     servers = [
-            { url = "http://localhost:80"; description = "로컬 서버" },
+            { url = "http://localhost:8080"; description = "로컬 서버" },
             { url = "http://hearit.o-r.kr"; description = "운영 서버" },
             { url = "http://hearit-dev.o-r.kr"; description = "개발 서버" }
     ]

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -15,7 +15,7 @@ spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
 # Server Port
-server.port=80
+server.port=8080
 
 # S3 public URL
 amazon.s3.bucket=${AMAZON_S3_BUCKET_URL}


### PR DESCRIPTION
release: bump version to 1.0.10-SNAPSHOT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 개발 환경의 서버 포트가 80에서 8080으로 변경되었습니다.
  - 로컬 실행 시 접속 주소가 http://localhost:8080 으로 바뀝니다.
  - 개발용 API 문서/엔드포인트의 기본 URL이 로컬 8080 포트로 갱신되었습니다.
  - 프로젝트 버전이 다음 스냅샷으로 업데이트되었습니다.
  - 프로덕션에는 영향이 없습니다; 개발/QA 사용자는 북마크·프록시·포트 포워딩·스크립트 설정을 업데이트하세요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->