### PR TITLE
[AN]  bug: 탐색 화면 북마크 오류 수정 #452

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -314,7 +314,7 @@ class ExploreFragment :
     override fun onPause() {
         super.onPause()
         val position = currentIndex()
-        viewModel.onPause(position, playerManager.getCurrentPosition(), adapter.itemCount)
+        viewModel.saveCurrentState(position, playerManager.getCurrentPosition(), adapter.itemCount)
         playerManager.pause()
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
@@ -65,7 +65,7 @@ class ExploreViewModel(
         fetchData(cursorInfo.cursorId)
     }
 
-    fun onPause(
+    fun saveCurrentState(
         position: Int,
         lastPlayerPosition: Long,
         itemCount: Int,
@@ -150,14 +150,7 @@ class ExploreViewModel(
     }
 
     private fun reFetchData() {
-        _shortsHearits.value?.lastOrNull()?.let { shortsLastItem ->
-            val lastBookmarkId = _bookmarkId.value?.get(shortsLastItem.id)
-            lastItem =
-                shortsLastItem.copy(
-                    bookmarkId = lastBookmarkId,
-                    isBookmarked = lastBookmarkId != null,
-                )
-        }
+        lastItem = _shortsHearits.value?.lastOrNull()
 
         _currentIndex.value = 0
         _bookmarkId.value = emptyMap()

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreViewModel.kt
@@ -46,12 +46,12 @@ class ExploreViewModel(
     private val _isLoading = MutableLiveData<Boolean>(true)
     val isLoading: LiveData<Boolean> = _isLoading
 
-    private lateinit var cursorInfo: CursorInfo
-    private var isFetchingData = false
-
     private val _currentIndex = MutableLiveData<Int>(0)
     val currentIndex: LiveData<Int> = _currentIndex
 
+    private lateinit var cursorInfo: CursorInfo
+
+    private var isFetchingData = false
     private var lastPlayerPosition: Long = 0L
     private var lastItem: ShortsHearit? = null
 
@@ -70,6 +70,8 @@ class ExploreViewModel(
         lastPlayerPosition: Long,
         itemCount: Int,
     ) {
+        refreshBookmarkState()
+
         if (position == itemCount - 1) {
             reFetchData()
         } else {
@@ -207,6 +209,27 @@ class ExploreViewModel(
                     onFinished(null)
                 }
         }
+    }
+
+    private fun refreshBookmarkState() {
+        val currentShortsList = _shortsHearits.value ?: return
+        val bookmarkStateMap = _bookmarkId.value ?: return
+
+        val updatedShortsList =
+            currentShortsList.map { shortsHearit ->
+                val latestBookmarkId = bookmarkStateMap[shortsHearit.id]
+
+                if (shortsHearit.bookmarkId != latestBookmarkId) {
+                    shortsHearit.copy(
+                        bookmarkId = latestBookmarkId,
+                        isBookmarked = (latestBookmarkId != null),
+                    )
+                } else {
+                    shortsHearit
+                }
+            }
+
+        _shortsHearits.value = updatedShortsList
     }
 
     private fun updateBookmarkState(


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 탐색 화면 북마크 갱신 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#452 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 탐색 화면 이탈/복귀 시 북마크 표시가 간헐적으로 틀리게 보이던 문제를 수정했습니다.
  - 목록 마지막 항목의 북마크 상태가 표시와 불일치하던 현상을 해소했습니다.
  - 재진입 시 재생 위치와 스크롤 위치 저장/복원의 신뢰성을 높였습니다.
- 리팩터링
  - 상태 저장 로직을 일원화해 화면 전환 시 데이터 동기화 안정성을 개선했습니다.
  - 불필요한 데이터 복제를 줄여 경미한 성능 및 지연 개선 효과가 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->