### PR TITLE
[AN] refactor: 카테고리에 따른 북마크 색상 변경 #450

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/dto/BookmarkResponse.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/dto/BookmarkResponse.kt
@@ -32,5 +32,7 @@ data class BookmarkResponse(
         val summary: String,
         @SerialName("playTime")
         val playTime: Int,
+        @SerialName("categoryColor")
+        val categoryColor: String,
     )
 }

--- a/android/app/src/main/java/com/onair/hearit/data/mapper/BookmarkMapper.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/mapper/BookmarkMapper.kt
@@ -12,6 +12,7 @@ fun BookmarkResponse.Content.toDomain(): Bookmark =
         title = title,
         summary = summary,
         playTime = playTime,
+        categoryColor = categoryColor,
     )
 
 fun BookmarkResponse.toDomain(): PageResult<Bookmark> =

--- a/android/app/src/main/java/com/onair/hearit/domain/model/Bookmark.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/model/Bookmark.kt
@@ -6,4 +6,5 @@ data class Bookmark(
     val title: String,
     val summary: String,
     val playTime: Int,
+    val categoryColor: String,
 )

--- a/android/app/src/main/res/layout/item_bookmark.xml
+++ b/android/app/src/main/res/layout/item_bookmark.xml
@@ -75,6 +75,7 @@
             android:layout_width="0dp"
             android:layout_height="56dp"
             android:background="@drawable/bg_purple3_radius_left_8dp"
+            app:backgroundColor="@{item.categoryColor}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintWidth_percent="0.05" />


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 카테고리에 따라 북마크의 색상을 다르게 보여준다

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부
<img width="260" alt="Screenshot_20250820_111408" src="https://github.com/user-attachments/assets/3813c22e-ffef-4d24-93b1-d9a268717743" />

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#450 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 북마크 목록에 카테고리 색상이 표시되어 각 항목을 색상 인디케이터로 쉽게 구분할 수 있습니다.
  - 항목의 배경 색상이 데이터에 따라 자동 반영되어 시각적 인지가 향상되었습니다.
- Style
  - 목록 항목의 좌측 장식 바에 카테고리 색상을 적용해 일관된 UI 강조 효과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->