### PR TITLE
[BE] release: 1.1.0

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -63,7 +63,7 @@ jobs:
   deploy:
     name: Deploy on EC2 for prod
     needs: build
-    runs-on: [ self-hosted, backend, Linux, ARM64 ]
+    runs-on: [ self-hosted, backend-prod, Linux, ARM64 ]
 
     steps:
       - name: Download jar artifact

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -77,6 +77,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Flyaway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 }
 
 tasks.named('jar') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.onair'
-version = '1.0.11-SNAPSHOT'
+version = '1.1.0-SNAPSHOT'
 
 java {
     toolchain {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -93,8 +93,8 @@ swaggerSources {
 openapi3 {
     servers = [
             { url = "http://localhost:80"; description = "로컬 서버" },
-            { url = "http://hearit.o-r.kr"; description = "운영 서버" },
-            { url = "http://hearit-dev.o-r.kr"; description = "개발 서버" }
+            { url = "https://hearit.o-r.kr"; description = "운영 서버" },
+            { url = "https://hearit-dev.o-r.kr"; description = "개발 서버" }
     ]
     title = "Hearit API 문서"
     description = "Spring REST Docs와 Swagger UI를 이용한 API 명세서"

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.onair'
-version = '1.0.10-SNAPSHOT'
+version = '1.0.11-SNAPSHOT'
 
 java {
     toolchain {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -92,7 +92,7 @@ swaggerSources {
 
 openapi3 {
     servers = [
-            { url = "http://localhost:8080"; description = "로컬 서버" },
+            { url = "http://localhost:80"; description = "로컬 서버" },
             { url = "http://hearit.o-r.kr"; description = "운영 서버" },
             { url = "http://hearit-dev.o-r.kr"; description = "개발 서버" }
     ]

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/ExploredHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/ExploredHearitResponse.java
@@ -43,11 +43,11 @@ public record ExploredHearitResponse(
                 .toList();
     }
 
-    private record KeywordResponse(
+    public record KeywordResponse(
             Long id,
             String name
     ) {
-        public static KeywordResponse from(Keyword keyword) {
+        private static KeywordResponse from(Keyword keyword) {
             return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
@@ -71,12 +71,12 @@ public record HearitDetailResponse(
         }
     }
 
-    private record KeywordResponse(
+    public record KeywordResponse(
             Long id,
             String name
     ) {
 
-        public static KeywordResponse from(Keyword keyword) {
+        private static KeywordResponse from(Keyword keyword) {
             return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()
@@ -84,12 +84,12 @@ public record HearitDetailResponse(
         }
     }
 
-    private record SourceResponse(
+    public record SourceResponse(
             String sourceName,
             String sourceUrl
     ) {
 
-        public static SourceResponse from(Source source) {
+        private static SourceResponse from(Source source) {
             return new SourceResponse(
                     source.getSourceName(),
                     source.getSourceUrl()

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
@@ -62,11 +62,12 @@ public record HearitDetailResponse(
 
     public record CategoryResponse(
             Long id,
-            String name
+            String name,
+            String colorCode
     ) {
 
         private static CategoryResponse of(Category category) {
-            return new CategoryResponse(category.getId(), category.getName());
+            return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
         }
     }
 

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.app.dto.response;
 
 import com.onair.hearit.common.domain.Bookmark;
+import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Source;
@@ -16,7 +17,7 @@ public record HearitDetailResponse(
         LocalDateTime createdAt,
         Boolean isBookmarked,
         Long bookmarkId,
-        String category,
+        CategoryResponse category,
         List<KeywordResponse> keywords
 ) {
     public static HearitDetailResponse from(Hearit hearit, List<Keyword> keywords) {
@@ -31,7 +32,7 @@ public record HearitDetailResponse(
                 hearit.getCreatedAt(),
                 false,
                 null,
-                hearit.getCategory().getName(),
+                CategoryResponse.of(hearit.getCategory()),
                 keywordNames);
     }
 
@@ -47,7 +48,7 @@ public record HearitDetailResponse(
                 hearit.getCreatedAt(),
                 true,
                 bookmark.getId(),
-                hearit.getCategory().getName(),
+                CategoryResponse.of(hearit.getCategory()),
                 keywordNames);
     }
 
@@ -57,6 +58,16 @@ public record HearitDetailResponse(
 
     private static List<SourceResponse> getSources(List<Source> sources) {
         return sources.stream().map(SourceResponse::from).toList();
+    }
+
+    public record CategoryResponse(
+            Long id,
+            String name
+    ) {
+
+        private static CategoryResponse of(Category category) {
+            return new CategoryResponse(category.getId(), category.getName());
+        }
     }
 
     private record KeywordResponse(

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitOfCategoryResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitOfCategoryResponse.java
@@ -24,11 +24,11 @@ public record HearitOfCategoryResponse(
         return keywords.stream().map(KeywordResponse::from).toList();
     }
 
-    private record KeywordResponse(
+    public record KeywordResponse(
             Long id,
             String name
     ) {
-        public static KeywordResponse from(Keyword keyword) {
+        private static KeywordResponse from(Keyword keyword) {
             return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
@@ -24,11 +24,11 @@ public record HearitSearchResponse(
         return keywords.stream().map(KeywordResponse::from).toList();
     }
 
-    private record KeywordResponse(
+    public record KeywordResponse(
             Long id,
             String name
     ) {
-        public static KeywordResponse from(Keyword keyword) {
+        private static KeywordResponse from(Keyword keyword) {
             return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitsWithRecommendCategoryResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitsWithRecommendCategoryResponse.java
@@ -26,12 +26,12 @@ public record HearitsWithRecommendCategoryResponse(
                 .toList();
     }
 
-    private record HearitResponse(
+    public record HearitResponse(
             Long hearitId,
             String title,
             LocalDateTime createdAt
     ) {
-        public static HearitResponse from(Hearit hearit) {
+        private static HearitResponse from(Hearit hearit) {
             return new HearitResponse(
                     hearit.getId(),
                     hearit.getTitle(),

--- a/backend/src/main/java/com/onair/hearit/common/domain/HearitKeyword.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/HearitKeyword.java
@@ -43,13 +43,13 @@ public class HearitKeyword {
         validateKeyword(keyword);
     }
 
-    private static void validateHearit(Hearit hearit) {
+    private void validateHearit(Hearit hearit) {
         if (hearit == null) {
-            throw new InvalidInputException("키워드는 null이 될 수 없습니다.");
+            throw new InvalidInputException("히어릿은 null이 될 수 없습니다.");
         }
     }
 
-    private static void validateKeyword(Keyword keyword) {
+    private void validateKeyword(Keyword keyword) {
         if (keyword == null) {
             throw new InvalidInputException("키워드는 null이 될 수 없습니다.");
         }

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -15,7 +15,7 @@ spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
 # Server Port
-server.port=8080
+server.port=80
 
 # S3 public URL
 amazon.s3.bucket=${AMAZON_S3_BUCKET_URL}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -3,16 +3,14 @@ spring.config.import=optional:file:.env[.properties]
 
 # Dev-DataSource
 spring.datasource.url=jdbc:mysql://localhost:13306/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=root
-spring.datasource.password=${MYSQL_ROOT_PASSWORD}
+spring.datasource.username=${MYSQL_WRITER}
+spring.datasource.password=${MYSQL_WRITER_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.defer-datasource-initialization=true
-spring.sql.init.mode=always
 
 # Server Port
 server.port=80
@@ -30,13 +28,6 @@ kakao.user-info.base-url=https://kapi.kakao.com
 kakao.user-info.connectTimeout=2s
 kakao.user-info.readTimeout=3s
 
-# Swagger
-springdoc.default-produces-media-type=application/json
-springdoc.swagger-ui.path=/docs
-springdoc.swagger-ui.operations-sorter=method
-springdoc.swagger-ui.tags-sorter=alpha
-springdoc.swagger-ui.display-request-duration=true
-
 # user-default-image
 hearit.profile.default-image-url=http://hearit.o-r.kr/images/default-profile.jpg
 
@@ -51,3 +42,9 @@ spring.servlet.multipart.max-request-size=100MB
 # logging
 logging.config=classpath:log4j2/log4j2.xml
 server.forward-headers-strategy=native
+
+# Flyaway
+spring.flyway.user=${MYSQL_USER}
+spring.flyway.password=${MYSQL_PASSWORD}
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=1

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -50,3 +50,4 @@ spring.servlet.multipart.max-request-size=100MB
 
 # logging
 logging.config=classpath:log4j2/log4j2.xml
+server.forward-headers-strategy=native

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,105 @@
+CREATE TABLE `keyword` (
+                           `id` bigint NOT NULL AUTO_INCREMENT,
+                           `name` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                           PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `member` (
+                          `id` bigint NOT NULL AUTO_INCREMENT,
+                          `local_id` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                          `social_id` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                          `nickname` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                          `password` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                          `profile_image` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                          `oauth_provider` enum('GOOGLE','KAKAO','NONE') COLLATE utf8mb4_general_ci DEFAULT NULL,
+                          `created_at` datetime(6) DEFAULT NULL,
+                          `deleted_at` datetime(6) DEFAULT NULL,
+                          PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `category` (
+                            `id` bigint NOT NULL AUTO_INCREMENT,
+                            `name` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                            `color_code` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                            PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `hearit` (
+                          `id` bigint NOT NULL AUTO_INCREMENT,
+                          `category_id` bigint NOT NULL,
+                          `title` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                          `summary` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                          `original_audio_url` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                          `short_audio_url` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                          `script_url` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                          `play_time` int NOT NULL,
+                          `created_at` datetime(6) NOT NULL,
+                          PRIMARY KEY (`id`),
+                          CONSTRAINT `fk_hearit_category` FOREIGN KEY (`category_id`) REFERENCES `category` (`id`)
+);
+
+CREATE TABLE `admin` (
+                         `id` bigint NOT NULL AUTO_INCREMENT,
+                         `login_id` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                         `nickname` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                         `password` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                         PRIMARY KEY (`id`),
+                         CONSTRAINT `uq_admin_login_id` UNIQUE (`login_id`)
+);
+
+CREATE TABLE `bookmark` (
+                            `id` bigint NOT NULL AUTO_INCREMENT,
+                            `member_id` bigint NOT NULL,
+                            `hearit_id` bigint NOT NULL,
+                            `created_at` datetime(6) DEFAULT NULL,
+                            PRIMARY KEY (`id`),
+                            CONSTRAINT `uq_bookmark_member_hearit` UNIQUE (`member_id`, `hearit_id`),
+                            CONSTRAINT `fk_bookmark_member` FOREIGN KEY (`member_id`) REFERENCES `member` (`id`),
+                            CONSTRAINT `fk_bookmark_hearit` FOREIGN KEY (`hearit_id`) REFERENCES `hearit` (`id`)
+);
+
+CREATE TABLE `explore_score` (
+                                 `id` bigint NOT NULL AUTO_INCREMENT,
+                                 `member_id` bigint DEFAULT NULL,
+                                 `hearit_id` bigint NOT NULL,
+                                 `score` double NOT NULL,
+                                 `cursor_id` bigint DEFAULT NULL,
+                                 PRIMARY KEY (`id`),
+                                 CONSTRAINT `uq_explore_score_member_hearit` UNIQUE (`member_id`, `hearit_id`)
+);
+
+CREATE TABLE `hearit_keyword` (
+                                  `id` bigint NOT NULL AUTO_INCREMENT,
+                                  `hearit_id` bigint NOT NULL,
+                                  `keyword_id` bigint NOT NULL,
+                                  PRIMARY KEY (`id`),
+                                  CONSTRAINT `uq_hearit_keyword` UNIQUE (`hearit_id`, `keyword_id`),
+                                  CONSTRAINT `fk_hearit_keyword_hearit` FOREIGN KEY (`hearit_id`) REFERENCES `hearit` (`id`),
+                                  CONSTRAINT `fk_hearit_keyword_keyword` FOREIGN KEY (`keyword_id`) REFERENCES `keyword` (`id`)
+);
+
+CREATE TABLE `hearit_source` (
+                                 `hearit_id` bigint NOT NULL,
+                                 `source_name` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                                 `source_url` varchar(255) COLLATE utf8mb4_general_ci DEFAULT NULL,
+                                 KEY (`hearit_id`),
+                                 CONSTRAINT `fk_hearit_source_hearit` FOREIGN KEY (`hearit_id`) REFERENCES `hearit` (`id`)
+);
+
+CREATE TABLE `recommend_hearit` (
+                                    `id` bigint NOT NULL AUTO_INCREMENT,
+                                    `hearit_id` bigint NOT NULL,
+                                    `recommend_date` date NOT NULL,
+                                    PRIMARY KEY (`id`),
+                                    CONSTRAINT `uq_recommend_hearit_date` UNIQUE (`hearit_id`, `recommend_date`),
+                                    CONSTRAINT `fk_recommend_hearit_hearit` FOREIGN KEY (`hearit_id`) REFERENCES `hearit` (`id`)
+);
+
+CREATE TABLE `refresh_token` (
+                                 `id` bigint NOT NULL AUTO_INCREMENT,
+                                 `member_id` bigint NOT NULL,
+                                 `token` varchar(255) COLLATE utf8mb4_general_ci NOT NULL,
+                                 `expiry_date` datetime(6) NOT NULL,
+                                 PRIMARY KEY (`id`),
+                                 CONSTRAINT `uq_refresh_token_member_id` UNIQUE (`member_id`)
+);

--- a/backend/src/main/resources/log4j2/log4j2.xml
+++ b/backend/src/main/resources/log4j2/log4j2.xml
@@ -40,32 +40,36 @@
         <!-- 파일 출력 설정 -->
         <!-- INFO, WARN, ERROR, FATAL 로그 파일 -->
         <!-- txt 파일로 저장 -->
-        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/2025_08_07/log.zip) -->
+        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/all-level/2025_08_07.zip) -->
         <!-- 7개 파일 쌓이면 오래된 로그부터 삭제 -->
         <RollingFile name="RollingFile">
             <FileName>${logDir}/all-level.log</FileName>
-            <FilePattern>${logDir}/archive/%d{yyyy_MM_dd}/all-level.zip</FilePattern>
+            <FilePattern>${logDir}/archive/all-level/%d{yyyy_MM_dd}.zip</FilePattern>
             <JsonLayout
-                complete="false"
-                compact="true"
-                eventEol="true"
-                objectMessageAsJsonObject="true"
-                charset="UTF-8">
+                    complete="false"
+                    compact="true"
+                    eventEol="true"
+                    objectMessageAsJsonObject="true"
+                    charset="UTF-8">
                 <KeyValuePair key="env" value="${env}"/>
             </JsonLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
             </Policies>
-            <DefaultRolloverStrategy max="7"/>
+            <DefaultRolloverStrategy>
+                <Delete basePath="${logDir}/archive/all-level" maxDepth="1">
+                    <IfLastModified age="7d"/>
+                </Delete>
+            </DefaultRolloverStrategy>
         </RollingFile>
 
         <!-- ERROR, FATAL 로그 파일-->
         <!-- json 파일로 저장 -->
-        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/2025_08_07/error-log.zip) -->
+        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/error/2025_08_07.zip) -->
         <!-- 20개 파일 쌓이면 오래된 로그부터 삭제 -->
         <RollingFile name="RollingErrorFile">
             <FileName>${logDir}/error.log</FileName>
-            <FilePattern>${logDir}/archive/%d{yyyy_MM_dd}/error.zip</FilePattern>
+            <FilePattern>${logDir}/archive/error/%d{yyyy_MM_dd}.zip</FilePattern>
             <JsonLayout complete="false"
                         compact="true"
                         eventEol="true"
@@ -76,7 +80,11 @@
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
             </Policies>
-            <DefaultRolloverStrategy max="20"/>
+            <DefaultRolloverStrategy>
+                <Delete basePath="${logDir}/archive/error" maxDepth="1">
+                    <IfLastModified age="20d"/>
+                </Delete>
+            </DefaultRolloverStrategy>
         </RollingFile>
     </Appenders>
 

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
@@ -5,9 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.application.recommend.FixedRecommendedHearitStrategy;
+import com.onair.hearit.app.dto.request.PagingRequest;
+import com.onair.hearit.app.dto.response.HearitDetailResponse;
+import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
+import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
+import com.onair.hearit.app.dto.response.PagedResponse;
+import com.onair.hearit.app.dto.response.RecommendHearitResponse;
 import com.onair.hearit.auth.domain.UserContext;
-import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
@@ -15,20 +19,16 @@ import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.RecommendHearit;
-import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.HearitDetailResponse;
-import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
-import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
-import com.onair.hearit.app.dto.response.PagedResponse;
-import com.onair.hearit.app.dto.response.RecommendHearitResponse;
-import com.onair.hearit.fixture.DbHelper;
-import com.onair.hearit.fixture.TestFixture;
+import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
 import com.onair.hearit.common.infrastructure.jpa.RecommendHearitRepository;
+import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -104,7 +104,8 @@ class HearitServiceTest {
                 () -> assertThat(response.summary()).isEqualTo(hearit.getSummary()),
                 () -> assertThat(response.isBookmarked()).isTrue(),
                 () -> assertThat(response.bookmarkId()).isEqualTo(bookmark.getId()),
-                () -> assertThat(response.category()).isEqualTo(hearit.getCategory().getName()),
+                () -> assertThat(response.category().id()).isEqualTo(hearit.getCategory().getId()),
+                () -> assertThat(response.category().name()).isEqualTo(hearit.getCategory().getName()),
                 () -> assertThat(response.keywords()).hasSize(1)
         );
     }
@@ -129,13 +130,13 @@ class HearitServiceTest {
         LocalDate today = LocalDate.now();
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         IntStream.rangeClosed(1, 3)
-                .forEach((num) -> {
+                .forEach(num -> {
                     Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
                     dbHelper.insertRecommendHearit(new RecommendHearit(hearit, today));
                 });
         LocalDate yesterday = today.minusDays(1);
         IntStream.rangeClosed(1, 5)
-                .forEach((num) -> {
+                .forEach(num -> {
                     Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
                     dbHelper.insertRecommendHearit(new RecommendHearit(hearit, yesterday));
                 });

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -9,15 +9,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
-import com.onair.hearit.docs.ApiDocSnippets;
-import com.onair.hearit.common.domain.Category;
-import com.onair.hearit.common.domain.Hearit;
-import com.onair.hearit.common.domain.HearitKeyword;
-import com.onair.hearit.common.domain.Keyword;
-import com.onair.hearit.common.domain.Member;
-import com.onair.hearit.common.domain.RecommendHearit;
-import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.app.dto.response.CursorResponse;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
@@ -25,6 +16,15 @@ import com.onair.hearit.app.dto.response.HearitSearchResponse;
 import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.app.dto.response.RecommendHearitResponse;
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.common.domain.Category;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.HearitKeyword;
+import com.onair.hearit.common.domain.Keyword;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.RecommendHearit;
+import com.onair.hearit.common.domain.Source;
+import com.onair.hearit.docs.ApiDocSnippets;
 import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.fixture.TestFixture;
 import io.restassured.RestAssured;
@@ -531,7 +531,9 @@ class HearitControllerTest extends IntegrationTest {
                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 일시"),
                 fieldWithPath("isBookmarked").type(JsonFieldType.BOOLEAN).description("현재 사용자의 북마크 여부"),
                 fieldWithPath("bookmarkId").type(JsonFieldType.NUMBER).description("북마크 ID (북마크된 경우)").optional(),
-                fieldWithPath("category").type(JsonFieldType.STRING).description("카테고리 이름"),
+                fieldWithPath("category").description("카테고리 정보"),
+                fieldWithPath("category.id").type(JsonFieldType.NUMBER).description("카테고리 아이디"),
+                fieldWithPath("category.name").type(JsonFieldType.STRING).description("카테고리 이름"),
                 fieldWithPath("keywords").type(JsonFieldType.ARRAY).description("키워드 목록"),
                 fieldWithPath("keywords[].id").type(JsonFieldType.NUMBER).description("키워드 ID"),
                 fieldWithPath("keywords[].name").type(JsonFieldType.STRING).description("키워드 이름")

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -12,6 +12,7 @@ import com.epages.restdocs.apispec.Schema;
 import com.onair.hearit.app.dto.response.CursorResponse;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
+import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
 import com.onair.hearit.app.dto.response.HearitSearchResponse;
 import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
@@ -416,7 +417,7 @@ class HearitControllerTest extends IntegrationTest {
         Hearit hearit3 = saveHearitWithCategoryAndKeyword(category2, keyword); // 카테고리 2의 히어릿
 
         // when
-        PagedResponse<HearitSearchResponse> pagedResponse = RestAssured.given(this.spec)
+        PagedResponse<HearitOfCategoryResponse> pagedResponse = RestAssured.given(this.spec)
                 .queryParam("categoryId", category1.getId())
                 .queryParam("page", 0)
                 .queryParam("size", 10)
@@ -453,7 +454,7 @@ class HearitControllerTest extends IntegrationTest {
                 .extract()
                 .as(new TypeRef<>() {
                 });
-        List<HearitSearchResponse> responses = pagedResponse.content();
+        List<HearitOfCategoryResponse> responses = pagedResponse.content();
 
         // then
         assertAll(

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -534,6 +534,7 @@ class HearitControllerTest extends IntegrationTest {
                 fieldWithPath("category").description("카테고리 정보"),
                 fieldWithPath("category.id").type(JsonFieldType.NUMBER).description("카테고리 아이디"),
                 fieldWithPath("category.name").type(JsonFieldType.STRING).description("카테고리 이름"),
+                fieldWithPath("category.colorCode").type(JsonFieldType.STRING).description("카테고리 컬러코드"),
                 fieldWithPath("keywords").type(JsonFieldType.ARRAY).description("키워드 목록"),
                 fieldWithPath("keywords[].id").type(JsonFieldType.NUMBER).description("키워드 ID"),
                 fieldWithPath("keywords[].name").type(JsonFieldType.STRING).description("키워드 이름")

--- a/backend/src/test/resources/application-fake-test.properties
+++ b/backend/src/test/resources/application-fake-test.properties
@@ -27,3 +27,4 @@ spring.servlet.multipart.max-request-size=100MB
 kakao.user-info.base-url=https://test.kakao
 kakao.user-info.connectTimeout=2s
 kakao.user-info.readTimeout=3s
+spring.flyway.enabled=false

--- a/backend/src/test/resources/application-integration-test.properties
+++ b/backend/src/test/resources/application-integration-test.properties
@@ -6,7 +6,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
@@ -31,3 +31,8 @@ aws.region=fake-region
 aws.s3.bucket=fake-bucket
 spring.servlet.multipart.max-file-size=30MB
 spring.servlet.multipart.max-request-size=100MB
+
+## Flyaway
+spring.flyway.url=jdbc:mysql://localhost:13307/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.flyway.user=root
+spring.flyway.password=root


### PR DESCRIPTION
Release 1.1.0 for backend service.
Version bump only.

- 로그 롤링 파일 삭제되도록 수정
- private subnet 이전으로 인한 port번호 변경 및 관련된 port 설정들 반영

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Hearit 상세 응답의 category가 문자열에서 객체(id, name, colorCode)로 변경되었습니다.

- **Documentation**
  - API 문서/테스트 스니펫이 새로운 category 구조와 HTTPS 서버 URL에 맞게 업데이트되었습니다.

- **Chores**
  - 프로젝트 버전 1.1.0-SNAPSHOT으로 상향, 서버 기본 포트를 80으로 변경 및 프록시 헤더 처리 활성화.
  - 로깅 아카이브 경로 및 보존 정책을 연령 기준으로 조정.
  - 배포 러너 라벨 정리 및 Flyway 기반 DB 마이그레이션 도입.

- **Tests**
  - 관련 단위/통합 테스트와 스니펫이 새로운 응답 구조 및 DB 설정에 맞게 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->