### PR TITLE
[BE] chore: 헬스체크 request API 로깅에서 제외 #440

### DIFF
--- a/backend/src/main/java/com/onair/hearit/log/RequestLoggingFilter.java
+++ b/backend/src/main/java/com/onair/hearit/log/RequestLoggingFilter.java
@@ -30,7 +30,8 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             "/admin/**",
             "/api/v1/admin/**",
             "/favicon.ico",
-            "/.well-known/**"
+            "/.well-known/**",
+            "/actuator/health"
     );
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -14,9 +14,6 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.defer-datasource-initialization=true
 spring.sql.init.mode=always
 
-# Server Port
-server.port=80
-
 # S3 public URL
 amazon.s3.bucket=${AMAZON_S3_BUCKET_URL}
 
@@ -29,13 +26,6 @@ jwt.refresh-token.expiration=${JWT_REFRESH_EXPIRATION}
 kakao.user-info.base-url=https://kapi.kakao.com
 kakao.user-info.connectTimeout=2s
 kakao.user-info.readTimeout=3s
-
-# Swagger
-springdoc.default-produces-media-type=application/json
-springdoc.swagger-ui.path=/docs
-springdoc.swagger-ui.operations-sorter=method
-springdoc.swagger-ui.tags-sorter=alpha
-springdoc.swagger-ui.display-request-duration=true
 
 # user-default-image
 hearit.profile.default-image-url=http://hearit.o-r.kr/images/default-profile.jpg


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 1분마다 헬스체크를 하고 있기에 로깅이 더러워짐
- 헬스체크 API는 application 로깅에서 제외하도록 함

- server port 제외 및 사용하지않는 properties 제거

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#440 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 헬스 체크 엔드포인트를 요청 로깅 대상에서 제외하여 모니터링 트래픽이 로그에 축적되지 않도록 정리했습니다.
  - 개발 환경 설정을 간소화했습니다: 고정 포트 및 Swagger UI 관련 설정을 제거해 기본값을 따르고 중복/불필요 구성을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->