### PR TITLE
[BE] fix: 로그 롤링파일 삭제안되는 문제 해결 #412

### DIFF
--- a/backend/src/main/resources/log4j2/log4j2.xml
+++ b/backend/src/main/resources/log4j2/log4j2.xml
@@ -40,32 +40,36 @@
         <!-- 파일 출력 설정 -->
         <!-- INFO, WARN, ERROR, FATAL 로그 파일 -->
         <!-- txt 파일로 저장 -->
-        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/2025_08_07/log.zip) -->
+        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/all-level/2025_08_07.zip) -->
         <!-- 7개 파일 쌓이면 오래된 로그부터 삭제 -->
         <RollingFile name="RollingFile">
             <FileName>${logDir}/all-level.log</FileName>
-            <FilePattern>${logDir}/archive/%d{yyyy_MM_dd}/all-level.zip</FilePattern>
+            <FilePattern>${logDir}/archive/all-level/%d{yyyy_MM_dd}.zip</FilePattern>
             <JsonLayout
-                complete="false"
-                compact="true"
-                eventEol="true"
-                objectMessageAsJsonObject="true"
-                charset="UTF-8">
+                    complete="false"
+                    compact="true"
+                    eventEol="true"
+                    objectMessageAsJsonObject="true"
+                    charset="UTF-8">
                 <KeyValuePair key="env" value="${env}"/>
             </JsonLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
             </Policies>
-            <DefaultRolloverStrategy max="7"/>
+            <DefaultRolloverStrategy>
+                <Delete basePath="${logDir}/archive/all-level" maxDepth="1">
+                    <IfLastModified age="7d"/>
+                </Delete>
+            </DefaultRolloverStrategy>
         </RollingFile>
 
         <!-- ERROR, FATAL 로그 파일-->
         <!-- json 파일로 저장 -->
-        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/2025_08_07/error-log.zip) -->
+        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/error/2025_08_07.zip) -->
         <!-- 20개 파일 쌓이면 오래된 로그부터 삭제 -->
         <RollingFile name="RollingErrorFile">
             <FileName>${logDir}/error.log</FileName>
-            <FilePattern>${logDir}/archive/%d{yyyy_MM_dd}/error.zip</FilePattern>
+            <FilePattern>${logDir}/archive/error/%d{yyyy_MM_dd}.zip</FilePattern>
             <JsonLayout complete="false"
                         compact="true"
                         eventEol="true"
@@ -76,7 +80,11 @@
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
             </Policies>
-            <DefaultRolloverStrategy max="20"/>
+            <DefaultRolloverStrategy>
+                <Delete basePath="${logDir}/archive/error" maxDepth="1">
+                    <IfLastModified age="20d"/>
+                </Delete>
+            </DefaultRolloverStrategy>
         </RollingFile>
     </Appenders>
 


### PR DESCRIPTION
- all level, error를 폴더로 분리하고 파일명을 날짜로 변경
- DefaultRolloverStrategy basePath 지정

<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

```xml
<DefaultRolloverStrategy>
                <Delete basePath="${logDir}/archive/all-level" maxDepth="1">
                    <IfLastModified age="7d"/>
                </Delete>
</DefaultRolloverStrategy>
```

으로 이제 log/archive/all-level/ (혹은 /error) 하위에 롤링 파일이 저장되고, 파일 명은 날짜로 저장됨
2m으로 테스트해봤을 때 삭제되는 것 확인 완료

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->

close #412


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능: 없음
- 버그 수정: 없음
- 리팩터: 없음
- 문서: 없음
- 테스트: 없음
- 스타일: 없음
- 작업(Chores)
  - 로그 아카이브 디렉터리 구조를 레벨별 하위 폴더로 재배치하여 탐색성과 관리성을 향상.
  - 보존 정책을 최대 개수 기반에서 기간 기반 삭제로 전환: 전체 로그 7일, 오류 로그 20일 보존.
  - 일 단위 롤오버 정책은 그대로 유지되어 운영 중 동작에는 변화 없음.
  - 문서화 주석을 최신 상태로 정리하여 설정 의도를 명확화.
  - 마이그레이션 시 기존 아카이브 위치를 참고해 필요시 백업 권장.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->