### PR TITLE
[AN] feat: 앱 난독화 proguard 적용

### DIFF
--- a/.github/workflows/android-cd-dev.yml
+++ b/.github/workflows/android-cd-dev.yml
@@ -3,6 +3,8 @@ name: Hearit Android dev CD
 on:
   pull_request:
     branches: [ "develop" ]
+    paths:
+      - 'android/**'
 
 env:
   BASE_URL: ${{ secrets.BASE_URL }}

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-release.aab
-          path: .android/app/build/outputs/bundle/release/app-release.aab
+          path: ./android/app/build/outputs/bundle/release/app-release.aab
           overwrite: 'true'
 
       - name: Deploy AAB On Google Play Console

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -61,11 +61,11 @@ jobs:
           path: .android/app/build/outputs/bundle/release/app-release.aab
           overwrite: 'true'
 
-#      - name: Deploy AAB On Google Play Console
-#        uses: r0adkll/upload-google-play@v1.1.3
-#        with:
-#          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
-#          packageName: com.onair.hearit
-#          releaseFiles: ./android/app/build/outputs/bundle/release/app-release.aab
-#          track: alpha
-#          whatsNewDirectory: ./android/app/whatsnew
+      - name: Deploy AAB On Google Play Console
+        uses: r0adkll/upload-google-play@v1.1.3
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+          packageName: com.onair.hearit
+          releaseFiles: ./android/app/build/outputs/bundle/release/app-release.aab
+          track: alpha
+          whatsNewDirectory: ./android/app/whatsnew

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -2,13 +2,13 @@ name: Hearit Android CI
 
 on:
   pull_request:
-    branches: [ "main", "develop-an" ]
+    branches: [ "develop-an" ]
     paths:
       - 'android/**'
 
 env:
   BASE_URL: ${{ secrets.BASE_URL }}
-  GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}        
+  GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
 
 jobs:
   build:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.onair.hearit"
         minSdk = 29
         targetSdk = 35
-        versionCode = 1012
-        versionName = "1.0.12"
+        versionCode = 1013
+        versionName = "1.0.13"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -54,7 +54,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -19,3 +19,79 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+#-keep class com.onair.hearit.** { *; }
+
+# -------------------------
+# kakao SDK
+# -------------------------
+-keep class com.kakao.sdk.**.model.* { <fields>; }
+
+# Retrofit does reflection on generic parameters.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Kotlin extension for suspend support
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+
+# Proxy 기반 인터페이스 보존
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
+# -------------------------
+# Kotlin & Coroutine
+# -------------------------
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+-keepattributes *Annotation*
+
+# Retrofit Response wrapper
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+# -------------------------
+# kotlinx-serialization
+# -------------------------
+-keepclassmembers class kotlinx.serialization.** { *; }
+-keepclassmembers class * {
+    @kotlinx.serialization.SerialName <fields>;
+}
+-dontnote kotlinx.serialization.**
+
+# -------------------------
+# Timber 로그 제거 (릴리즈)
+# -------------------------
+-assumenosideeffects class timber.log.Timber {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+}
+
+# -------------------------
+# Firebase Crashlytics
+# -------------------------
+-keepattributes SourceFile,LineNumberTable
+-keep class com.google.firebase.crashlytics.** { *; }
+-dontwarn com.google.firebase.crashlytics.**


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
- 앱 난독화 적용
- proguard.pro 파일 설정

## 📸 스크린샷 (선택)

- 앱 용량 22MB -> 13MB로 줄어듬

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#393 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * v1.0.13 출시
  * 릴리스 빌드에서 코드 난독화·리소스 축소 및 불필요 로깅 제거로 앱 용량 감소 및 로드 안정성 향상
  * 프로가드 설정 강화로 외부 SDK와 직렬화/리플렉션 의존성 보존

* Chores
  * Android CI/CD 워크플로우의 브랜치·경로 기반 트리거 정교화로 불필요한 실행 감소
  * 스토어 배포 단계 활성화로 알파 트랙 자동 배포 정비
<!-- end of auto-generated comment: release notes by coderabbit.ai -->