### PR TITLE
[BE] fix: 마스킹 실패 해결을 위한 inner record 접근제어자 변경 #434

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/dto/response/ExploredHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/ExploredHearitResponse.java
@@ -43,11 +43,11 @@ public record ExploredHearitResponse(
                 .toList();
     }
 
-    private record KeywordResponse(
+    public record KeywordResponse(
             Long id,
             String name
     ) {
-        public static KeywordResponse from(Keyword keyword) {
+        private static KeywordResponse from(Keyword keyword) {
             return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
@@ -59,12 +59,12 @@ public record HearitDetailResponse(
         return sources.stream().map(SourceResponse::from).toList();
     }
 
-    private record KeywordResponse(
+    public record KeywordResponse(
             Long id,
             String name
     ) {
 
-        public static KeywordResponse from(Keyword keyword) {
+        private static KeywordResponse from(Keyword keyword) {
             return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()
@@ -72,12 +72,12 @@ public record HearitDetailResponse(
         }
     }
 
-    private record SourceResponse(
+    public record SourceResponse(
             String sourceName,
             String sourceUrl
     ) {
 
-        public static SourceResponse from(Source source) {
+        private static SourceResponse from(Source source) {
             return new SourceResponse(
                     source.getSourceName(),
                     source.getSourceUrl()

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitOfCategoryResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitOfCategoryResponse.java
@@ -24,11 +24,11 @@ public record HearitOfCategoryResponse(
         return keywords.stream().map(KeywordResponse::from).toList();
     }
 
-    private record KeywordResponse(
+    public record KeywordResponse(
             Long id,
             String name
     ) {
-        public static KeywordResponse from(Keyword keyword) {
+        private static KeywordResponse from(Keyword keyword) {
             return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
@@ -24,11 +24,11 @@ public record HearitSearchResponse(
         return keywords.stream().map(KeywordResponse::from).toList();
     }
 
-    private record KeywordResponse(
+    public record KeywordResponse(
             Long id,
             String name
     ) {
-        public static KeywordResponse from(Keyword keyword) {
+        private static KeywordResponse from(Keyword keyword) {
             return new KeywordResponse(
                     keyword.getId(),
                     keyword.getName()

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitsWithRecommendCategoryResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitsWithRecommendCategoryResponse.java
@@ -26,12 +26,12 @@ public record HearitsWithRecommendCategoryResponse(
                 .toList();
     }
 
-    private record HearitResponse(
+    public record HearitResponse(
             Long hearitId,
             String title,
             LocalDateTime createdAt
     ) {
-        public static HearitResponse from(Hearit hearit) {
+        private static HearitResponse from(Hearit hearit) {
             return new HearitResponse(
                     hearit.getId(),
                     hearit.getTitle(),


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- dto의 inner record 접근제어자를 public으로 변경
    -  private 내부 클래스에 리플렉션 접근하면 Java 17+에서 InaccessibleObjectException 발생
 
- inner record의 정펙메 접근제어자는 private으로 통일하여 일관성 유지
    - 해당 클래스 안에서만 사용되는 정펙메라 private으로 해도 됨

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#434 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 리팩터링
  - 응답 모델의 하위 타입 공개 범위를 정리하고 내부 생성 유틸리티의 접근 수준을 축소했습니다.
  - 클라이언트가 받는 응답의 필드와 동작에는 변화가 없으며 기존 기능은 그대로 유지됩니다.
  - 외부 연동이나 버전 업그레이드 없이 배포 가능하며, 성능·오류 처리에 영향이 없습니다.
  - 타입 노출을 정리해 향후 확장과 유지보수를 용이하게 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->