### PR TITLE
Revert "[BE] fix: swagger 설정에서 서버 내부 포트 80으로 변경 #409"

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -92,7 +92,7 @@ swaggerSources {
 
 openapi3 {
     servers = [
-            { url = "http://localhost:8080"; description = "로컬 서버" },
+            { url = "http://localhost:80"; description = "로컬 서버" },
             { url = "http://hearit.o-r.kr"; description = "운영 서버" },
             { url = "http://hearit-dev.o-r.kr"; description = "개발 서버" }
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 로컬 환경의 OpenAPI 서버 접속 주소를 http://localhost:80 으로 변경했습니다. 사용자는 앱 기능이나 동작 변화를 느끼지 않습니다. 운영 및 스테이징 환경에는 영향이 없습니다. 로컬에서 API 문서를 확인할 때 기본 포트를 사용하므로 접속이 일관되고 간편해집니다. 개발용 링크가 표준 포트를 사용해 일부 네트워크 설정에서도 접속 성공률이 높아집니다. 별도 조치는 필요 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->