### PR TITLE
[BE] chore: private subnet에 위치한 서버의 deploy 설정 변경 #424

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -93,5 +93,5 @@ jobs:
           aws ssm send-command \
               --instance-ids "$PUBLIC_EC2_ID" \
               --document-name "AWS-RunShellScript" \
-              --parameters commands="sudo sed -i 's/proxy_pass http:\/\/.*:80/proxy_pass http:\/\/'$PRIVATE_IP':80/g' /etc/nginx/sites-available/default; sudo nginx -t && sudo nginx -s reload" \
+              --parameters commands="sudo sed -i 's|proxy_pass http://.*:80|proxy_pass http://$PRIVATE_IP:80|g' /etc/nginx/sites-available/default; sudo nginx -t && sudo nginx -s reload" \
               --region ap-northeast-2

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-disabled: true
 
       - name: Build with Gradle
         working-directory: backend

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -85,24 +85,22 @@ jobs:
       - name: Run deploy script with sudo
         run: sudo bash ~/hearit/deploy.sh
 
-      - name: Configure Nginx reverse proxy
+      - name: Point Nginx (dev) upstream to this private IP
         shell: bash
         run: |
           set -euo pipefail
-
           PUBLIC_EC2_ID="${{ secrets.PUBLIC_NGINX_EC2_ID }}"
           PRIVATE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
-          
+
           cat > /tmp/ssm-params.json <<'EOF'
           {
             "commands": [
-              "sudo sed -i.bak 's|proxy_pass http://[^:]*:80|proxy_pass http://__PRIVATE_IP__:80|g' /etc/nginx/sites-available/default",
+              "cat >/etc/nginx/conf.d/upstream_dev.conf <<UP\nupstream backend_dev { server __PRIVATE_IP__:80; keepalive 32; }\nUP",
               "sudo nginx -t",
-              "sudo nginx -s reload"
+              "sudo systemctl reload nginx"
             ]
           }
           EOF
-
           sed -i "s|__PRIVATE_IP__|$PRIVATE_IP|g" /tmp/ssm-params.json
 
           aws ssm send-command \
@@ -110,4 +108,4 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --parameters file:///tmp/ssm-params.json \
             --region ap-northeast-2 \
-            --comment "Update proxy_pass to $PRIVATE_IP and reload Nginx"
+            --comment "Update backend_dev upstream to $PRIVATE_IP:80 and reload Nginx"

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -1,10 +1,15 @@
 name: Backend CD to EC2 for dev
 
+#on:
+#  push:
+#    branches: [ "develop-be" ]
+#    paths:
+#      - 'backend/**'
+#  workflow_dispatch:
+    
 on:
   push:
