### PR TITLE
[BE] fix: swagger 설정에서 서버 내부 포트 80으로 변경 #409

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -92,7 +92,7 @@ swaggerSources {
 
 openapi3 {
     servers = [
-            { url = "http://localhost:80"; description = "로컬 서버" },
+            { url = "http://localhost:8080"; description = "로컬 서버" },
             { url = "http://hearit.o-r.kr"; description = "운영 서버" },
             { url = "http://hearit-dev.o-r.kr"; description = "개발 서버" }
     ]


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 포트 변경에 따른 swagger url 포트 변경

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #409 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 문서
  - 로컬 환경의 OpenAPI/Swagger 서버 URL을 80 포트에서 8080 포트로 업데이트했습니다. 이제 로컬에서 API 문서와 Try it out 기능 사용 시 기본 대상이 8080으로 지정되어 연결 정확성이 향상됩니다. 프로덕션/개발 서버 설정은 그대로이며, 사용자 동작 변경은 없습니다. 로컬에서 8080 포트를 사용 중이라면 추가 설정 없이 바로 이용 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->