### PR TITLE
[BE] chore: Manual release&rollback workflow 추가 #462 

### DIFF
--- a/.github/workflows/be-manual-release.yml
+++ b/.github/workflows/be-manual-release.yml
@@ -35,20 +35,20 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Build app.jar
+      - name: Build backend-app.jar
         working-directory: backend
         run: |
           ./gradlew clean build -x test
           ls -al build/libs
-          cp "$(ls build/libs/*.jar | head -n 1)" ../app.jar
+          cp "$(ls build/libs/*.jar | head -n 1)" ../backend-app.jar
 
-      - name: Create/Update GitHub Release (attach app.jar)
+      - name: Create/Update GitHub Release (attach backend-app.jar)
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.release_tag }}
           name: ${{ github.event.inputs.release_tag }}
           generate_release_notes: true
-          files: app.jar
+          files: backend-app.jar
 
       - name: Promote LKG (move LKG_PROD tag)
         run: |

--- a/.github/workflows/be-manual-release.yml
+++ b/.github/workflows/be-manual-release.yml
@@ -1,0 +1,62 @@
+name: BE Manual Release (Prod, build from release)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "예: v1.2.3"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: release
+
+      - name: Print commit info
+        run: |
+          echo "Release branch HEAD:"
+          git rev-parse HEAD
+          git log -1 --pretty=oneline
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build app.jar
+        working-directory: backend
+        run: |
+          ./gradlew clean build -x test
+          ls -al build/libs
+          cp "$(ls build/libs/*.jar | head -n 1)" ../app.jar
+
+      - name: Create/Update GitHub Release (attach app.jar)
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.release_tag }}
+          name: ${{ github.event.inputs.release_tag }}
+          generate_release_notes: true
+          files: app.jar
+
+      - name: Promote LKG (move LKG_PROD tag)
+        run: |
+          git fetch --tags --force --prune
+          COMMIT=$(git rev-parse "${{ github.event.inputs.release_tag }}^{}")
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -f LKG_PROD "$COMMIT"
+          git push origin -f refs/tags/LKG_PROD

--- a/.github/workflows/be-manual-rollback.yml
+++ b/.github/workflows/be-manual-rollback.yml
@@ -1,0 +1,85 @@
+name: Manual Rollback (Prod)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "롤백 대상 (예: v1.2.3 또는 LKG)"
+        required: true
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: rollback-prod
+  cancel-in-progress: false
+
+jobs:
+  fetch:
+    name: Fetch app.jar from Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for tag list/validation)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve target tag (LKG → LKG_PROD)
+        id: res
+        shell: bash
+        run: |
+          set -e
+          t='${{ github.event.inputs.target }}'
+          if [[ "$t" =~ ^(LKG|lkg|LKG_PROD)$ ]]; then
+            TAG="LKG_PROD"
+          else
+            TAG="$t"
+          fi
+          git fetch --tags --force --prune
+          if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::Tag not found: ${TAG}"
+            echo "---- Latest tags ----"
+            git tag --list --sort=-creatordate | head -n 20
+            exit 1
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Download app.jar from GitHub Release
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: ${{ github.repository }}
+          tag: ${{ steps.res.outputs.tag }}
+          fileName: "app.jar"
+          out-file-path: "rollback"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify file
+        run: |
+          test -f rollback/app.jar
+          ls -al rollback
+          sha256sum rollback/app.jar || shasum -a 256 rollback/app.jar
+
+      - name: Upload artifact (app.jar)
+        uses: actions/upload-artifact@v4
+        with:
+          name: rollback-jar
+          path: rollback/app.jar
+          if-no-files-found: error
+          retention-days: 7
+
+  deploy:
+    needs: fetch
+    runs-on: [ self-hosted, backend-prod, Linux, ARM64 ]
+    steps:
+      - name: Download rollback artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: rollback-jar
+          path: ~/hearit
+
+      - name: Sanity check
+        run: test -f ~/hearit/app.jar
+
+      - name: Run deploy script
+        run: sudo bash ~/hearit/deploy.sh

--- a/.github/workflows/be-manual-rollback.yml
+++ b/.github/workflows/be-manual-rollback.yml
@@ -1,4 +1,4 @@
-name: Manual Rollback (Prod)
+name: BE Manual Rollback (Prod)
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   fetch:
-    name: Fetch app.jar from Release
+    name: Fetch backend-app.jar from Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (for tag list/validation)
@@ -29,42 +29,40 @@ jobs:
         id: res
         shell: bash
         run: |
-          set -e
+          set -euo pipefail
           t='${{ github.event.inputs.target }}'
