### PR TITLE
Revert "[BE] fix: server port 번호 변경 #406"

### DIFF
--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -15,7 +15,7 @@ spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
 # Server Port
-server.port=8080
+server.port=80
 
 # S3 public URL
 amazon.s3.bucket=${AMAZON_S3_BUCKET_URL}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 서버 HTTP 포트를 8080에서 80으로 변경했습니다. 이제 브라우저에서 포트 번호 없이 기본 주소로 접속할 수 있어 접근성이 향상됩니다(예: http://your-domain). 기능 변경은 없으며 서비스 동작에는 영향이 없습니다. 다만 8080 포트를 포함한 기존 즐겨찾기/링크는 기본 주소로 업데이트하는 것을 권장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->