### PR TITLE
[BE] fix: 스웨거의 server url을 https로 변경  #426

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -93,8 +93,8 @@ swaggerSources {
 openapi3 {
     servers = [
             { url = "http://localhost:80"; description = "로컬 서버" },
-            { url = "http://hearit.o-r.kr"; description = "운영 서버" },
-            { url = "http://hearit-dev.o-r.kr"; description = "개발 서버" }
+            { url = "https://hearit.o-r.kr"; description = "운영 서버" },
+            { url = "https://hearit-dev.o-r.kr"; description = "개발 서버" }
     ]
     title = "Hearit API 문서"
     description = "Spring REST Docs와 Swagger UI를 이용한 API 명세서"


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

### 변경 내용
스웨거 ui 테스트 동작을 위한 http -> https 변경
### 이유
Swagger UI 내부 동작 방식
- Swagger UI는 내부적으로 fetch 또는 XMLHttpRequest를 사용해 요청을 보냄 
- HTTP → HTTPS 리다이렉션은 브라우저가 관장 ,브라우저 주소창에 http  로 입력하면 브라우저 차원에서 HTTPS로 리다이렉트됨
- 하지만 Swagger의 fetch 요청은 JavaScript 코드 내에서 발생 → 브라우저가 자동 리다이렉트 처리 안 함 
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#426 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * OpenAPI 서버 정의의 운영/개발 기본 URL을 모두 HTTPS로 갱신하여 보안 연결을 기본값으로 통일했습니다.
* Documentation
  * 공개 API 명세에 최신 HTTPS 서버 주소를 반영해 사용자와 클라이언트가 올바른 엔드포인트에 연결되도록 안내했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->