-          if [[ "$t" =~ ^(LKG|lkg|LKG_PROD)$ ]]; then
-            TAG="LKG_PROD"
-          else
-            TAG="$t"
-          fi
+          if [[ "$t" =~ ^(LKG|lkg|LKG_PROD)$ ]]; then TAG="LKG_PROD"; else TAG="$t"; fi
           git fetch --tags --force --prune
-          if ! git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+          git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null || {
             echo "::error::Tag not found: ${TAG}"
-            echo "---- Latest tags ----"
-            git tag --list --sort=-creatordate | head -n 20
+            echo "---- Latest tags ----"; git tag --list --sort=-creatordate | head -n 20
             exit 1
-          fi
+          }
           echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Resolved rollback tag: $TAG"
 
-      - name: Download app.jar from GitHub Release
+      - name: Download backend-app.jar from GitHub Release
         uses: robinraju/release-downloader@v1.10
         with:
           repository: ${{ github.repository }}
           tag: ${{ steps.res.outputs.tag }}
-          fileName: "app.jar"
+          fileName: "backend-app.jar"
           out-file-path: "rollback"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify file
+        shell: bash
         run: |
-          test -f rollback/app.jar
+          set -euo pipefail
+          test -f rollback/backend-app.jar
           ls -al rollback
-          sha256sum rollback/app.jar || shasum -a 256 rollback/app.jar
+          sha256sum rollback/backend-app.jar || shasum -a 256 rollback/backend-app.jar
 
-      - name: Upload artifact (app.jar)
+      - name: Upload artifact (backend-app.jar)
         uses: actions/upload-artifact@v4
         with:
           name: rollback-jar
-          path: rollback/app.jar
+          path: rollback/backend-app.jar
           if-no-files-found: error
           retention-days: 7
 
@@ -79,7 +77,7 @@ jobs:
           path: ~/hearit
 
       - name: Sanity check
-        run: test -f ~/hearit/app.jar
+        run: test -f ~/hearit/backend-app.jar
 
       - name: Run deploy script
         run: sudo bash ~/hearit/deploy.sh


### PR DESCRIPTION
### 개요
1. Manual Release: release 브랜치 기준으로 빌드 → backend-app.jar 생성 및 GitHub Release에 Asset 업로드 → LKG_PROD 태그 최신화
2. Manual Rollback: Release Asset(backend-app.jar) 다운로드 → self-hosted runner에서 deploy.sh 실행 → 이전 버전으로 롤백

### 변경 사항

1. BE Manual Release (Prod, build from release)
    - workflow_dispatch 입력값 release_tag 기반으로 실행
    - Gradle 빌드(bootJar) 후 결과물을 backend-app.jar로 고정
    - GitHub Release 생성/업데이트, Release Asset 업로드
    - LKG_PROD 태그 최신화 (마지막 Known Good 배포 버전)

2. BE Manual Rollback (Prod)
    - workflow_dispatch 입력값 target (예: v1.2.3 또는 LKG) 기반으로 실행
    - 태그 확인 및 Release Asset(backend-app.jar) 다운로드
    - 파일 검증(존재/sha256 출력) 및 artifact 업로드
    - self-hosted runner에서 deploy.sh 실행, 해당 버전으로 롤백

### 실행 플로우
```
 A[Release 브랜치] -->|Manual Release| B[backend-app.jar 빌드]
  B --> C[GitHub Release Asset 업로드]
  C --> D[LKG_PROD 태그 최신화]

  E[Release Asset 선택] -->|Manual Rollback| F[backend-app.jar 다운로드]
  F --> G[파일 검증 & artifact 업로드]
  G --> H[self-hosted runner deploy.sh 실행]
  H --> I[Rollback 완료]
```

### 기대 효과
- 릴리즈 시점: 일관된 파일명(backend-app.jar)으로 Asset 관리
- 롤백 시점: Release Asset 다운로드 기반 → 안정적/재현 가능한 롤백
- 운영 환경에서 신속한 배포/롤백 가능
	
## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#462 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 프로덕션 수동 릴리스 워크플로우 추가: 릴리스 태그로 백엔드 빌드·아티팩트 첨부 및 안정 태그 승격 지원.
  - 프로덕션 수동 롤백 워크플로우 추가: 대상 태그 검증, 릴리스에서 아티팩트 다운로드·무결성 확인 후 배포 스크립트로 롤백 수행.

- 작업
  - 워크플로우 권한, 실행 환경 및 동시성 설정 정비.
  - 로그와 검증 단계 강화로 배포 및 롤백 신뢰성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->