-    branches: [ "develop-be" ]
-    paths:
-      - 'backend/**'
+    branches: [ "develop-be", "chore/#424-private-subnet-ci-cd" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -84,28 +84,3 @@ jobs:
 
       - name: Run deploy script with sudo
         run: sudo bash ~/hearit/deploy.sh
-
-      - name: Point Nginx (dev) upstream to this private IP
-        shell: bash
-        run: |
-          set -euo pipefail
-          PUBLIC_EC2_ID="${{ secrets.PUBLIC_NGINX_EC2_ID }}"
-          PRIVATE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
-
-          cat > /tmp/ssm-params.json <<'EOF'
-          {
-            "commands": [
-              "cat >/etc/nginx/conf.d/upstream_dev.conf <<UP\nupstream backend_dev { server __PRIVATE_IP__:80; keepalive 32; }\nUP",
-              "sudo nginx -t",
-              "sudo systemctl reload nginx"
-            ]
-          }
-          EOF
-          sed -i "s|__PRIVATE_IP__|$PRIVATE_IP|g" /tmp/ssm-params.json
-
-          aws ssm send-command \
-            --instance-ids "$PUBLIC_EC2_ID" \
-            --document-name "AWS-RunShellScript" \
-            --parameters file:///tmp/ssm-params.json \
-            --region ap-northeast-2 \
-            --comment "Update backend_dev upstream to $PRIVATE_IP:80 and reload Nginx"

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -93,5 +93,5 @@ jobs:
           aws ssm send-command \
               --instance-ids "$PUBLIC_EC2_ID" \
               --document-name "AWS-RunShellScript" \
-              --parameters commands="sudo sed -i 's/proxy_pass http:\/\/.*:8080/proxy_pass http:\/\/'$PRIVATE_IP':8080/g' /etc/nginx/sites-available/default; sudo nginx -t && sudo nginx -s reload" \
+              --parameters commands="sudo sed -i 's/proxy_pass http:\/\/.*:80/proxy_pass http:\/\/'$PRIVATE_IP':80/g' /etc/nginx/sites-available/default; sudo nginx -t && sudo nginx -s reload" \
               --region ap-northeast-2

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -77,3 +77,14 @@ jobs:
 
       - name: Run deploy script with sudo
         run: sudo bash ~/hearit/deploy.sh
+
+      - name: Configure Nginx reverse proxy
+        run: |
+          PUBLIC_EC2_ID="${{ secrets.PUBLIC_NGINX_EC2_ID }}"
+          PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+
+          aws ssm send-command \
+              --instance-ids "$PUBLIC_EC2_ID" \
+              --document-name "AWS-RunShellScript" \
+              --parameters commands="sudo sed -i 's/proxy_pass http:\/\/.*:8080/proxy_pass http:\/\/'$PRIVATE_IP':8080/g' /etc/nginx/sites-available/default; sudo nginx -t && sudo nginx -s reload" \
+              --region ap-northeast-2

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -1,15 +1,10 @@
 name: Backend CD to EC2 for dev
 
-#on:
-#  push:
-#    branches: [ "develop-be" ]
-#    paths:
-#      - 'backend/**'
-#  workflow_dispatch:
-    
 on:
   push:
-    branches: [ "develop-be", "chore/#424-private-subnet-ci-cd" ]
+    branches: [ "develop-be" ]
+    paths:
+      - 'backend/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -86,12 +86,28 @@ jobs:
         run: sudo bash ~/hearit/deploy.sh
 
       - name: Configure Nginx reverse proxy
+        shell: bash
         run: |
+          set -euo pipefail
+
           PUBLIC_EC2_ID="${{ secrets.PUBLIC_NGINX_EC2_ID }}"
-          PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+          PRIVATE_IP=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+          
+          cat > /tmp/ssm-params.json <<'EOF'
+          {
+            "commands": [
+              "sudo sed -i.bak 's|proxy_pass http://[^:]*:80|proxy_pass http://__PRIVATE_IP__:80|g' /etc/nginx/sites-available/default",
+              "sudo nginx -t",
+              "sudo nginx -s reload"
+            ]
+          }
+          EOF
+
+          sed -i "s|__PRIVATE_IP__|$PRIVATE_IP|g" /tmp/ssm-params.json
 
           aws ssm send-command \
-              --instance-ids "$PUBLIC_EC2_ID" \
-              --document-name "AWS-RunShellScript" \
-              --parameters commands="sudo sed -i 's|proxy_pass http://.*:80|proxy_pass http://$PRIVATE_IP:80|g' /etc/nginx/sites-available/default; sudo nginx -t && sudo nginx -s reload" \
-              --region ap-northeast-2
+            --instance-ids "$PUBLIC_EC2_ID" \
+            --document-name "AWS-RunShellScript" \
+            --parameters file:///tmp/ssm-params.json \
+            --region ap-northeast-2 \
+            --comment "Update proxy_pass to $PRIVATE_IP and reload Nginx"

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
-        with:
-          cache-disabled: true
 
       - name: Build with Gradle
         working-directory: backend

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -1,15 +1,10 @@
 name: Backend CD to EC2 for prod
 
-#on:
-#  push:
-#    branches: [ "release" ]
-#    paths:
-#      - 'backend/**'
-#  workflow_dispatch:
-
 on:
   push:
-    branches: [ "release", "chore/#424-private-subnet-ci-cd" ]
+    branches: [ "release" ]
+    paths:
+      - 'backend/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -77,3 +77,14 @@ jobs:
 
       - name: Run deploy script with sudo
         run: sudo bash ~/hearit/deploy.sh
+
+      - name: Configure Nginx reverse proxy
+        run: |
+          PUBLIC_EC2_ID="${{ secrets.PUBLIC_NGINX_EC2_ID }}"
+          PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+
+          aws ssm send-command \
+              --instance-ids "$PUBLIC_EC2_ID" \
+              --document-name "AWS-RunShellScript" \
+              --parameters commands="sudo sed -i 's/proxy_pass http:\/\/.*:8080/proxy_pass http:\/\/'$PRIVATE_IP':8080/g' /etc/nginx/sites-available/default; sudo nginx -t && sudo nginx -s reload" \
+              --region ap-northeast-2

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -1,10 +1,15 @@
 name: Backend CD to EC2 for prod
 
+#on:
+#  push:
+#    branches: [ "release" ]
+#    paths:
+#      - 'backend/**'
+#  workflow_dispatch:
+
 on:
   push:
-    branches: [ "release" ]
-    paths:
-      - 'backend/**'
+    branches: [ "release", "chore/#424-private-subnet-ci-cd" ]
   workflow_dispatch:
 
 jobs:
@@ -63,7 +68,7 @@ jobs:
   deploy:
     name: Deploy on EC2 for prod
     needs: build
-    runs-on: [ self-hosted, backend, Linux, ARM64 ]
+    runs-on: [ self-hosted, backend-prod, Linux, ARM64 ]
 
     steps:
       - name: Download jar artifact
@@ -77,14 +82,3 @@ jobs:
 
       - name: Run deploy script with sudo
         run: sudo bash ~/hearit/deploy.sh
-
-      - name: Configure Nginx reverse proxy
-        run: |
-          PUBLIC_EC2_ID="${{ secrets.PUBLIC_NGINX_EC2_ID }}"
-          PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
-
-          aws ssm send-command \
-              --instance-ids "$PUBLIC_EC2_ID" \
-              --document-name "AWS-RunShellScript" \
-              --parameters commands="sudo sed -i 's/proxy_pass http:\/\/.*:8080/proxy_pass http:\/\/'$PRIVATE_IP':8080/g' /etc/nginx/sites-available/default; sudo nginx -t && sudo nginx -s reload" \
-              --region ap-northeast-2


### PR DESCRIPTION
  - 프로덕션 배포 라벨만 변경했습니다. runner를 다시 띄우면서 backend -> backend-prod 라벨로 변경해서 그렇습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 사용자에게 노출되는 변화는 없습니다.
- 유지보수(Chores)
  - 프로덕션 배포의 실행 환경 라벨을 전용 러너 레이블("backend-prod")로 변경했습니다.
  - 워크플로우 트리거(브랜치/경로 및 수동 실행)는 기존과 동일하게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->