### PR TITLE
[BE] refactor: 히어릿 상세정보에 카테고리 id 추가 #433

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.app.dto.response;
 
 import com.onair.hearit.common.domain.Bookmark;
+import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Source;
@@ -16,7 +17,7 @@ public record HearitDetailResponse(
         LocalDateTime createdAt,
         Boolean isBookmarked,
         Long bookmarkId,
-        String category,
+        CategoryResponse category,
         List<KeywordResponse> keywords
 ) {
     public static HearitDetailResponse from(Hearit hearit, List<Keyword> keywords) {
@@ -31,7 +32,7 @@ public record HearitDetailResponse(
                 hearit.getCreatedAt(),
                 false,
                 null,
-                hearit.getCategory().getName(),
+                CategoryResponse.of(hearit.getCategory()),
                 keywordNames);
     }
 
@@ -47,7 +48,7 @@ public record HearitDetailResponse(
                 hearit.getCreatedAt(),
                 true,
                 bookmark.getId(),
-                hearit.getCategory().getName(),
+                CategoryResponse.of(hearit.getCategory()),
                 keywordNames);
     }
 
@@ -57,6 +58,16 @@ public record HearitDetailResponse(
 
     private static List<SourceResponse> getSources(List<Source> sources) {
         return sources.stream().map(SourceResponse::from).toList();
+    }
+
+    public record CategoryResponse(
+            Long id,
+            String name
+    ) {
+
+        private static CategoryResponse of(Category category) {
+            return new CategoryResponse(category.getId(), category.getName());
+        }
     }
 
     private record KeywordResponse(

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
@@ -5,9 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.application.recommend.FixedRecommendedHearitStrategy;
+import com.onair.hearit.app.dto.request.PagingRequest;
+import com.onair.hearit.app.dto.response.HearitDetailResponse;
+import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
+import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
+import com.onair.hearit.app.dto.response.PagedResponse;
+import com.onair.hearit.app.dto.response.RecommendHearitResponse;
 import com.onair.hearit.auth.domain.UserContext;
-import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
@@ -15,20 +19,16 @@ import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.RecommendHearit;
-import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.HearitDetailResponse;
-import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
-import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
-import com.onair.hearit.app.dto.response.PagedResponse;
-import com.onair.hearit.app.dto.response.RecommendHearitResponse;
-import com.onair.hearit.fixture.DbHelper;
-import com.onair.hearit.fixture.TestFixture;
+import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
 import com.onair.hearit.common.infrastructure.jpa.RecommendHearitRepository;
+import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -104,7 +104,8 @@ class HearitServiceTest {
                 () -> assertThat(response.summary()).isEqualTo(hearit.getSummary()),
                 () -> assertThat(response.isBookmarked()).isTrue(),
                 () -> assertThat(response.bookmarkId()).isEqualTo(bookmark.getId()),
-                () -> assertThat(response.category()).isEqualTo(hearit.getCategory().getName()),
+                () -> assertThat(response.category().id()).isEqualTo(hearit.getCategory().getId()),
+                () -> assertThat(response.category().name()).isEqualTo(hearit.getCategory().getName()),
                 () -> assertThat(response.keywords()).hasSize(1)
         );
     }
@@ -129,13 +130,13 @@ class HearitServiceTest {
         LocalDate today = LocalDate.now();
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         IntStream.rangeClosed(1, 3)
-                .forEach((num) -> {
+                .forEach(num -> {
                     Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
                     dbHelper.insertRecommendHearit(new RecommendHearit(hearit, today));
                 });
         LocalDate yesterday = today.minusDays(1);
         IntStream.rangeClosed(1, 5)
-                .forEach((num) -> {
+                .forEach(num -> {
                     Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
                     dbHelper.insertRecommendHearit(new RecommendHearit(hearit, yesterday));
                 });

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -9,15 +9,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
-import com.onair.hearit.docs.ApiDocSnippets;
-import com.onair.hearit.common.domain.Category;
-import com.onair.hearit.common.domain.Hearit;
-import com.onair.hearit.common.domain.HearitKeyword;
-import com.onair.hearit.common.domain.Keyword;
-import com.onair.hearit.common.domain.Member;
-import com.onair.hearit.common.domain.RecommendHearit;
-import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.app.dto.response.CursorResponse;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
@@ -25,6 +16,15 @@ import com.onair.hearit.app.dto.response.HearitSearchResponse;
 import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.app.dto.response.RecommendHearitResponse;
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.common.domain.Category;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.HearitKeyword;
+import com.onair.hearit.common.domain.Keyword;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.RecommendHearit;
+import com.onair.hearit.common.domain.Source;
+import com.onair.hearit.docs.ApiDocSnippets;
 import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.fixture.TestFixture;
 import io.restassured.RestAssured;
@@ -531,7 +531,9 @@ class HearitControllerTest extends IntegrationTest {
                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 일시"),
                 fieldWithPath("isBookmarked").type(JsonFieldType.BOOLEAN).description("현재 사용자의 북마크 여부"),
                 fieldWithPath("bookmarkId").type(JsonFieldType.NUMBER).description("북마크 ID (북마크된 경우)").optional(),
-                fieldWithPath("category").type(JsonFieldType.STRING).description("카테고리 이름"),
+                fieldWithPath("category").description("카테고리 정보"),
+                fieldWithPath("category.id").type(JsonFieldType.NUMBER).description("카테고리 아이디"),
+                fieldWithPath("category.name").type(JsonFieldType.STRING).description("카테고리 이름"),
                 fieldWithPath("keywords").type(JsonFieldType.ARRAY).description("키워드 목록"),
                 fieldWithPath("keywords[].id").type(JsonFieldType.NUMBER).description("키워드 ID"),
                 fieldWithPath("keywords[].name").type(JsonFieldType.STRING).description("키워드 이름")


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

GET hearits/{hearits_id}에서 category id 추가했습니다 

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->

close #433 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 없음
- 리팩터: 상세 조회 응답의 category를 문자열에서 객체(id, name)로 변경하여 구조화된 정보 제공. 클라이언트는 category.id와 category.name을 참조하도록 수정 필요(호환성 주의).
- 문서: API 응답 예시와 필드 설명을 category 객체(id, name) 구조로 업데이트.
- 테스트: 변경된 응답 구조에 맞춰 검증 로직 및 기대값을 갱신.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->