### PR TITLE
[BE] refactor: 히어릿 상세 조회 응답에 category color 코드 추가 #441

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
@@ -62,11 +62,12 @@ public record HearitDetailResponse(
 
     public record CategoryResponse(
             Long id,
-            String name
+            String name,
+            String colorCode
     ) {
 
         private static CategoryResponse of(Category category) {
-            return new CategoryResponse(category.getId(), category.getName());
+            return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
         }
     }
 

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -534,6 +534,7 @@ class HearitControllerTest extends IntegrationTest {
                 fieldWithPath("category").description("카테고리 정보"),
                 fieldWithPath("category.id").type(JsonFieldType.NUMBER).description("카테고리 아이디"),
                 fieldWithPath("category.name").type(JsonFieldType.STRING).description("카테고리 이름"),
+                fieldWithPath("category.colorCode").type(JsonFieldType.STRING).description("카테고리 컬러코드"),
                 fieldWithPath("keywords").type(JsonFieldType.ARRAY).description("키워드 목록"),
                 fieldWithPath("keywords[].id").type(JsonFieldType.NUMBER).description("키워드 ID"),
                 fieldWithPath("keywords[].name").type(JsonFieldType.STRING).description("키워드 이름")


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->

close #441 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * Hearit 상세 응답에 카테고리 색상 코드(colorCode) 필드가 추가되었습니다. 이제 앱/웹에서 카테고리 색상을 직접 표시할 수 있습니다. 응답 스키마가 확장되어 클라이언트 파싱 로직 업데이트가 필요할 수 있습니다.
* 문서
  * API 문서에 카테고리 색상 코드 필드를 반영하고 필드 설명과 예시를 최신화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->