### PR TITLE
[BE] feat:  사용자 재생기록 저장 및 조회 #487

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -43,14 +43,10 @@ public class BookmarkService {
     }
 
     private Page<BookmarkHearitResponse> toBookmarkHearitResponse(Page<BookmarkWithPlaytimeProjection> projections) {
-        return projections.map(p -> new BookmarkHearitResponse(
-                p.getBookmark().getHearit().getId(),
-                p.getBookmark().getId(),
-                p.getBookmark().getHearit().getTitle(),
-                p.getBookmark().getHearit().getSummary(),
-                p.getBookmark().getHearit().getPlayTime(),
-                p.getLastPlayTime(),
-                p.getBookmark().getHearit().getCategory().getColorCode()
+        return projections.map(p -> BookmarkHearitResponse.of(
+                p.getBookmark(),
+                p.getBookmark().getHearit(),
+                p.getLastPlayTime()
         ));
     }
 

--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -16,6 +16,9 @@ import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,16 +41,30 @@ public class BookmarkService {
         Member member = getMemberByUserContext(userContext);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(member, pageable);
+        Map<Long, Long> playTimeMap = getPlayTimeMap(member.getId(), bookmarks.getContent());
+        Page<BookmarkHearitResponse> response = mapToResponsePage(bookmarks, playTimeMap);
 
-        return PagedResponse.from(bookmarks.map(hearit -> toBookmarkHearitResponse(hearit, member)));
+        return PagedResponse.from(response);
     }
 
-    private BookmarkHearitResponse toBookmarkHearitResponse(Bookmark bookmark, Member member) {
-        Hearit hearit = bookmark.getHearit();
-        Long lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
-                .map(PlayingHistory::getLastPlayTime)
-                .orElse(null);
-        return BookmarkHearitResponse.of(bookmark, hearit, lastPlayTime);
+    private Map<Long, Long> getPlayTimeMap(Long memberId, List<Bookmark> bookmarks) {
+        List<Long> hearitIds = bookmarks.stream()
+                .map(bookmark -> bookmark.getHearit().getId())
+                .toList();
+        return playingHistoryRepository.findByMemberIdAndHearitIdIn(memberId, hearitIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        PlayingHistory::getHearitId,
+                        PlayingHistory::getLastPlayTime
+                ));
+    }
+
+    private Page<BookmarkHearitResponse> mapToResponsePage(Page<Bookmark> bookmarks, Map<Long, Long> playTimeMap) {
+        return bookmarks.map(bookmark -> {
+            Hearit hearit = bookmark.getHearit();
+            Long lastPlayTime = playTimeMap.getOrDefault(hearit.getId(), null);
+            return BookmarkHearitResponse.of(bookmark, hearit, lastPlayTime);
+        });
     }
 
     @Transactional

--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -8,17 +8,13 @@ import com.onair.hearit.auth.domain.UserContext;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
-import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlaytimeProjection;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
-import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -33,38 +29,29 @@ public class BookmarkService {
     private final HearitRepository hearitRepository;
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
-    private final PlayingHistoryRepository playingHistoryRepository;
 
     public PagedResponse<BookmarkHearitResponse> getBookmarkHearits(
             UserContext userContext,
             PagingRequest pagingRequest) {
         Member member = getMemberByUserContext(userContext);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
-        Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(member, pageable);
-        Map<Long, Long> playTimeMap = getPlayTimeMap(member.getId(), bookmarks.getContent());
-        Page<BookmarkHearitResponse> response = mapToResponsePage(bookmarks, playTimeMap);
-
+        Page<BookmarkWithPlaytimeProjection> projections = bookmarkRepository.findAllByMemberOrderByRecent(
+                member.getId(),
+                pageable);
+        Page<BookmarkHearitResponse> response = toBookmarkHearitResponse(projections);
         return PagedResponse.from(response);
     }
 
-    private Map<Long, Long> getPlayTimeMap(Long memberId, List<Bookmark> bookmarks) {
-        List<Long> hearitIds = bookmarks.stream()
-                .map(bookmark -> bookmark.getHearit().getId())
-                .toList();
-        return playingHistoryRepository.findByMemberIdAndHearitIdIn(memberId, hearitIds)
-                .stream()
-                .collect(Collectors.toMap(
-                        PlayingHistory::getHearitId,
-                        PlayingHistory::getLastPlayTime
-                ));
-    }
-
-    private Page<BookmarkHearitResponse> mapToResponsePage(Page<Bookmark> bookmarks, Map<Long, Long> playTimeMap) {
-        return bookmarks.map(bookmark -> {
-            Hearit hearit = bookmark.getHearit();
-            Long lastPlayTime = playTimeMap.getOrDefault(hearit.getId(), null);
-            return BookmarkHearitResponse.of(bookmark, hearit, lastPlayTime);
-        });
+    private Page<BookmarkHearitResponse> toBookmarkHearitResponse(Page<BookmarkWithPlaytimeProjection> projections) {
+        return projections.map(p -> new BookmarkHearitResponse(
+                p.getBookmark().getHearit().getId(),
+                p.getBookmark().getId(),
+                p.getBookmark().getHearit().getTitle(),
+                p.getBookmark().getHearit().getSummary(),
+                p.getBookmark().getHearit().getPlayTime(),
+                p.getLastPlayTime(),
+                p.getBookmark().getHearit().getCategory().getColorCode()
+        ));
     }
 
     @Transactional

--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -44,7 +44,7 @@ public class BookmarkService {
 
     private BookmarkHearitResponse toBookmarkHearitResponse(Bookmark bookmark, Member member) {
         Hearit hearit = bookmark.getHearit();
-        Integer lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
+        Long lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
                 .map(PlayingHistory::getLastPlayTime)
                 .orElse(null);
         return BookmarkHearitResponse.of(bookmark, hearit, lastPlayTime);

--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -1,19 +1,21 @@
 package com.onair.hearit.app.application;
 
-import com.onair.hearit.auth.domain.UserContext;
-import com.onair.hearit.common.exception.custom.AlreadyExistException;
-import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
-import com.onair.hearit.common.domain.Bookmark;
-import com.onair.hearit.common.domain.Hearit;
-import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
+import com.onair.hearit.auth.domain.UserContext;
+import com.onair.hearit.common.domain.Bookmark;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.exception.custom.AlreadyExistException;
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -28,6 +30,7 @@ public class BookmarkService {
     private final HearitRepository hearitRepository;
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
+    private final PlayingHistoryRepository playingHistoryRepository;
 
     public PagedResponse<BookmarkHearitResponse> getBookmarkHearits(
             UserContext userContext,
@@ -35,9 +38,16 @@ public class BookmarkService {
         Member member = getMemberByUserContext(userContext);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(member, pageable);
-        Page<BookmarkHearitResponse> bookmarkHearits = bookmarks.map(
-                bookmark -> BookmarkHearitResponse.of(bookmark, bookmark.getHearit()));
-        return PagedResponse.from(bookmarkHearits);
+
+        return PagedResponse.from(bookmarks.map(hearit -> toBookmarkHearitResponse(hearit, member)));
+    }
+
+    private BookmarkHearitResponse toBookmarkHearitResponse(Bookmark bookmark, Member member) {
+        Hearit hearit = bookmark.getHearit();
+        Integer lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
+                .map(PlayingHistory::getLastPlayTime)
+                .orElse(null);
+        return BookmarkHearitResponse.of(bookmark, hearit, lastPlayTime);
     }
 
     @Transactional

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
@@ -51,7 +51,7 @@ public class HearitSearchService {
     }
 
     private HearitSearchResponse toHearitSearchResponseForMember(Hearit hearit, Member member) {
-        Integer lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
+        Long lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
                 .map(PlayingHistory::getLastPlayTime)
                 .orElse(null);
         List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
@@ -1,12 +1,19 @@
 package com.onair.hearit.app.application;
 
-import com.onair.hearit.common.domain.Hearit;
-import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.HearitSearchResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
+import com.onair.hearit.auth.domain.UserContext;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.Keyword;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
+import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -22,17 +29,45 @@ public class HearitSearchService {
 
     private final HearitRepository hearitRepository;
     private final HearitKeywordRepository hearitKeywordRepository;
+    private final MemberRepository memberRepository;
+    private final PlayingHistoryRepository playingHistoryRepository;
 
-    public PagedResponse<HearitSearchResponse> search(String searchTerm, PagingRequest pagingRequest) {
+    public PagedResponse<HearitSearchResponse> search(String searchTerm, PagingRequest pagingRequest,
+                                                      UserContext userContext) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> hearits = hearitRepository.searchByTerm(searchTerm, pageable);
-        Page<HearitSearchResponse> hearitDtos = hearits.map(this::toHearitSearchResponseWithKeywords);
-        return PagedResponse.from(hearitDtos);
+        if (userContext == null || userContext.isGuest()) {
+            return PagedResponse.from(hearits.map(this::toHearitSearchResponseForGuest));
+        }
+
+        Member member = getMemberByUserContext(userContext);
+        return PagedResponse.from(hearits.map(hearit -> toHearitSearchResponseForMember(hearit, member)));
     }
 
-    private HearitSearchResponse toHearitSearchResponseWithKeywords(Hearit hearit) {
+    private HearitSearchResponse toHearitSearchResponseForGuest(Hearit hearit) {
         List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
                 KEYWORD_PER_HEARIT);
-        return HearitSearchResponse.from(hearit, keywords);
+        return HearitSearchResponse.of(hearit, keywords, null);
+    }
+
+    private HearitSearchResponse toHearitSearchResponseForMember(Hearit hearit, Member member) {
+        Integer lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
+                .map(PlayingHistory::getLastPlayTime)
+                .orElse(null);
+        List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
+                KEYWORD_PER_HEARIT);
+        return HearitSearchResponse.of(hearit, keywords, lastPlayTime);
+    }
+
+    private Member getMemberByUserContext(UserContext userContext) {
+        if (userContext == null || userContext.isGuest()) {
+            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+        }
+        return getMemberById(userContext.memberId());
+    }
+
+    private Member getMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -11,6 +11,7 @@ import com.onair.hearit.auth.domain.UserContext;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
@@ -26,7 +27,9 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -113,7 +116,6 @@ public class HearitService {
                 .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
     }
 
-
     private List<Long> pickTodayRandomCategoryIds(List<Category> recommendCategories, int count) {
         long seed = LocalDate.now().toEpochDay();
         List<Long> categoryIds = getAllCategoryIdsWithoutRecommend(recommendCategories);
@@ -135,16 +137,54 @@ public class HearitService {
         return HearitsWithRecommendCategoryResponse.from(category, hearits);
     }
 
-    public PagedResponse<HearitOfCategoryResponse> getHearitsByCategory(Long categoryId, PagingRequest pagingRequest) {
+    public PagedResponse<HearitOfCategoryResponse> getHearitsByCategory(
+            Long categoryId,
+            PagingRequest pagingRequest,
+            UserContext userContext) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> hearits = hearitRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
-        Page<HearitOfCategoryResponse> hearitResponses = hearits.map(this::toHearitOfCategoryResponse);
-        return PagedResponse.from(hearitResponses);
+        List<Long> hearitIds = hearits.getContent().stream().map(Hearit::getId).toList();
+        Map<Long, List<Keyword>> keywordsMap = getKeywordsMap(hearitIds);
+        Map<Long, Long> playTimeMap;
+        if (userContext == null || userContext.isGuest()) {
+            playTimeMap = Collections.emptyMap();
+        } else {
+            playTimeMap = getPlayTimeMap(userContext.memberId(), hearitIds);
+        }
+        Page<HearitOfCategoryResponse> response = hearits.map(hearit -> {
+            List<Keyword> keywords = keywordsMap.getOrDefault(hearit.getId(), Collections.emptyList());
+            Long lastPlayTime = playTimeMap.get(hearit.getId());
+            return HearitOfCategoryResponse.from(hearit, keywords, lastPlayTime);
+        });
+
+        return PagedResponse.from(response);
     }
 
-    private HearitOfCategoryResponse toHearitOfCategoryResponse(Hearit hearit) {
-        List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
-                KEYWORDS_PER_CATEGORIZED_HEARIT);
-        return HearitOfCategoryResponse.from(hearit, keywords);
+    private Map<Long, List<Keyword>> getKeywordsMap(List<Long> hearitIds) {
+        List<HearitKeyword> hearitKeywords = hearitKeywordRepository.findByHearitIdIn(hearitIds);
+        return hearitKeywords.stream()
+                .collect(Collectors.groupingBy(
+                        hk -> hk.getHearit().getId(),
+                        Collectors.mapping(HearitKeyword::getKeyword, Collectors.toList())
+                ))
+                .entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().stream()
+                                .limit(KEYWORDS_PER_CATEGORIZED_HEARIT)
+                                .toList()
+                ));
+    }
+
+    private Map<Long, Long> getPlayTimeMap(Long memberId, List<Long> hearitIds) {
+        if (hearitIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return playingHistoryRepository.findByMemberIdAndHearitIdIn(memberId, hearitIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        PlayingHistory::getHearitId,
+                        PlayingHistory::getLastPlayTime
+                ));
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -1,30 +1,31 @@
 package com.onair.hearit.app.application;
 
 import com.onair.hearit.app.application.recommend.RecommendHearitStrategy;
-import com.onair.hearit.auth.domain.UserContext;
-import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
-import com.onair.hearit.common.domain.Bookmark;
-import com.onair.hearit.common.domain.Category;
-import com.onair.hearit.common.domain.Hearit;
-import com.onair.hearit.common.domain.Keyword;
-import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
 import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
 import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.app.dto.response.RecommendHearitResponse;
+import com.onair.hearit.auth.domain.UserContext;
+import com.onair.hearit.common.domain.Bookmark;
+import com.onair.hearit.common.domain.Category;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.Keyword;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Random;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -46,21 +47,24 @@ public class HearitService {
     private final BookmarkRepository bookmarkRepository;
     private final HearitKeywordRepository hearitKeywordRepository;
     private final CategoryRepository categoryRepository;
+    private final PlayingHistoryRepository playingHistoryRepository;
     private final RecommendHearitStrategy recommendHearitStrategy;
 
     public HearitDetailResponse getHearitDetail(Long hearitId, UserContext userContext) {
         Hearit hearit = getHearitById(hearitId);
         List<Keyword> keywords = hearitKeywordRepository.findKeywordsByHearitId(hearit.getId());
         if (userContext == null || userContext.isGuest()) {
-            return HearitDetailResponse.from(hearit, keywords);
+            return HearitDetailResponse.of(hearit, keywords, null, null);
         }
 
         Member member = getMemberByUserContext(userContext);
-        Optional<Bookmark> bookmarkOptional = bookmarkRepository.findByHearitAndMember(hearit, member);
-        if (bookmarkOptional.isPresent()) {
-            return HearitDetailResponse.fromWithBookmark(hearit, bookmarkOptional.get(), keywords);
-        }
-        return HearitDetailResponse.from(hearit, keywords);
+        Long bookmarkId = bookmarkRepository.findByHearitAndMember(hearit, member)
+                .map(Bookmark::getId)
+                .orElse(null);
+        Integer lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
+                .map(PlayingHistory::getLastPlayTime)
+                .orElse(null);
+        return HearitDetailResponse.of(hearit, keywords, lastPlayTime, bookmarkId);
     }
 
     private Hearit getHearitById(Long hearitId) {

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -61,7 +61,7 @@ public class HearitService {
         Long bookmarkId = bookmarkRepository.findByHearitAndMember(hearit, member)
                 .map(Bookmark::getId)
                 .orElse(null);
-        Integer lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
+        Long lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
                 .map(PlayingHistory::getLastPlayTime)
                 .orElse(null);
         return HearitDetailResponse.of(hearit, keywords, lastPlayTime, bookmarkId);

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -17,11 +17,11 @@ import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.infrastructure.dto.HearitWithPlayTimeProjection;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
-import com.onair.hearit.common.infrastructure.jpa.HearitWithPlayTime;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import java.time.LocalDate;
@@ -145,10 +145,10 @@ public class HearitService {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
 
         Long memberId = (userContext == null || userContext.isGuest()) ? null : userContext.memberId();
-        Page<HearitWithPlayTime> hearitsWithPlayTime =
+        Page<HearitWithPlayTimeProjection> hearitsWithPlayTime =
                 hearitRepository.findWithPlayTimeByCategoryId(categoryId, memberId, pageable);
         List<Hearit> hearits = hearitsWithPlayTime.getContent().stream()
-                .map(HearitWithPlayTime::getHearit)
+                .map(HearitWithPlayTimeProjection::getHearit)
                 .toList();
         List<Long> hearitIds = hearits.stream().map(Hearit::getId).toList();
         Map<Long, List<Keyword>> keywordsMap = getKeywordsMap(hearitIds);

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -21,6 +21,7 @@ import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
+import com.onair.hearit.common.infrastructure.jpa.HearitWithPlayTime;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import java.time.LocalDate;
@@ -142,21 +143,21 @@ public class HearitService {
             PagingRequest pagingRequest,
             UserContext userContext) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
-        Page<Hearit> hearits = hearitRepository.findByCategoryIdOrderByCreatedAtDesc(categoryId, pageable);
-        List<Long> hearitIds = hearits.getContent().stream().map(Hearit::getId).toList();
+
+        Long memberId = (userContext == null || userContext.isGuest()) ? null : userContext.memberId();
+        Page<HearitWithPlayTime> hearitsWithPlayTime =
+                hearitRepository.findWithPlayTimeByCategoryId(categoryId, memberId, pageable);
+        List<Hearit> hearits = hearitsWithPlayTime.getContent().stream()
+                .map(HearitWithPlayTime::getHearit)
+                .toList();
+        List<Long> hearitIds = hearits.stream().map(Hearit::getId).toList();
         Map<Long, List<Keyword>> keywordsMap = getKeywordsMap(hearitIds);
-        Map<Long, Long> playTimeMap;
-        if (userContext == null || userContext.isGuest()) {
-            playTimeMap = Collections.emptyMap();
-        } else {
-            playTimeMap = getPlayTimeMap(userContext.memberId(), hearitIds);
-        }
-        Page<HearitOfCategoryResponse> response = hearits.map(hearit -> {
+        Page<HearitOfCategoryResponse> response = hearitsWithPlayTime.map(projection -> {
+            Hearit hearit = projection.getHearit();
+            Long lastPlayTime = projection.getLastPlayTime();
             List<Keyword> keywords = keywordsMap.getOrDefault(hearit.getId(), Collections.emptyList());
-            Long lastPlayTime = playTimeMap.get(hearit.getId());
             return HearitOfCategoryResponse.from(hearit, keywords, lastPlayTime);
         });
-
         return PagedResponse.from(response);
     }
 
@@ -173,18 +174,6 @@ public class HearitService {
                         entry -> entry.getValue().stream()
                                 .limit(KEYWORDS_PER_CATEGORIZED_HEARIT)
                                 .toList()
-                ));
-    }
-
-    private Map<Long, Long> getPlayTimeMap(Long memberId, List<Long> hearitIds) {
-        if (hearitIds.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return playingHistoryRepository.findByMemberIdAndHearitIdIn(memberId, hearitIds)
-                .stream()
-                .collect(Collectors.toMap(
-                        PlayingHistory::getHearitId,
-                        PlayingHistory::getLastPlayTime
                 ));
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -4,6 +4,7 @@ import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
 import com.onair.hearit.app.infrastructure.scheduler.PlayingHistoryBuffer;
 import com.onair.hearit.auth.domain.UserContext;
 import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
@@ -20,16 +21,11 @@ public class PlayingHistoryService {
     private final HearitRepository hearitRepository;
 
     public boolean addPlayingHistory(UserContext userContext, PlayingHistoryRequest request) {
-        validateHearit(request.hearitId());
         checkMember(userContext);
-        playingHistoryBuffer.addPlayingHistory(userContext.memberId(), request.hearitId(), request.lastPlayTime());
+        Hearit hearit = getHearitById(request.hearitId());
+        PlayingHistory history = new PlayingHistory(userContext.memberId(), hearit, request.lastPlayTime());
+        playingHistoryBuffer.add(history);
         return !playingHistoryRepository.existsByHearitIdAndMemberId(request.hearitId(), userContext.memberId());
-    }
-
-    private void validateHearit(Long hearitId) {
-        if (!hearitRepository.existsById(hearitId)) {
-            throw new NotFoundException("hearitId", hearitId.toString());
-        }
     }
 
     private void checkMember(UserContext userContext) {

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -6,7 +6,6 @@ import com.onair.hearit.auth.domain.UserContext;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,17 +20,18 @@ public class PlayingHistoryService {
     private final HearitRepository hearitRepository;
 
     public boolean addPlayingHistory(UserContext userContext, PlayingHistoryRequest request) {
-        checkMember(userContext);
+        if (userContext == null || userContext.isGuest()) {
+            return false;
+        }
         Hearit hearit = getHearitById(request.hearitId());
         PlayingHistory history = new PlayingHistory(userContext.memberId(), hearit, request.lastPlayTime());
-        playingHistoryBuffer.add(history);
-        return !playingHistoryRepository.existsByHearitIdAndMemberId(request.hearitId(), userContext.memberId());
+        return !addPlayingHistory(history, request.hearitId(), userContext.memberId());
     }
 
-    private void checkMember(UserContext userContext) {
-        if (userContext == null || userContext.isGuest()) {
-            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
-        }
+    private boolean addPlayingHistory(PlayingHistory history, Long hearitId, Long memberId) {
+        boolean isExited = playingHistoryRepository.existsByHearitIdAndMemberId(hearitId, memberId);
+        playingHistoryBuffer.add(history);
+        return isExited;
     }
 
     private Hearit getHearitById(Long hearitId) {

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -20,11 +20,19 @@ public class PlayingHistoryService {
     private final HearitRepository hearitRepository;
 
     @Transactional
-    public void addPlayingHistory(UserContext userContext, PlayingHistoryRequest request) {
+    public boolean addPlayingHistory(UserContext userContext, PlayingHistoryRequest request) {
         checkMember(userContext);
         Hearit hearit = getHearitById(request.hearitId());
-        PlayingHistory playingHistory = new PlayingHistory(userContext.memberId(), hearit, request.lastPlayTime());
-        playingHistoryRepository.save(playingHistory);
+        return playingHistoryRepository.findByHearitIdAndMemberId(request.hearitId(), userContext.memberId())
+                .map(ph -> {
+                    ph.setLastPlayTime(request.lastPlayTime());
+                    return false;
+                })
+                .orElseGet(() -> {
+                    playingHistoryRepository.save(
+                            new PlayingHistory(userContext.memberId(), hearit, request.lastPlayTime()));
+                    return true;
+                });
     }
 
     private void checkMember(UserContext userContext) {

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -1,0 +1,40 @@
+package com.onair.hearit.app.application;
+
+import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.auth.domain.UserContext;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlayingHistoryService {
+
+    private final PlayingHistoryRepository playingHistoryRepository;
+    private final HearitRepository hearitRepository;
+
+    @Transactional
+    public void addPlayingHistory(UserContext userContext, PlayingHistoryRequest request) {
+        checkMember(userContext);
+        Hearit hearit = getHearitById(request.hearitId());
+        PlayingHistory playingHistory = new PlayingHistory(userContext.memberId(), hearit, request.lastPlayTime());
+        playingHistoryRepository.save(playingHistory);
+    }
+
+    private void checkMember(UserContext userContext) {
+        if (userContext == null || userContext.isGuest()) {
+            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+        }
+    }
+
+    private Hearit getHearitById(Long hearitId) {
+        return hearitRepository.findById(hearitId)
+                .orElseThrow(() -> new NotFoundException("hearitId", hearitId.toString()));
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -19,19 +19,13 @@ public class PlayingHistoryService {
     private final PlayingHistoryBuffer playingHistoryBuffer;
     private final HearitRepository hearitRepository;
 
-    public boolean addPlayingHistory(UserContext userContext, PlayingHistoryRequest request) {
+    public void addPlayingHistory(UserContext userContext, PlayingHistoryRequest request) {
         if (userContext == null || userContext.isGuest()) {
-            return false;
+            return;
         }
         Hearit hearit = getHearitById(request.hearitId());
         PlayingHistory history = new PlayingHistory(userContext.memberId(), hearit, request.lastPlayTime());
-        return !addPlayingHistory(history, request.hearitId(), userContext.memberId());
-    }
-
-    private boolean addPlayingHistory(PlayingHistory history, Long hearitId, Long memberId) {
-        boolean isExited = playingHistoryRepository.existsByHearitIdAndMemberId(hearitId, memberId);
         playingHistoryBuffer.add(history);
-        return isExited;
     }
 
     private Hearit getHearitById(Long hearitId) {

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -1,14 +1,13 @@
 package com.onair.hearit.app.application;
 
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.app.infrastructure.scheduler.PlayingHistoryBuffer;
 import com.onair.hearit.auth.domain.UserContext;
 import com.onair.hearit.common.domain.Hearit;
-import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,22 +16,20 @@ import org.springframework.stereotype.Service;
 public class PlayingHistoryService {
 
     private final PlayingHistoryRepository playingHistoryRepository;
+    private final PlayingHistoryBuffer playingHistoryBuffer;
     private final HearitRepository hearitRepository;
 
-    @Transactional
     public boolean addPlayingHistory(UserContext userContext, PlayingHistoryRequest request) {
+        validateHearit(request.hearitId());
         checkMember(userContext);
-        Hearit hearit = getHearitById(request.hearitId());
-        return playingHistoryRepository.findByHearitIdAndMemberId(request.hearitId(), userContext.memberId())
-                .map(ph -> {
-                    ph.setLastPlayTime(request.lastPlayTime());
-                    return false;
-                })
-                .orElseGet(() -> {
-                    playingHistoryRepository.save(
-                            new PlayingHistory(userContext.memberId(), hearit, request.lastPlayTime()));
-                    return true;
-                });
+        playingHistoryBuffer.addPlayingHistory(userContext.memberId(), request.hearitId(), request.lastPlayTime());
+        return !playingHistoryRepository.existsByHearitIdAndMemberId(request.hearitId(), userContext.memberId());
+    }
+
+    private void validateHearit(Long hearitId) {
+        if (!hearitRepository.existsById(hearitId)) {
+            throw new NotFoundException("hearitId", hearitId.toString());
+        }
     }
 
     private void checkMember(UserContext userContext) {

--- a/backend/src/main/java/com/onair/hearit/app/dto/request/PlayingHistoryRequest.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/request/PlayingHistoryRequest.java
@@ -1,0 +1,17 @@
+package com.onair.hearit.app.dto.request;
+
+import com.onair.hearit.common.exception.custom.InvalidInputException;
+
+public record PlayingHistoryRequest(
+        Long hearitId,
+        Integer lastPlayTime
+) {
+    public PlayingHistoryRequest {
+        if (hearitId == null) {
+            throw new InvalidInputException("히어릿은 null이 될 수 없습니다.");
+        }
+        if (lastPlayTime < 0) {
+            throw new InvalidInputException("마지막 재생 기록은 0 이상이어야 합니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/app/dto/request/PlayingHistoryRequest.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/request/PlayingHistoryRequest.java
@@ -4,13 +4,13 @@ import com.onair.hearit.common.exception.custom.InvalidInputException;
 
 public record PlayingHistoryRequest(
         Long hearitId,
-        Integer lastPlayTime
+        Long lastPlayTime
 ) {
     public PlayingHistoryRequest {
         if (hearitId == null) {
             throw new InvalidInputException("히어릿은 null이 될 수 없습니다.");
         }
-        if (lastPlayTime < 0) {
+        if (lastPlayTime == null || lastPlayTime < 0) {
             throw new InvalidInputException("마지막 재생 기록은 0 이상이어야 합니다.");
         }
     }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
@@ -9,15 +9,17 @@ public record BookmarkHearitResponse(
         String title,
         String summary,
         Integer playTime,
+        Integer lastPlayTime,
         String categoryColor
 ) {
-    public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit) {
+    public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit, Integer lastPlayTime) {
         return new BookmarkHearitResponse(
                 hearit.getId(),
                 bookmark.getId(),
                 hearit.getTitle(),
                 hearit.getSummary(),
                 hearit.getPlayTime(),
+                lastPlayTime,
                 hearit.getCategory().getColorCode());
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
@@ -9,10 +9,10 @@ public record BookmarkHearitResponse(
         String title,
         String summary,
         Integer playTime,
-        Integer lastPlayTime,
+        Long lastPlayTime,
         String categoryColor
 ) {
-    public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit, Integer lastPlayTime) {
+    public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit, Long lastPlayTime) {
         return new BookmarkHearitResponse(
                 hearit.getId(),
                 bookmark.getId(),

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
@@ -1,6 +1,5 @@
 package com.onair.hearit.app.dto.response;
 
-import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Keyword;
@@ -14,42 +13,33 @@ public record HearitDetailResponse(
         String summary,
         List<SourceResponse> sources,
         Integer playTime,
+        Integer lastPlayTime,
         LocalDateTime createdAt,
         Boolean isBookmarked,
         Long bookmarkId,
         CategoryResponse category,
         List<KeywordResponse> keywords
 ) {
-    public static HearitDetailResponse from(Hearit hearit, List<Keyword> keywords) {
-        List<KeywordResponse> keywordNames = getKeywordNames(keywords);
+    public static HearitDetailResponse of(Hearit hearit,
+                                          List<Keyword> keywords,
+                                          Integer lastPlayTime,
+                                          Long bookmarkId) {
+        List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         List<SourceResponse> sources = getSources(hearit.getSources());
-        return new HearitDetailResponse(
-                hearit.getId(),
-                hearit.getTitle(),
-                hearit.getSummary(),
-                sources,
-                hearit.getPlayTime(),
-                hearit.getCreatedAt(),
-                false,
-                null,
-                CategoryResponse.of(hearit.getCategory()),
-                keywordNames);
-    }
 
-    public static HearitDetailResponse fromWithBookmark(Hearit hearit, Bookmark bookmark, List<Keyword> keywords) {
-        List<KeywordResponse> keywordNames = getKeywordNames(keywords);
-        List<SourceResponse> sources = getSources(hearit.getSources());
         return new HearitDetailResponse(
                 hearit.getId(),
                 hearit.getTitle(),
                 hearit.getSummary(),
                 sources,
                 hearit.getPlayTime(),
+                lastPlayTime,
                 hearit.getCreatedAt(),
-                true,
-                bookmark.getId(),
+                bookmarkId != null,
+                bookmarkId,
                 CategoryResponse.of(hearit.getCategory()),
-                keywordNames);
+                keywordResponses
+        );
     }
 
     private static List<KeywordResponse> getKeywordNames(List<Keyword> keywords) {

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitDetailResponse.java
@@ -13,7 +13,7 @@ public record HearitDetailResponse(
         String summary,
         List<SourceResponse> sources,
         Integer playTime,
-        Integer lastPlayTime,
+        Long lastPlayTime,
         LocalDateTime createdAt,
         Boolean isBookmarked,
         Long bookmarkId,
@@ -22,7 +22,7 @@ public record HearitDetailResponse(
 ) {
     public static HearitDetailResponse of(Hearit hearit,
                                           List<Keyword> keywords,
-                                          Integer lastPlayTime,
+                                          Long lastPlayTime,
                                           Long bookmarkId) {
         List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         List<SourceResponse> sources = getSources(hearit.getSources());

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitOfCategoryResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitOfCategoryResponse.java
@@ -8,14 +8,16 @@ public record HearitOfCategoryResponse(
         Long id,
         String title,
         Integer playTime,
+        Long lastPlayTime,
         List<KeywordResponse> keywords
 ) {
-    public static HearitOfCategoryResponse from(Hearit hearit, List<Keyword> keywords) {
+    public static HearitOfCategoryResponse from(Hearit hearit, List<Keyword> keywords, Long lastPlayTime) {
         List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         return new HearitOfCategoryResponse(
                 hearit.getId(),
                 hearit.getTitle(),
                 hearit.getPlayTime(),
+                lastPlayTime,
                 keywordResponses
         );
     }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
@@ -8,14 +8,16 @@ public record HearitSearchResponse(
         Long id,
         String title,
         Integer playTime,
+        Integer lastPlayTime,
         List<KeywordResponse> keywords
 ) {
-    public static HearitSearchResponse from(Hearit hearit, List<Keyword> keywords) {
+    public static HearitSearchResponse of(Hearit hearit, List<Keyword> keywords, Integer lastPlayTime) {
         List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         return new HearitSearchResponse(
                 hearit.getId(),
                 hearit.getTitle(),
                 hearit.getPlayTime(),
+                lastPlayTime,
                 keywordResponses
         );
     }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
@@ -8,10 +8,10 @@ public record HearitSearchResponse(
         Long id,
         String title,
         Integer playTime,
-        Integer lastPlayTime,
+        Long lastPlayTime,
         List<KeywordResponse> keywords
 ) {
-    public static HearitSearchResponse of(Hearit hearit, List<Keyword> keywords, Integer lastPlayTime) {
+    public static HearitSearchResponse of(Hearit hearit, List<Keyword> keywords, Long lastPlayTime) {
         List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         return new HearitSearchResponse(
                 hearit.getId(),

--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
@@ -1,0 +1,68 @@
+package com.onair.hearit.app.infrastructure.scheduler;
+
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.infrastructure.jdbc.PlayingHistoryCommandRepository;
+import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PlayingHistoryBuffer {
+
+    private final PlayingHistoryCommandRepository playingHistoryCommandRepository;
+    private final HearitRepository hearitRepository;
+
+    private final BlockingQueue<HistoryRecord> queue = new LinkedBlockingQueue<>();
+
+    public void addPlayingHistory(Long memberId, Long hearitId, int lastPlayTime) {
+        if (memberId == null || hearitId == null) {
+            return;
+        }
+        queue.add(new HistoryRecord(memberId, hearitId, lastPlayTime));
+    }
+
+    /*
+     * 5초마다 또는 500개 이상 모이면 DB에 flush()
+     */
+    @Transactional
+    @Scheduled(fixedDelay = 5000)
+    public void flush() {
+        if (queue.isEmpty()) {
+            return;
+        }
+
+        List<HistoryRecord> batchRecords = new ArrayList<>();
+        queue.drainTo(batchRecords, 500);
+        if (!batchRecords.isEmpty()) {
+            List<Long> hearitIds = batchRecords.stream()
+                    .map(HistoryRecord::hearitId)
+                    .distinct()
+                    .toList();
+            Map<Long, Hearit> hearitMap = hearitRepository.findAllById(hearitIds).stream()
+                    .collect(Collectors.toMap(Hearit::getId, hearit -> hearit));
+
+            List<PlayingHistory> historiesToInsert = new ArrayList<>();
+            for (HistoryRecord record : batchRecords) {
+                Hearit hearit = hearitMap.get(record.hearitId());
+                historiesToInsert.add(new PlayingHistory(record.memberId(), hearit, record.lastPlayTime()));
+            }
+
+            if (!historiesToInsert.isEmpty()) {
+                playingHistoryCommandRepository.bulkInsert(historiesToInsert);
+            }
+        }
+    }
+
+    private record HistoryRecord(Long memberId, Long hearitId, int lastPlayTime) {
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
@@ -1,15 +1,11 @@
 package com.onair.hearit.app.infrastructure.scheduler;
 
-import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.infrastructure.jdbc.PlayingHistoryCommandRepository;
-import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -20,15 +16,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlayingHistoryBuffer {
 
     private final PlayingHistoryCommandRepository playingHistoryCommandRepository;
-    private final HearitRepository hearitRepository;
+    private final BlockingQueue<PlayingHistory> queue = new LinkedBlockingQueue<>();
 
-    private final BlockingQueue<HistoryRecord> queue = new LinkedBlockingQueue<>();
-
-    public void addPlayingHistory(Long memberId, Long hearitId, Long lastPlayTime) {
-        if (memberId == null || hearitId == null || lastPlayTime == null) {
-            return;
+    public void add(PlayingHistory playingHistory) {
+        if (playingHistory != null) {
+            queue.add(playingHistory);
         }
-        queue.add(new HistoryRecord(memberId, hearitId, lastPlayTime));
     }
 
     /*
@@ -37,32 +30,12 @@ public class PlayingHistoryBuffer {
     @Transactional
     @Scheduled(fixedDelay = 5000)
     public void flush() {
-        if (queue.isEmpty()) {
-            return;
-        }
-
-        List<HistoryRecord> batchRecords = new ArrayList<>();
-        queue.drainTo(batchRecords, 500);
-        if (!batchRecords.isEmpty()) {
-            List<Long> hearitIds = batchRecords.stream()
-                    .map(HistoryRecord::hearitId)
-                    .distinct()
-                    .toList();
-            Map<Long, Hearit> hearitMap = hearitRepository.findAllById(hearitIds).stream()
-                    .collect(Collectors.toMap(Hearit::getId, hearit -> hearit));
-
-            List<PlayingHistory> historiesToInsert = new ArrayList<>();
-            for (HistoryRecord record : batchRecords) {
-                Hearit hearit = hearitMap.get(record.hearitId());
-                historiesToInsert.add(new PlayingHistory(record.memberId(), hearit, record.lastPlayTime()));
-            }
-
-            if (!historiesToInsert.isEmpty()) {
-                playingHistoryCommandRepository.bulkInsert(historiesToInsert);
+        if (!queue.isEmpty()) {
+            List<PlayingHistory> batchRecords = new ArrayList<>();
+            queue.drainTo(batchRecords, 500);
+            if (!batchRecords.isEmpty()) {
+                playingHistoryCommandRepository.bulkInsert(batchRecords);
             }
         }
-    }
-
-    private record HistoryRecord(Long memberId, Long hearitId, Long lastPlayTime) {
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
@@ -24,8 +24,8 @@ public class PlayingHistoryBuffer {
 
     private final BlockingQueue<HistoryRecord> queue = new LinkedBlockingQueue<>();
 
-    public void addPlayingHistory(Long memberId, Long hearitId, int lastPlayTime) {
-        if (memberId == null || hearitId == null) {
+    public void addPlayingHistory(Long memberId, Long hearitId, Long lastPlayTime) {
+        if (memberId == null || hearitId == null || lastPlayTime == null) {
             return;
         }
         queue.add(new HistoryRecord(memberId, hearitId, lastPlayTime));
@@ -63,6 +63,6 @@ public class PlayingHistoryBuffer {
         }
     }
 
-    private record HistoryRecord(Long memberId, Long hearitId, int lastPlayTime) {
+    private record HistoryRecord(Long memberId, Long hearitId, Long lastPlayTime) {
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.app.infrastructure.scheduler;
 
 import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.exception.custom.BufferRequestException;
 import com.onair.hearit.common.infrastructure.jdbc.PlayingHistoryCommandRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,12 +16,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PlayingHistoryBuffer {
 
+    private static final int BUFFER_SIZE = 10_000;
+
     private final PlayingHistoryCommandRepository playingHistoryCommandRepository;
-    private final BlockingQueue<PlayingHistory> queue = new LinkedBlockingQueue<>();
+    private final BlockingQueue<PlayingHistory> queue = new LinkedBlockingQueue<>(BUFFER_SIZE);
 
     public void add(PlayingHistory playingHistory) {
-        if (playingHistory != null) {
-            queue.add(playingHistory);
+        if (!queue.offer(playingHistory)) {
+            throw new BufferRequestException("큐가 가득 차서 요청을 처리할 수 없습니다.");
         }
     }
 

--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
@@ -27,9 +27,6 @@ public class PlayingHistoryBuffer {
         }
     }
 
-    /*
-     * 5초마다 또는 500개 이상 모이면 DB에 flush()
-     */
     @Transactional
     @Scheduled(fixedDelay = 5000)
     public void flush() {

--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/SchedulerConfig.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.onair.hearit.app.infrastructure.scheduler;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
@@ -1,9 +1,8 @@
 package com.onair.hearit.app.presentation;
 
+import com.onair.hearit.app.application.HearitExploreService;
 import com.onair.hearit.app.application.HearitSearchService;
 import com.onair.hearit.app.application.HearitService;
-import com.onair.hearit.app.application.HearitExploreService;
-import com.onair.hearit.auth.domain.UserContext;
 import com.onair.hearit.app.dto.request.CursorRequest;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.CursorResponse;
@@ -14,6 +13,7 @@ import com.onair.hearit.app.dto.response.HearitSearchResponse;
 import com.onair.hearit.app.dto.response.HearitsWithRecommendCategoryResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.app.dto.response.RecommendHearitResponse;
+import com.onair.hearit.auth.domain.UserContext;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -62,9 +62,11 @@ public class HearitController {
     public ResponseEntity<PagedResponse<HearitSearchResponse>> readSearchedHearits(
             @RequestParam(name = "searchTerm") String searchTerm,
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "20") int size) {
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @AuthenticationPrincipal UserContext userContext) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        PagedResponse<HearitSearchResponse> response = hearitSearchService.search(searchTerm, pagingRequest);
+        PagedResponse<HearitSearchResponse> response = hearitSearchService.search(searchTerm, pagingRequest,
+                userContext);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
@@ -82,10 +82,11 @@ public class HearitController {
     public ResponseEntity<PagedResponse<HearitOfCategoryResponse>> readHearitsByCategory(
             @RequestParam(name = "categoryId") Long categoryId,
             @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "20") int size) {
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @AuthenticationPrincipal UserContext userContext) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
         PagedResponse<HearitOfCategoryResponse> response = hearitService.getHearitsByCategory(categoryId,
-                pagingRequest);
+                pagingRequest, userContext);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,11 +19,14 @@ public class PlayingHistoryController {
 
     private final PlayingHistoryService playingHistoryService;
 
-    @PostMapping
+    @PutMapping
     public ResponseEntity<Void> createPlayingHistory(
             @RequestBody PlayingHistoryRequest request,
             @AuthenticationPrincipal UserContext userContext) {
-        playingHistoryService.addPlayingHistory(userContext, request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        boolean isCreated = playingHistoryService.addPlayingHistory(userContext, request);
+        if (isCreated) {
+            return ResponseEntity.status(HttpStatus.CREATED).build();
+        }
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,14 +19,11 @@ public class PlayingHistoryController {
 
     private final PlayingHistoryService playingHistoryService;
 
-    @PutMapping
+    @PostMapping
     public ResponseEntity<Void> createPlayingHistory(
             @RequestBody PlayingHistoryRequest request,
             @AuthenticationPrincipal UserContext userContext) {
-        boolean isCreated = playingHistoryService.addPlayingHistory(userContext, request);
-        if (isCreated) {
-            return ResponseEntity.status(HttpStatus.CREATED).build();
-        }
+        playingHistoryService.addPlayingHistory(userContext, request);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
@@ -1,0 +1,29 @@
+package com.onair.hearit.app.presentation;
+
+import com.onair.hearit.app.application.PlayingHistoryService;
+import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.auth.domain.UserContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/playing-histories")
+public class PlayingHistoryController {
+
+    private final PlayingHistoryService playingHistoryService;
+
+    @PostMapping
+    public ResponseEntity<Void> createPlayingHistory(
+            @RequestBody PlayingHistoryRequest request,
+            @AuthenticationPrincipal UserContext userContext) {
+        playingHistoryService.addPlayingHistory(userContext, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -62,4 +62,8 @@ public class PlayingHistory {
             throw new InvalidInputException("마지막 재생 시간은 히어릿의 총 재생 시간보다 작아야 합니다");
         }
     }
+
+    public void setLastPlayTime(Integer lastPlayTime) {
+        this.lastPlayTime = lastPlayTime;
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -68,8 +68,4 @@ public class PlayingHistory {
             throw new InvalidInputException("마지막 재생 시간은 히어릿의 총 재생 시간보다 작아야 합니다");
         }
     }
-
-    public void setLastPlayTime(long lastPlayTime) {
-        this.lastPlayTime = lastPlayTime;
-    }
 }

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -30,6 +30,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class PlayingHistory {
 
     private static final int FINISHED_TIME_RANGE = 10;
+    private static final int MILLISECONDS_PER_SECOND = 1_000;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,7 +43,7 @@ public class PlayingHistory {
     private Long hearitId;
 
     @Column(name = "last_play_time", nullable = false)
-    private int lastPlayTime;
+    private long lastPlayTime;
 
     @Column(name = "is_finished", nullable = false)
     private boolean isFinished;
@@ -51,7 +52,7 @@ public class PlayingHistory {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public PlayingHistory(Long memberId, Hearit hearit, int lastPlayTime) {
+    public PlayingHistory(Long memberId, Hearit hearit, long lastPlayTime) {
         validateHearitPlayTime(hearit, lastPlayTime);
         this.memberId = memberId;
         this.hearitId = hearit.getId();
@@ -59,17 +60,17 @@ public class PlayingHistory {
         this.isFinished = checkIsFinished(hearit, lastPlayTime);
     }
 
-    private boolean checkIsFinished(Hearit hearit, int lastPlayTime) {
-        return lastPlayTime >= hearit.getPlayTime() - FINISHED_TIME_RANGE;
+    private boolean checkIsFinished(Hearit hearit, long lastPlayTime) {
+        return lastPlayTime >= (long) (hearit.getPlayTime() - FINISHED_TIME_RANGE) * MILLISECONDS_PER_SECOND;
     }
 
-    private void validateHearitPlayTime(Hearit hearit, int lastPlayTime) {
-        if (lastPlayTime > hearit.getPlayTime()) {
+    private void validateHearitPlayTime(Hearit hearit, long lastPlayTime) {
+        if (lastPlayTime > hearit.getPlayTime() * MILLISECONDS_PER_SECOND) {
             throw new InvalidInputException("마지막 재생 시간은 히어릿의 총 재생 시간보다 작아야 합니다");
         }
     }
 
-    public void setLastPlayTime(Integer lastPlayTime) {
+    public void setLastPlayTime(long lastPlayTime) {
         this.lastPlayTime = lastPlayTime;
     }
 }

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,9 +19,14 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
-@Table(name = "playing_history")
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "playing_history",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_playing_history_member_hearit", columnNames = {"member_id", "hearit_id"})
+        }
+)
 public class PlayingHistory {
 
     private static final int FINISHED_TIME_RANGE = 10;

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -1,0 +1,44 @@
+package com.onair.hearit.common.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Table(name = "playing_history")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlayingHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "hearit_id", nullable = false)
+    private Long hearitId;
+
+    @Column(name = "last_play_time",nullable = false)
+    private int lastPlayTime;
+
+    @Column(name = "is_finished",nullable = false)
+    private boolean isFinished;
+
+    @LastModifiedDate
+    @Column(name = "updated_at",nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -1,6 +1,5 @@
 package com.onair.hearit.common.domain;
 
-
 import com.onair.hearit.common.exception.custom.InvalidInputException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -65,7 +64,7 @@ public class PlayingHistory {
     }
 
     private void validateHearitPlayTime(Hearit hearit, long lastPlayTime) {
-        if (lastPlayTime > hearit.getPlayTime() * MILLISECONDS_PER_SECOND) {
+        if (lastPlayTime < 0 || lastPlayTime > hearit.getPlayTime() * MILLISECONDS_PER_SECOND) {
             throw new InvalidInputException("마지막 재생 시간은 히어릿의 총 재생 시간보다 작아야 합니다");
         }
     }

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.common.domain;
 
 
+import com.onair.hearit.common.exception.custom.InvalidInputException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -22,6 +23,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlayingHistory {
 
+    private static final int FINISHED_TIME_RANGE = 10;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -32,13 +35,31 @@ public class PlayingHistory {
     @Column(name = "hearit_id", nullable = false)
     private Long hearitId;
 
-    @Column(name = "last_play_time",nullable = false)
+    @Column(name = "last_play_time", nullable = false)
     private int lastPlayTime;
 
-    @Column(name = "is_finished",nullable = false)
+    @Column(name = "is_finished", nullable = false)
     private boolean isFinished;
 
     @LastModifiedDate
-    @Column(name = "updated_at",nullable = false)
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public PlayingHistory(Long memberId, Hearit hearit, int lastPlayTime) {
+        validateHearitPlayTime(hearit, lastPlayTime);
+        this.memberId = memberId;
+        this.hearitId = hearit.getId();
+        this.lastPlayTime = lastPlayTime;
+        this.isFinished = checkIsFinished(hearit, lastPlayTime);
+    }
+
+    private boolean checkIsFinished(Hearit hearit, int lastPlayTime) {
+        return lastPlayTime >= hearit.getPlayTime() - FINISHED_TIME_RANGE;
+    }
+
+    private void validateHearitPlayTime(Hearit hearit, int lastPlayTime) {
+        if (lastPlayTime > hearit.getPlayTime()) {
+            throw new InvalidInputException("마지막 재생 시간은 히어릿의 총 재생 시간보다 작아야 합니다");
+        }
+    }
 }

--- a/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정보를 찾을 수 없습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
+    BUFFER_OVERFLOW(HttpStatus.TOO_MANY_REQUESTS, "대기 중인 요청이 너무 많습니다."),
 
     //SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),

--- a/backend/src/main/java/com/onair/hearit/common/exception/custom/BufferRequestException.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/custom/BufferRequestException.java
@@ -1,0 +1,10 @@
+package com.onair.hearit.common.exception.custom;
+
+import com.onair.hearit.common.exception.ErrorCode;
+
+public class BufferRequestException extends HearitException {
+
+    public BufferRequestException(String detail) {
+        super(ErrorCode.BUFFER_OVERFLOW, detail);
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/dto/BookmarkWithPlaytimeProjection.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/dto/BookmarkWithPlaytimeProjection.java
@@ -1,0 +1,9 @@
+package com.onair.hearit.common.infrastructure.dto;
+
+import com.onair.hearit.common.domain.Bookmark;
+
+public interface BookmarkWithPlaytimeProjection {
+    Bookmark getBookmark();
+
+    Long getLastPlayTime();
+}

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/dto/HearitWithPlayTimeProjection.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/dto/HearitWithPlayTimeProjection.java
@@ -1,8 +1,8 @@
-package com.onair.hearit.common.infrastructure.jpa;
+package com.onair.hearit.common.infrastructure.dto;
 
 import com.onair.hearit.common.domain.Hearit;
 
-public interface HearitWithPlayTime {
+public interface HearitWithPlayTimeProjection {
     Hearit getHearit();
 
     Long getLastPlayTime();

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jdbc/PlayingHistoryCommandRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jdbc/PlayingHistoryCommandRepository.java
@@ -1,0 +1,35 @@
+package com.onair.hearit.common.infrastructure.jdbc;
+
+import com.onair.hearit.common.domain.PlayingHistory;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PlayingHistoryCommandRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public void bulkInsert(List<PlayingHistory> histories) {
+        String sql = """
+                INSERT INTO playing_history (member_id, hearit_id, last_play_time, is_finished, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON DUPLICATE KEY UPDATE
+                    last_play_time = VALUES(last_play_time),
+                    is_finished = VALUES(is_finished),
+                    updated_at = VALUES(updated_at)
+                """;
+
+        jdbcTemplate.batchUpdate(sql, histories, histories.size(), (ps, history) -> {
+            ps.setLong(1, history.getMemberId());
+            ps.setLong(2, history.getHearitId());
+            ps.setInt(3, history.getLastPlayTime());
+            ps.setBoolean(4, history.isFinished());
+            ps.setTimestamp(5, Timestamp.valueOf(LocalDateTime.now()));
+        });
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jdbc/PlayingHistoryCommandRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jdbc/PlayingHistoryCommandRepository.java
@@ -27,7 +27,7 @@ public class PlayingHistoryCommandRepository {
         jdbcTemplate.batchUpdate(sql, histories, histories.size(), (ps, history) -> {
             ps.setLong(1, history.getMemberId());
             ps.setLong(2, history.getHearitId());
-            ps.setInt(3, history.getLastPlayTime());
+            ps.setLong(3, history.getLastPlayTime());
             ps.setBoolean(4, history.isFinished());
             ps.setTimestamp(5, Timestamp.valueOf(LocalDateTime.now()));
         });

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jdbc/PlayingHistoryCommandRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jdbc/PlayingHistoryCommandRepository.java
@@ -3,6 +3,7 @@ package com.onair.hearit.common.infrastructure.jdbc;
 import com.onair.hearit.common.domain.PlayingHistory;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -15,6 +16,7 @@ public class PlayingHistoryCommandRepository {
     private final JdbcTemplate jdbcTemplate;
 
     public void bulkInsert(List<PlayingHistory> histories) {
+        LocalDateTime nowDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         String sql = """
                 INSERT INTO playing_history (member_id, hearit_id, last_play_time, is_finished, updated_at)
                 VALUES (?, ?, ?, ?, ?)
@@ -29,7 +31,7 @@ public class PlayingHistoryCommandRepository {
             ps.setLong(2, history.getHearitId());
             ps.setLong(3, history.getLastPlayTime());
             ps.setBoolean(4, history.isFinished());
-            ps.setTimestamp(5, Timestamp.valueOf(LocalDateTime.now()));
+            ps.setTimestamp(5, Timestamp.valueOf(nowDateTime));
         });
     }
 }

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/BookmarkRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/BookmarkRepository.java
@@ -3,6 +3,7 @@ package com.onair.hearit.common.infrastructure.jpa;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlaytimeProjection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -14,14 +15,19 @@ import org.springframework.data.repository.query.Param;
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     @Query("""
-                SELECT b
+                SELECT
+                    b AS bookmark,
+                    ph.lastPlayTime AS lastPlayTime
                 FROM Bookmark b
-                JOIN FETCH b.hearit
-                JOIN FETCH b.hearit.category
-                WHERE b.member = :member
+                JOIN FETCH b.hearit h
+                JOIN FETCH h.category c
+                LEFT JOIN PlayingHistory ph
+                    ON ph.hearitId = h.id AND ph.memberId = :memberId
+                WHERE b.member.id = :memberId
                 ORDER BY b.createdAt DESC
             """)
-    Page<Bookmark> findAllByMemberOrderByRecent(@Param("member") Member member, Pageable pageable);
+    Page<BookmarkWithPlaytimeProjection> findAllByMemberOrderByRecent(@Param("memberId") Long memberId,
+                                                                      Pageable pageable);
 
     Optional<Bookmark> findByHearitAndMember(Hearit hearit, Member member);
 

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.common.infrastructure.jpa;
 
 import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.infrastructure.dto.HearitWithPlayTimeProjection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -57,7 +58,7 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
             WHERE h.category.id = :categoryId
             ORDER BY h.createdAt DESC
             """)
-    Page<HearitWithPlayTime> findWithPlayTimeByCategoryId(
+    Page<HearitWithPlayTimeProjection> findWithPlayTimeByCategoryId(
             @Param("categoryId") Long categoryId,
             @Param("memberId") Long memberId,
             Pageable pageable

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
@@ -49,4 +49,17 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
     Page<Hearit> findAll(Pageable pageable);
 
     List<Hearit> findAllByIdIn(List<Long> hearitIds);
+
+    @Query("""
+            SELECT h AS hearit, ph.lastPlayTime AS lastPlayTime
+            FROM Hearit h
+            LEFT JOIN PlayingHistory ph ON h.id = ph.hearitId AND ph.memberId = :memberId
+            WHERE h.category.id = :categoryId
+            ORDER BY h.createdAt DESC
+            """)
+    Page<HearitWithPlayTime> findWithPlayTimeByCategoryId(
+            @Param("categoryId") Long categoryId,
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
 }

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
@@ -15,8 +15,6 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
     @Query("SELECT h FROM Hearit h JOIN FETCH h.category WHERE h.id = :id")
     Optional<Hearit> findWithCategoryById(Long id);
 
-    Page<Hearit> findByCategoryIdOrderByCreatedAtDesc(Long categoryId, Pageable pageable);
-
     @Query(value = """
             SELECT DISTINCT h.*
             FROM hearit h

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitWithPlayTime.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitWithPlayTime.java
@@ -1,0 +1,9 @@
+package com.onair.hearit.common.infrastructure.jpa;
+
+import com.onair.hearit.common.domain.Hearit;
+
+public interface HearitWithPlayTime {
+    Hearit getHearit();
+
+    Long getLastPlayTime();
+}

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.common.infrastructure.jpa;
 
 import com.onair.hearit.common.domain.PlayingHistory;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ public interface PlayingHistoryRepository extends JpaRepository<PlayingHistory, 
     Optional<PlayingHistory> findByHearitIdAndMemberId(Long hearitId, Long memberId);
 
     boolean existsByHearitIdAndMemberId(Long hearitId, Long memberId);
+
+    List<PlayingHistory> findByMemberIdAndHearitIdIn(Long memberId, List<Long> hearitIds);
 }

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.onair.hearit.common.infrastructure.jpa;
+
+import com.onair.hearit.common.domain.PlayingHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlayingHistoryRepository extends JpaRepository<PlayingHistory, Long> {
+}

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PlayingHistoryRepository extends JpaRepository<PlayingHistory, Long> {
 
     Optional<PlayingHistory> findByHearitIdAndMemberId(Long hearitId, Long memberId);
+
+    boolean existsByHearitIdAndMemberId(Long hearitId, Long memberId);
 }

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
@@ -1,7 +1,10 @@
 package com.onair.hearit.common.infrastructure.jpa;
 
 import com.onair.hearit.common.domain.PlayingHistory;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlayingHistoryRepository extends JpaRepository<PlayingHistory, Long> {
+
+    Optional<PlayingHistory> findByHearitIdAndMemberId(Long hearitId, Long memberId);
 }

--- a/backend/src/main/resources/db/migration/V202509071351__playing_history.sql
+++ b/backend/src/main/resources/db/migration/V202509071351__playing_history.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `playing_history` (
+    `id` bigint NOT NULL AUTO_INCREMENT,
+    `member_id` BIGINT NOT NULL,
+    `hearit_id` BIGINT NOT NULL,
+    `last_play_time` INT NOT NULL,
+    `is_finished` BOOLEAN NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+     PRIMARY KEY (`id`),
+     CONSTRAINT `uq_playing_history_member_hearit` UNIQUE (`member_id`, `hearit_id`)
+);

--- a/backend/src/main/resources/db/migration/V202509081624__last_play_time_to_long.sql
+++ b/backend/src/main/resources/db/migration/V202509081624__last_play_time_to_long.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `playing_history`
+    MODIFY COLUMN `last_play_time` BIGINT NOT NULL;

--- a/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
@@ -54,8 +54,7 @@ class BookmarkServiceTest {
 
     @BeforeEach
     void setup() {
-        bookmarkService = new BookmarkService(hearitRepository, memberRepository, bookmarkRepository,
-                playingHistoryRepository);
+        bookmarkService = new BookmarkService(hearitRepository, memberRepository, bookmarkRepository);
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
@@ -4,22 +4,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.onair.hearit.app.dto.request.PagingRequest;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.auth.domain.UserContext;
-import com.onair.hearit.common.exception.custom.AlreadyExistException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
-import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
-import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
-import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
-import com.onair.hearit.fixture.DbHelper;
-import com.onair.hearit.fixture.TestFixture;
+import com.onair.hearit.common.exception.custom.AlreadyExistException;
+import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
+import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,11 +47,15 @@ class BookmarkServiceTest {
     @Autowired
     private BookmarkRepository bookmarkRepository;
 
+    @Autowired
+    private PlayingHistoryRepository playingHistoryRepository;
+
     private BookmarkService bookmarkService;
 
     @BeforeEach
     void setup() {
-        bookmarkService = new BookmarkService(hearitRepository, memberRepository, bookmarkRepository);
+        bookmarkService = new BookmarkService(hearitRepository, memberRepository, bookmarkRepository,
+                playingHistoryRepository);
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
@@ -12,6 +12,7 @@ import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
@@ -64,15 +65,20 @@ class BookmarkServiceTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 1));
 
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
         List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(
                 UserContext.member(member.getId()), new PagingRequest(0, 20)).content();
 
         // then
-        assertThat(responses).hasSize(1);
+        assertAll(() -> {
+            assertThat(responses).hasSize(1);
+            assertThat(responses.getFirst().bookmarkId()).isEqualTo(bookmark.getId());
+            assertThat(responses.getFirst().lastPlayTime()).isEqualTo(playingHistory.getLastPlayTime());
+        });
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitSearchServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitSearchServiceTest.java
@@ -3,19 +3,23 @@ package com.onair.hearit.app.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
+import com.onair.hearit.app.dto.request.PagingRequest;
+import com.onair.hearit.app.dto.response.HearitSearchResponse;
+import com.onair.hearit.app.dto.response.PagedResponse;
+import com.onair.hearit.auth.domain.UserContext;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
+import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.Source;
-import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.HearitSearchResponse;
-import com.onair.hearit.app.dto.response.PagedResponse;
-import com.onair.hearit.fixture.DbHelper;
-import com.onair.hearit.fixture.TestFixture;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
+import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
+import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,11 +43,18 @@ class HearitSearchServiceTest {
     @Autowired
     private HearitKeywordRepository hearitKeywordRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PlayingHistoryRepository playingHistoryRepository;
+
     private HearitSearchService hearitSearchService;
 
     @BeforeEach
     void setup() {
-        hearitSearchService = new HearitSearchService(hearitRepository, hearitKeywordRepository);
+        hearitSearchService = new HearitSearchService(hearitRepository, hearitKeywordRepository, memberRepository,
+                playingHistoryRepository);
     }
 
     @Test
@@ -51,6 +62,7 @@ class HearitSearchServiceTest {
     void searchHearitsByTitle_Success() {
         // given
         PagingRequest request = new PagingRequest(0, 10);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Hearit hearit = saveHearitWithTitleAndKeyword("exampleSpring1", saveKeyword("keyword"));     // 제목에 검색어 포함됨
         Hearit hearit1 = saveHearitWithTitleAndKeyword("spring1example", saveKeyword("1spring1"));   // 제목에 검색어 포함됨
         Hearit hearit2 = saveHearitWithTitleAndKeyword("wwSpring1ww", saveKeyword("keyword2"));      // 제목에 검색어 포함됨
@@ -59,7 +71,8 @@ class HearitSearchServiceTest {
         saveHearitWithTitleAndKeyword("notitle", saveKeyword("noKeyword"));         // 검색에서 제외됨
 
         // when
-        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request,
+                UserContext.member(member.getId()));
 
         // then
         assertAll(
@@ -75,6 +88,7 @@ class HearitSearchServiceTest {
     void searchHearitsByKeyword_Succces() {
         // given
         PagingRequest request = new PagingRequest(0, 10);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Hearit hearit = saveHearitWithTitleAndKeyword("example1", saveKeyword("Spring1"));     // 키워드에 검색어 포함됨
         Hearit hearit1 = saveHearitWithTitleAndKeyword("noTitle", saveKeyword("1springA"));    // 키워드에 검색어 포함됨
         Hearit hearit2 = saveHearitWithTitleAndKeyword("SpringS", saveKeyword("2sprINg1"));    // 키워드에 검색어 포함됨
@@ -82,7 +96,8 @@ class HearitSearchServiceTest {
         Hearit hearit4 = saveHearitWithTitleAndKeyword("noTitle", saveKeyword("noKeyword"));   // 검색에서 제외됨
 
         // when
-        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request,
+                UserContext.member(member.getId()));
 
         // then
         assertAll(
@@ -99,14 +114,15 @@ class HearitSearchServiceTest {
     void searchHearitsByTitleOrKeyword_Success() {
         // given
         PagingRequest request = new PagingRequest(0, 10);
-
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Hearit titleOnly = saveHearitWithTitleAndKeyword("spring-title", saveKeyword("nomatch")); // 제목만 매칭
         Hearit keywordOnly = saveHearitWithTitleAndKeyword("nomatch-title", saveKeyword("spring-keyword")); // 키워드만 매칭
         Hearit bothMatch = saveHearitWithTitleAndKeyword("spring-title", saveKeyword("spring-keyword")); // 둘 다 매칭
         Hearit neither = saveHearitWithTitleAndKeyword("notitle", saveKeyword("nokeyword")); // 둘 다 매칭 안 됨
 
         // when
-        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("spring", request,
+                UserContext.member(member.getId()));
 
         // then
         assertAll(
@@ -123,12 +139,14 @@ class HearitSearchServiceTest {
     void searchHearitsWithKeywords_includedInResponse() {
         // given
         PagingRequest request = new PagingRequest(0, 10);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Keyword keyword1 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
         Keyword keyword2 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
         Hearit hearit = saveHearitWithTitleAndKeyword("Spring in Action", keyword1);
 
         // when
-        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request,
+                UserContext.member(member.getId()));
 
         // then
         assertAll(
@@ -142,12 +160,14 @@ class HearitSearchServiceTest {
     void searchHearitsByTitle_sortedByCreatedAtDesc() {
         // given
         PagingRequest request = new PagingRequest(0, 10);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Hearit hearit1 = saveHearitWithTitleAndKeyword("spring1", saveKeyword("keyword"));         // oldest
         Hearit hearit2 = saveHearitWithTitleAndKeyword("notitle", saveKeyword("springKeyword"));   // middle
         Hearit hearit3 = saveHearitWithTitleAndKeyword("notitle", saveKeyword("springKeyword"));   // latest
 
         // when
-        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("Spring", request,
+                UserContext.member(member.getId()));
 
         // then
         assertAll(
@@ -163,12 +183,14 @@ class HearitSearchServiceTest {
     void searchHearits_pagination() {
         // given
         PagingRequest request = new PagingRequest(1, 2);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Hearit hearit1 = saveHearitWithTitleAndKeyword("spring1", saveKeyword("keyword"));
         Hearit hearit2 = saveHearitWithTitleAndKeyword("spring2", saveKeyword("springKeyword"));
         Hearit hearit3 = saveHearitWithTitleAndKeyword("otherTitle", saveKeyword("Spring"));
 
         // when
-        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("spring", request);
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("spring", request,
+                UserContext.member(member.getId()));
 
         // then
         assertAll(

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
@@ -18,7 +18,9 @@ import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.RecommendHearit;
+import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
@@ -103,16 +105,16 @@ class HearitServiceTest {
                 UserContext.member(member.getId()));
 
         // then
-        assertAll(
-                () -> assertThat(response.id()).isEqualTo(hearit.getId()),
-                () -> assertThat(response.title()).isEqualTo(hearit.getTitle()),
-                () -> assertThat(response.summary()).isEqualTo(hearit.getSummary()),
-                () -> assertThat(response.isBookmarked()).isTrue(),
-                () -> assertThat(response.bookmarkId()).isEqualTo(bookmark.getId()),
-                () -> assertThat(response.category().id()).isEqualTo(hearit.getCategory().getId()),
-                () -> assertThat(response.category().name()).isEqualTo(hearit.getCategory().getName()),
-                () -> assertThat(response.keywords()).hasSize(1)
-        );
+        assertAll(() -> {
+            assertThat(response.id()).isEqualTo(hearit.getId());
+            assertThat(response.title()).isEqualTo(hearit.getTitle());
+            assertThat(response.summary()).isEqualTo(hearit.getSummary());
+            assertThat(response.isBookmarked()).isTrue();
+            assertThat(response.bookmarkId()).isEqualTo(bookmark.getId());
+            assertThat(response.category().id()).isEqualTo(hearit.getCategory().getId());
+            assertThat(response.category().name()).isEqualTo(hearit.getCategory().getName());
+            assertThat(response.keywords()).hasSize(1);
+        });
     }
 
     @Test
@@ -230,7 +232,7 @@ class HearitServiceTest {
 
     @Test
     @DisplayName("히어릿 목록을 카테고리 조회 시 카테고리에 해당하는 히어릿만 반환한다.")
-    void searchHearitsByCategory_onlyMatchingCategory() {
+    void getHearitsByCategory_onlyMatchingCategory() {
         // given
         Category category1 = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Category category2 = dbHelper.insertCategory(TestFixture.createFixedCategory());
@@ -253,7 +255,7 @@ class HearitServiceTest {
 
     @Test
     @DisplayName("카테고리 내의 히어릿들을 조회 시 각 히어릿에 키워드가 포함되어 반환된다.")
-    void searchHearitsByCategory_includesKeywords() {
+    void getHearitsByCategory_includesKeywords() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
@@ -268,16 +270,16 @@ class HearitServiceTest {
                 request, UserContext.guest());
 
         // then
-        assertAll(
-                () -> assertThat(result.content()).hasSize(1),
-                () -> assertThat(result.content().get(0).id()).isEqualTo(hearit.getId()),
-                () -> assertThat(result.content().get(0).keywords()).hasSize(2)
-        );
+        assertAll(() -> {
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.content().get(0).id()).isEqualTo(hearit.getId());
+            assertThat(result.content().get(0).keywords()).hasSize(2);
+        });
     }
 
     @Test
     @DisplayName("카테고리 내의 히어릿들을 조회 시 최신순으로 페이지네이션이 적용된다.")
-    void searchHearitsByCategory_pagination() {
+    void getHearitsByCategory_pagination() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
@@ -290,9 +292,47 @@ class HearitServiceTest {
                 request, UserContext.guest());
 
         // then
+        assertAll(() -> {
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.content().get(0).id()).isEqualTo(hearit1.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("멤버 로그인한 사용자가 카테고리 내의 히어릿들을 조회 시 마지막 재생 시간도 함께 조회된다.")
+    void getHearitsByCategory_lastPlayTime() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit1 = dbHelper.insertHearit(new Hearit(
+                "title",
+                "summary",
+                500,
+                "/hearit/audio/original/ORG_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/audio/short/SHR_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/script/SCR_bf7c513e-579e-4224-8505-3824bb22ed01.json",
+                List.of(
+                        new Source("이 컨텐츠는 쿠버네티스 공식 문서 (저작자: The Kubernetes Authors)를 참고하여 만들어졌습니다.",
+                                "https://example.com/1"),
+                        new Source("원본은 CC BY 4.0 라이선스를 따릅니다.", "https://example.com/2")
+                ),
+                category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(1L, hearit1, 450));
+        PagingRequest request = new PagingRequest(1, 2);
+
+        // when
+        PagedResponse<HearitOfCategoryResponse> result = hearitService.getHearitsByCategory(category.getId(),
+                request, UserContext.member(member.getId()));
+
+        // then
         assertAll(
-                () -> assertThat(result.content()).hasSize(1),
-                () -> assertThat(result.content().get(0).id()).isEqualTo(hearit1.getId())
+                () -> {
+                    assertThat(result.content()).hasSize(1);
+                    assertThat(result.content().get(0).id()).isEqualTo(hearit1.getId());
+                    assertThat(result.content().get(0).lastPlayTime()).isEqualTo(playingHistory.getLastPlayTime());
+                }
         );
     }
 }

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
@@ -319,7 +319,7 @@ class HearitServiceTest {
                 category));
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(1L, hearit1, 450));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit1, 450));
         PagingRequest request = new PagingRequest(1, 2);
 
         // when

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
@@ -25,6 +25,7 @@ import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import com.onair.hearit.common.infrastructure.jpa.RecommendHearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
 import com.onair.hearit.fixture.DbHelper;
@@ -64,6 +65,9 @@ class HearitServiceTest {
     private MemberRepository memberRepository;
 
     @Autowired
+    private PlayingHistoryRepository playingHistoryRepository;
+
+    @Autowired
     private RecommendHearitRepository recommendHearitRepository;
 
     private FixedRecommendedHearitStrategy recommendHearitProvider;
@@ -79,6 +83,7 @@ class HearitServiceTest {
                 bookmarkRepository,
                 hearitKeywordRepository,
                 categoryRepository,
+                playingHistoryRepository,
                 recommendHearitProvider);
     }
 

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
@@ -241,7 +241,7 @@ class HearitServiceTest {
 
         // when
         PagedResponse<HearitOfCategoryResponse> result = hearitService.getHearitsByCategory(category1.getId(),
-                request);
+                request, UserContext.guest());
 
         // then
         assertAll(() -> {
@@ -265,7 +265,7 @@ class HearitServiceTest {
 
         // when
         PagedResponse<HearitOfCategoryResponse> result = hearitService.getHearitsByCategory(category.getId(),
-                request);
+                request, UserContext.guest());
 
         // then
         assertAll(
@@ -287,7 +287,7 @@ class HearitServiceTest {
 
         // when
         PagedResponse<HearitOfCategoryResponse> result = hearitService.getHearitsByCategory(category.getId(),
-                request);
+                request, UserContext.guest());
 
         // then
         assertAll(

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.app.infrastructure.scheduler.PlayingHistoryBuffer;
 import com.onair.hearit.auth.domain.UserContext;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
@@ -13,6 +14,7 @@ import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.infrastructure.jdbc.PlayingHistoryCommandRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
@@ -23,13 +25,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
-@Import({DbHelper.class, TestJpaAuditingConfig.class})
-@ActiveProfiles("fake-test")
+@Sql("/dbclean.sql")
+@ActiveProfiles("integration-test")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({DbHelper.class, TestJpaAuditingConfig.class, PlayingHistoryBuffer.class,
+        PlayingHistoryCommandRepository.class})
 class PlayingHistoryServiceTest {
 
     @Autowired
@@ -39,18 +47,22 @@ class PlayingHistoryServiceTest {
     private PlayingHistoryRepository playingHistoryRepository;
 
     @Autowired
+    private PlayingHistoryBuffer playingHistoryBuffer;
+
+    @Autowired
     private HearitRepository hearitRepository;
 
     private PlayingHistoryService playingHistoryService;
 
     @BeforeEach
     void setup() {
-        playingHistoryService = new PlayingHistoryService(playingHistoryRepository, hearitRepository);
+        playingHistoryService = new PlayingHistoryService(playingHistoryRepository, playingHistoryBuffer,
+                hearitRepository);
     }
 
     @Test
     @DisplayName("로그인한 회원은 재생기록을 저장할 수 있다.")
-    void addPlayHistory() {
+    void addPlayHistory() throws InterruptedException {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
@@ -59,6 +71,7 @@ class PlayingHistoryServiceTest {
 
         // when
         playingHistoryService.addPlayingHistory(UserContext.member(member.getId()), request);
+        playingHistoryBuffer.flush();
 
         // then
         List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -83,6 +83,30 @@ class PlayingHistoryServiceTest {
     }
 
     @Test
+    @DisplayName("로그인한 회원은 재생기록을 수정할 수 있다.")
+    void modifyPlayHistory() throws InterruptedException {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getId(), hearit, 10_000));
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
+
+        // when
+        playingHistoryService.addPlayingHistory(UserContext.member(member.getId()), request);
+        playingHistoryBuffer.flush();
+
+        // then
+        List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
+        assertAll(() -> {
+            assertThat(playingHistories.size()).isEqualTo(1);
+            assertThat(playingHistories.getFirst().getMemberId()).isEqualTo(member.getId());
+            assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId());
+        });
+    }
+
+    @Test
     @DisplayName("로그인하지 않은 회원은 재생기록을 저장할 수 없다.")
     void checkMember() {
         // given

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -1,0 +1,108 @@
+package com.onair.hearit.app.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.auth.domain.UserContext;
+import com.onair.hearit.common.domain.Category;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.domain.Source;
+import com.onair.hearit.common.exception.custom.NotFoundException;
+import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
+import com.onair.hearit.common.infrastructure.jpa.TestJpaAuditingConfig;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({DbHelper.class, TestJpaAuditingConfig.class})
+@ActiveProfiles("fake-test")
+class PlayingHistoryServiceTest {
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Autowired
+    private PlayingHistoryRepository playingHistoryRepository;
+
+    @Autowired
+    private HearitRepository hearitRepository;
+
+    private PlayingHistoryService playingHistoryService;
+
+    @BeforeEach
+    void setup() {
+        playingHistoryService = new PlayingHistoryService(playingHistoryRepository, hearitRepository);
+    }
+
+    @Test
+    @DisplayName("로그인한 회원은 재생기록을 저장할 수 있다.")
+    void addPlayHistory() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100);
+
+        // when
+        playingHistoryService.addPlayingHistory(UserContext.member(member.getId()), request);
+
+        // then
+        List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
+        assertAll(() -> {
+            assertThat(playingHistories.size()).isEqualTo(1);
+            assertThat(playingHistories.getFirst().getMemberId()).isEqualTo(member.getId());
+            assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 회원은 재생기록을 저장할 수 없다.")
+    void checkMember() {
+        // given
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100);
+
+        // when & then
+        assertThatThrownBy(() -> playingHistoryService.addPlayingHistory(UserContext.guest(), request))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 히어릿에 대한 재생기록을 저장할 수 없다.")
+    void checkHearit() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        PlayingHistoryRequest request = new PlayingHistoryRequest(1L, 100);
+
+        // when
+        assertThatThrownBy(() -> playingHistoryService.addPlayingHistory(UserContext.member(member.getId()), request))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    private Hearit createHearitWith(int playTime, Category category) {
+        return new Hearit("title",
+                "summary",
+                playTime,
+                "/hearit/audio/original/ORG_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/audio/short/SHR_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/script/SCR_bf7c513e-579e-4224-8505-3824bb22ed01.json",
+                List.of(new Source("원본은 CC BY 4.0 라이선스를 따릅니다.", "https://example.com/2")),
+                category
+        );
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -13,7 +13,6 @@ import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
 import com.onair.hearit.common.infrastructure.jdbc.PlayingHistoryCommandRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
@@ -114,9 +113,11 @@ class PlayingHistoryServiceTest {
         Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
         PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
-        // when & then
-        assertThatThrownBy(() -> playingHistoryService.addPlayingHistory(UserContext.guest(), request))
-                .isInstanceOf(UnauthorizedException.class);
+        // when
+        boolean isSaved = playingHistoryService.addPlayingHistory(UserContext.guest(), request);
+
+        // then
+        assertThat(isSaved).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -67,7 +67,7 @@ class PlayingHistoryServiceTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
         Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100);
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
         // when
         playingHistoryService.addPlayingHistory(UserContext.member(member.getId()), request);
@@ -88,7 +88,7 @@ class PlayingHistoryServiceTest {
         // given
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
         Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100);
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
         // when & then
         assertThatThrownBy(() -> playingHistoryService.addPlayingHistory(UserContext.guest(), request))
@@ -100,7 +100,7 @@ class PlayingHistoryServiceTest {
     void checkHearit() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        PlayingHistoryRequest request = new PlayingHistoryRequest(1L, 100);
+        PlayingHistoryRequest request = new PlayingHistoryRequest(1L, 100L);
 
         // when
         assertThatThrownBy(() -> playingHistoryService.addPlayingHistory(UserContext.member(member.getId()), request))

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -114,10 +114,10 @@ class PlayingHistoryServiceTest {
         PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
         // when
-        boolean isSaved = playingHistoryService.addPlayingHistory(UserContext.guest(), request);
+        playingHistoryService.addPlayingHistory(UserContext.guest(), request);
 
         // then
-        assertThat(isSaved).isFalse();
+        assertThat(playingHistoryRepository.findAll()).hasSize(0);
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -9,13 +9,13 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
+import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
-import com.onair.hearit.docs.ApiDocSnippets;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
-import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
+import com.onair.hearit.docs.ApiDocSnippets;
 import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.fixture.TestFixture;
 import io.restassured.RestAssured;
@@ -70,6 +70,8 @@ class BookmarkControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].summary").description("히어릿 요약"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
+                                                        fieldWithPath("content[].lastPlayTime").description(
+                                                                "히어릿 마지막 재생 시간(초)"),
                                                         fieldWithPath("content[].categoryColor").description(
                                                                 "해당 히어릿 카테고리 ColoCode")
                                                 }),

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -73,7 +73,7 @@ class BookmarkControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].lastPlayTime").description(
                                                                 "히어릿 마지막 재생 시간(초)"),
                                                         fieldWithPath("content[].categoryColor").description(
-                                                                "해당 히어릿 카테고리 ColoCode")
+                                                                "해당 히어릿 카테고리 ColorCode")
                                                 }),
                                                 Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields())
                                         ).toArray(FieldDescriptor[]::new)

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -71,7 +71,7 @@ class BookmarkControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].summary").description("히어릿 요약"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
                                                         fieldWithPath("content[].lastPlayTime").description(
-                                                                "히어릿 마지막 재생 시간(초)"),
+                                                                "히어릿 마지막 재생 시간(ms)").optional(),
                                                         fieldWithPath("content[].category.id").description("카테고리 ID"),
                                                         fieldWithPath("content[].category.name").description("카테고리 이름"),
                                                         fieldWithPath("content[].category.colorCode").description("카테고리 색상 코드")

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -55,7 +55,8 @@ class HearitControllerTest extends IntegrationTest {
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 1));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getId(), hearit, 1_000));
         Keyword keyword1 = dbHelper.insertKeyword(new Keyword("Java"));
         Keyword keyword2 = dbHelper.insertKeyword(new Keyword("Spring"));
         dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword1));

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -91,6 +91,8 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("로그인 하지 않은 사용자가 히어릿 단일 조회 시, 200 OK 및 히어릿 정보를 제공한다.")
     void readHearitWithSuccessWithNotMember() {
         // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Keyword keyword1 = dbHelper.insertKeyword(new Keyword("Java"));
@@ -98,6 +100,7 @@ class HearitControllerTest extends IntegrationTest {
 
         // when & then
         HearitDetailResponse response = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
                 .when()
                 .get("/api/v1/hearits/{hearitId}", hearit.getId())
                 .then()
@@ -114,10 +117,13 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("히어릿 단일 조회 시, 존재하지 않는 아이디인 경우 404 NOT_FOUND를 반환한다.")
     void readHearitWithNotFound() {
         // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
         Long notFoundHearitId = 9999L;
 
         // when & then
         RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
                 .filter(document("hearit-read-detail-not-found",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
@@ -246,6 +252,8 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("히어릿 검색 요청 시 200 OK 및 제목 또는 키워드에 검색어가 포함된 히어릿을 최신순으로 반환한다.")
     void readHearitsByCategoryWithPagination() {
         // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
         Keyword keyword = dbHelper.insertKeyword(new Keyword("Spring"));
         Keyword keyword1 = dbHelper.insertKeyword(new Keyword("noKeyword"));
 
@@ -256,6 +264,7 @@ class HearitControllerTest extends IntegrationTest {
 
         // when
         PagedResponse<HearitSearchResponse> pagedResponse = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
                 .queryParam("searchTerm", "spring")
                 .queryParam("page", 0)
                 .queryParam("size", 10)
@@ -312,8 +321,11 @@ class HearitControllerTest extends IntegrationTest {
     @Test
     @DisplayName("검색 파라미터가 유효하지 않을 때 400 에러를 반환한다. ")
     void readHearitsByCategoryWithInvalidParams() {
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
         // when & then
         RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
                 .queryParam("searchTerm", "spring")
                 .queryParam("page", -1)
                 .queryParam("size", 10)
@@ -331,6 +343,7 @@ class HearitControllerTest extends IntegrationTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value());
 
         RestAssured.given()
+                .header("Authorization", "Bearer " + token)
                 .queryParam("searchTerm", "spring")
                 .queryParam("page", 0)
                 .queryParam("size", -1)
@@ -413,6 +426,8 @@ class HearitControllerTest extends IntegrationTest {
     @DisplayName("카테고리로 히어릿 검색 시 200 OK 및 해당 카테고리의 히어릿들을 최신순으로 반환한다.")
     void searchHearitsByCategoryWithPagination() {
         // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
         Category category1 = dbHelper.insertCategory(new Category("Spring", "#000001"));
         Category category2 = dbHelper.insertCategory(new Category("Java", "#000002"));
 
@@ -423,6 +438,7 @@ class HearitControllerTest extends IntegrationTest {
 
         // when
         PagedResponse<HearitOfCategoryResponse> pagedResponse = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
                 .queryParam("categoryId", category1.getId())
                 .queryParam("page", 0)
                 .queryParam("size", 10)
@@ -473,8 +489,12 @@ class HearitControllerTest extends IntegrationTest {
     @Test
     @DisplayName("전체 카테고리 조회 시 유효하지 않은 페이지 번호를 보내면 400 BAD_REQUEST를 반환한다.")
     void readAllCategoriesWithInvalidPage() {
+        //given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
         // when & then
         RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
                 .param("page", -1)
                 .param("size", 10)
                 .filter(document("category-read-list-bad-request",

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -100,7 +100,6 @@ class HearitControllerTest extends IntegrationTest {
 
         // when & then
         HearitDetailResponse response = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
                 .when()
                 .get("/api/v1/hearits/{hearitId}", hearit.getId())
                 .then()

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -277,7 +277,7 @@ class HearitControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
                                                         fieldWithPath("content[].lastPlayTime").description(
-                                                                "히어릿 마지막 재생 시간(초)").optional(),
+                                                                "히어릿 마지막 재생 시간(ms)").optional(),
                                                         fieldWithPath("content[].keywords").description(
                                                                 "히어릿에 포함된 키워드 목록"),
                                                         fieldWithPath("content[].keywords[].id").description("키워드 ID"),
@@ -444,7 +444,7 @@ class HearitControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
                                                         fieldWithPath("content[].lastPlayTime").description(
-                                                                "히어릿 마지막 재생 시간(밀리초)"),
+                                                                "히어릿 마지막 재생 시간(ms)").optional(),
                                                         fieldWithPath("content[].keywords[].id").description("키워드 ID"),
                                                         fieldWithPath("content[].keywords[].name").description("키워드 이름")
                                                 }),
@@ -535,7 +535,7 @@ class HearitControllerTest extends IntegrationTest {
                 fieldWithPath("sources[].sourceName").description("출처의 이름"),
                 fieldWithPath("sources[].sourceUrl").description("출처의 URL"),
                 fieldWithPath("playTime").type(JsonFieldType.NUMBER).description("재생 시간(초)"),
-                fieldWithPath("lastPlayTime").type(JsonFieldType.NUMBER).description("마지막 재생 시간(초)").optional(),
+                fieldWithPath("lastPlayTime").type(JsonFieldType.NUMBER).description("마지막 재생 시간(ms)").optional(),
                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 일시"),
                 fieldWithPath("isBookmarked").type(JsonFieldType.BOOLEAN).description("현재 사용자의 북마크 여부"),
                 fieldWithPath("bookmarkId").type(JsonFieldType.NUMBER).description("북마크 ID (북마크된 경우)").optional(),

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -443,7 +443,8 @@ class HearitControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].id").description("히어릿 ID"),
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
-                                                        fieldWithPath("content[].keywords").description("관련 키워드 목록"),
+                                                        fieldWithPath("content[].lastPlayTime").description(
+                                                                "히어릿 마지막 재생 시간(밀리초)"),
                                                         fieldWithPath("content[].keywords[].id").description("키워드 ID"),
                                                         fieldWithPath("content[].keywords[].name").description("키워드 이름")
                                                 }),

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -23,6 +23,7 @@ import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.RecommendHearit;
 import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.docs.ApiDocSnippets;
@@ -54,6 +55,7 @@ class HearitControllerTest extends IntegrationTest {
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 1));
         Keyword keyword1 = dbHelper.insertKeyword(new Keyword("Java"));
         Keyword keyword2 = dbHelper.insertKeyword(new Keyword("Spring"));
         dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword1));
@@ -77,7 +79,7 @@ class HearitControllerTest extends IntegrationTest {
                 ))
                 .when()
                 .get("/api/v1/hearits/{hearitId}", hearit.getId())
-                .then()
+                .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract().as(HearitDetailResponse.class);
 
@@ -273,6 +275,8 @@ class HearitControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].id").description("히어릿 ID"),
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
+                                                        fieldWithPath("content[].lastPlayTime").description(
+                                                                "히어릿 마지막 재생 시간(초)").optional(),
                                                         fieldWithPath("content[].keywords").description(
                                                                 "히어릿에 포함된 키워드 목록"),
                                                         fieldWithPath("content[].keywords[].id").description("키워드 ID"),
@@ -529,6 +533,7 @@ class HearitControllerTest extends IntegrationTest {
                 fieldWithPath("sources[].sourceName").description("출처의 이름"),
                 fieldWithPath("sources[].sourceUrl").description("출처의 URL"),
                 fieldWithPath("playTime").type(JsonFieldType.NUMBER).description("재생 시간(초)"),
+                fieldWithPath("lastPlayTime").type(JsonFieldType.NUMBER).description("마지막 재생 시간(초)").optional(),
                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("생성 일시"),
                 fieldWithPath("isBookmarked").type(JsonFieldType.BOOLEAN).description("현재 사용자의 북마크 여부"),
                 fieldWithPath("bookmarkId").type(JsonFieldType.NUMBER).description("북마크 ID (북마크된 경우)").optional(),

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -78,17 +78,6 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .contentType("application/json")
                 .body(request)
-                .filter(document("playing-history",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Playing History API")
-                                .summary("재생기록 생성")
-                                .description("로그인한 회원의 재생기록을 저장합니다.")
-                                .requestFields(
-                                        fieldWithPath("hearitId").description("히어릿 ID"),
-                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간")
-                                )
-                                .build())
-                ))
                 .when()
                 .put("/api/v1/playing-histories")
                 .then()

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -60,9 +60,9 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 .build())
                 ))
                 .when()
-                .put("/api/v1/playing-histories")
+                .post("/api/v1/playing-histories")
                 .then()
-                .statusCode(HttpStatus.CREATED.value());
+                .statusCode(HttpStatus.OK.value());
     }
 
     @Test
@@ -99,7 +99,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 .build())
                 ))
                 .when()
-                .put("/api/v1/playing-histories")
+                .post("/api/v1/playing-histories")
                 .then()
                 .statusCode(HttpStatus.OK.value());
     }

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -44,14 +44,14 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .contentType("application/json")
                 .body(request)
-                .filter(document("playing-history",
+                .filter(document("playing-history-createad",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
                                 .summary("재생기록 생성")
-                                .description("로그인한 회원의 재생기록을 저장합니다.")
+                                .description("로그인한 회원의 처음 재생기록을 저장합니다.")
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
-                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간")
+                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
                                 )
                                 .build())
                 ))
@@ -79,6 +79,17 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .contentType("application/json")
                 .body(request)
+                .filter(document("playing-history-ok",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Playing History API")
+                                .summary("재생기록 생성")
+                                .description("로그인한 회원의 기존 재생기록을 수정합니다.")
+                                .requestFields(
+                                        fieldWithPath("hearitId").description("히어릿 ID"),
+                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
+                                )
+                                .build())
+                ))
                 .when()
                 .put("/api/v1/playing-histories")
                 .then()
@@ -105,7 +116,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 .description("로그인하지 않은 사용자는 재생기록을 저장할 수 없습니다.")
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
-                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간")
+                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
                                 )
                                 .responseSchema(Schema.schema("ProblemDetail"))
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -47,8 +47,12 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                 .filter(document("playing-history-createad",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
-                                .summary("재생기록 생성")
-                                .description("로그인한 회원의 처음 재생기록을 저장합니다.")
+                                .summary("재생기록 생성 또는 수정")
+                                .description("""
+                                        사용자의 재생 기록을 생성하거나 업데이트합니다.
+                                        - 사용자가 특정 히어릿에 대한 재생 기록이 없을 경우, 새로운 기록을 생성하고 `201 Created`를 반환합니다.
+                                        - 사용자가 특정 히어릿에 대한 재생 기록이 있을 경우, 기존 기록을 수정하고 `200 OK`를 반환합니다.
+                                        """)
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
@@ -82,8 +86,12 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                 .filter(document("playing-history-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
-                                .summary("재생기록 생성")
-                                .description("로그인한 회원의 기존 재생기록을 수정합니다.")
+                                .summary("재생기록 생성 또는 저장")
+                                .description("""
+                                        사용자의 재생 기록을 생성하거나 업데이트합니다.
+                                        - 사용자가 특정 히어릿에 대한 재생 기록이 없을 경우, 새로운 기록을 생성하고 `201 Created`를 반환합니다.
+                                        - 사용자가 특정 히어릿에 대한 재생 기록이 있을 경우, 기존 기록을 수정하고 `200 OK`를 반환합니다.
+                                        """)
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
@@ -112,8 +120,12 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                 .filter(document("playing-history-unauthorized",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
-                                .summary("재생기록 생성")
-                                .description("로그인하지 않은 사용자는 재생기록을 저장할 수 없습니다.")
+                                .summary("재생기록 생성 또는 저장")
+                                .description("""
+                                        사용자의 재생 기록을 생성하거나 업데이트합니다.
+                                        - 사용자가 특정 히어릿에 대한 재생 기록이 없을 경우, 새로운 기록을 생성하고 `201 Created`를 반환합니다.
+                                        - 사용자가 특정 히어릿에 대한 재생 기록이 있을 경우, 기존 기록을 수정하고 `200 OK`를 반환합니다.
+                                        """)
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -48,11 +48,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
                                 .summary("재생기록 생성 또는 수정")
-                                .description("""
-                                        사용자의 재생 기록을 생성하거나 업데이트합니다.
-                                        - 사용자가 특정 히어릿에 대한 재생 기록이 없을 경우, 새로운 기록을 생성하고 `201 Created`를 반환합니다.
-                                        - 사용자가 특정 히어릿에 대한 재생 기록이 있을 경우, 기존 기록을 수정하고 `200 OK`를 반환합니다.
-                                        """)
+                                .description("사용자의 재생 기록을 생성하거나 업데이트합니다.")
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
@@ -87,11 +83,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
                                 .summary("재생기록 생성 또는 저장")
-                                .description("""
-                                        사용자의 재생 기록을 생성하거나 업데이트합니다.
-                                        - 사용자가 특정 히어릿에 대한 재생 기록이 없을 경우, 새로운 기록을 생성하고 `201 Created`를 반환합니다.
-                                        - 사용자가 특정 히어릿에 대한 재생 기록이 있을 경우, 기존 기록을 수정하고 `200 OK`를 반환합니다.
-                                        """)
+                                .description("사용자의 재생 기록을 생성하거나 업데이트합니다.")
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
@@ -121,11 +113,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
                                 .summary("재생기록 생성 또는 저장")
-                                .description("""
-                                        사용자의 재생 기록을 생성하거나 업데이트합니다.
-                                        - 사용자가 특정 히어릿에 대한 재생 기록이 없을 경우, 새로운 기록을 생성하고 `201 Created`를 반환합니다.
-                                        - 사용자가 특정 히어릿에 대한 재생 기록이 있을 경우, 기존 기록을 수정하고 `200 OK`를 반환합니다.
-                                        """)
+                                .description("사용자의 재생 기록을 생성하거나 업데이트합니다.")
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -37,7 +37,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
         Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
 
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100);
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
         // when & then
         RestAssured.given(this.spec)
@@ -69,9 +69,10 @@ class PlayingHistoryControllerTest extends IntegrationTest {
         String token = generateToken(member);
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
         Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 20));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getId(), hearit, 20_000));
 
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50);
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
         // when & then
         RestAssured.given(this.spec)
@@ -91,7 +92,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
         Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
 
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100);
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
         // when & then
         RestAssured.given(this.spec)

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -142,5 +142,4 @@ class PlayingHistoryControllerTest extends IntegrationTest {
     private String generateToken(Member member) {
         return jwtTokenProvider.createAccessToken(member.getId());
     }
-
 }

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -11,6 +11,7 @@ import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.docs.ApiDocSnippets;
 import com.onair.hearit.fixture.IntegrationTest;
@@ -28,8 +29,8 @@ class PlayingHistoryControllerTest extends IntegrationTest {
     private JwtTokenProvider jwtTokenProvider;
 
     @Test
-    @DisplayName("로그인한 사용자가 재생기록 저장 시, 201 CREATED를 반환한다.")
-    void createBookmarkTest() {
+    @DisplayName("로그인한 사용자가 처음 재생기록 저장 시, 201 CREATED를 반환한다.")
+    void createPlayingHistory() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);
@@ -55,9 +56,43 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 .build())
                 ))
                 .when()
-                .post("/api/v1/playing-histories")
+                .put("/api/v1/playing-histories")
                 .then()
                 .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 다시 재생기록 저장 시, 200 OK를 반환한다.")
+    void updatePlayingHistory() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 20));
+
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50);
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body(request)
+                .filter(document("playing-history",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Playing History API")
+                                .summary("재생기록 생성")
+                                .description("로그인한 회원의 재생기록을 저장합니다.")
+                                .requestFields(
+                                        fieldWithPath("hearitId").description("히어릿 ID"),
+                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간")
+                                )
+                                .build())
+                ))
+                .when()
+                .put("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.OK.value());
     }
 
     @Test
@@ -87,7 +122,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 .build())
                 ))
                 .when()
-                .post("/api/v1/playing-histories")
+                .put("/api/v1/playing-histories")
                 .then()
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -1,0 +1,111 @@
+package com.onair.hearit.app.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.common.domain.Category;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.Source;
+import com.onair.hearit.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.fixture.TestFixture;
+import io.restassured.RestAssured;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+class PlayingHistoryControllerTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("로그인한 사용자가 재생기록 저장 시, 201 CREATED를 반환한다.")
+    void createBookmarkTest() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100);
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body(request)
+                .filter(document("playing-history",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Playing History API")
+                                .summary("재생기록 생성")
+                                .description("로그인한 회원의 재생기록을 저장합니다.")
+                                .requestFields(
+                                        fieldWithPath("hearitId").description("히어릿 ID"),
+                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간")
+                                )
+                                .build())
+                ))
+                .when()
+                .post("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 재생기록 저장 시, 추가 후 401 UNAUTHORIZED 반환한다.")
+    void createBookmarkTestWithConflict() {
+        // given
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100);
+
+        // when & then
+        RestAssured.given(this.spec)
+                .contentType("application/json")
+                .body(request)
+                .filter(document("playing-history-unauthorized",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Playing History API")
+                                .summary("재생기록 생성")
+                                .description("로그인하지 않은 사용자는 재생기록을 저장할 수 없습니다.")
+                                .requestFields(
+                                        fieldWithPath("hearitId").description("히어릿 ID"),
+                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간")
+                                )
+                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .build())
+                ))
+                .when()
+                .post("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    private Hearit createHearitWith(int playTime, Category category) {
+        return new Hearit("title",
+                "summary",
+                playTime,
+                "/hearit/audio/original/ORG_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/audio/short/SHR_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/script/SCR_bf7c513e-579e-4224-8505-3824bb22ed01.json",
+                List.of(new Source("원본은 CC BY 4.0 라이선스를 따릅니다.", "https://example.com/2")),
+                category
+        );
+    }
+
+    private String generateToken(Member member) {
+        return jwtTokenProvider.createAccessToken(member.getId());
+    }
+
+}

--- a/backend/src/test/java/com/onair/hearit/common/domain/PlayingHistoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/domain/PlayingHistoryTest.java
@@ -1,0 +1,47 @@
+package com.onair.hearit.common.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PlayingHistoryTest {
+
+    @Test
+    @DisplayName("재생 기록의 마지막 시간은 히어릿의 총 재생 시간보다 작아야 한다")
+    void validateHearitPlayTime() {
+        // given
+        Hearit hearit = createHearitWith(100);
+
+        // when & then
+        assertThatThrownBy(() -> new PlayingHistory(1L, hearit, 101));
+    }
+
+    @Test
+    @DisplayName("재생 기록의 마지막 시간이 히어릿의 총 재생 시간과 차이가 10초 이하라면 재생 기록이 완료 상태이다.")
+    void checkIsFinished() {
+        // given
+        Hearit hearit = createHearitWith(100);
+
+        // when
+        PlayingHistory playingHistory = new PlayingHistory(1L, hearit, 90);
+
+        // then
+        assertThat(playingHistory.isFinished()).isTrue();
+    }
+
+    private Hearit createHearitWith(int playTime) {
+        Category category = new Category("name", "#000000");
+        return new Hearit("title",
+                "summary",
+                playTime,
+                "/hearit/audio/original/ORG_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/audio/short/SHR_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/script/SCR_bf7c513e-579e-4224-8505-3824bb22ed01.json",
+                List.of(new Source("원본은 CC BY 4.0 라이선스를 따릅니다.", "https://example.com/2")),
+                category
+        );
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/common/domain/PlayingHistoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/domain/PlayingHistoryTest.java
@@ -16,7 +16,7 @@ class PlayingHistoryTest {
         Hearit hearit = createHearitWith(100);
 
         // when & then
-        assertThatThrownBy(() -> new PlayingHistory(1L, hearit, 101));
+        assertThatThrownBy(() -> new PlayingHistory(1L, hearit, 101_000));
     }
 
     @Test
@@ -26,7 +26,7 @@ class PlayingHistoryTest {
         Hearit hearit = createHearitWith(100);
 
         // when
-        PlayingHistory playingHistory = new PlayingHistory(1L, hearit, 90);
+        PlayingHistory playingHistory = new PlayingHistory(1L, hearit, 90_000);
 
         // then
         assertThat(playingHistory.isFinished()).isTrue();

--- a/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/BookmarkRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/BookmarkRepositoryTest.java
@@ -7,6 +7,7 @@ import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlaytimeProjection;
 import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.fixture.TestFixture;
 import java.util.List;
@@ -45,14 +46,15 @@ class BookmarkRepositoryTest {
         Bookmark newestBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit3));
 
         // when
-        Page<Bookmark> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(member,
+        Page<BookmarkWithPlaytimeProjection> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(
+                member.getId(),
                 PageRequest.of(0, 5));
 
         // then
         assertAll(() -> {
-            assertThat(bookmarks.getContent().get(0)).isEqualTo(newestBookmark);
-            assertThat(bookmarks.getContent().get(1)).isEqualTo(mideumBookmark);
-            assertThat(bookmarks.getContent().get(2)).isEqualTo(oldestBookmark);
+            assertThat(bookmarks.getContent().get(0).getBookmark().getId()).isEqualTo(newestBookmark.getId());
+            assertThat(bookmarks.getContent().get(1).getBookmark().getId()).isEqualTo(mideumBookmark.getId());
+            assertThat(bookmarks.getContent().get(2).getBookmark().getId()).isEqualTo(oldestBookmark.getId());
         });
     }
 

--- a/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/HearitRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/HearitRepositoryTest.java
@@ -7,7 +7,10 @@ import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.Source;
+import com.onair.hearit.common.infrastructure.dto.HearitWithPlayTimeProjection;
 import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.fixture.TestFixture;
 import java.util.List;
@@ -140,6 +143,43 @@ class HearitRepositoryTest {
             assertThat(hearits.get(0).getId()).isEqualTo(hearit1.getId());
             assertThat(hearits.get(1).getId()).isEqualTo(hearit2.getId());
             assertThat(hearits.get(2).getId()).isEqualTo(hearit3.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("멤버별 카테고리 내 히어릿 조회 시 마지막 재생 시간도 포함된다.")
+    void findWithPlayTimeByCategoryIdTest() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        PlayingHistory playingHistory1 = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit1, 14));
+        PlayingHistory playingHistory2 = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getId(), hearit3, 300));
+
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<HearitWithPlayTimeProjection> result =
+                hearitRepository.findWithPlayTimeByCategoryId(category.getId(), member.getId(), pageable);
+
+        HearitWithPlayTimeProjection projection3 = result.getContent().get(0);
+        HearitWithPlayTimeProjection projection2 = result.getContent().get(1);
+        HearitWithPlayTimeProjection projection1 = result.getContent().get(2);
+
+        // then
+        assertAll(() -> {
+            assertThat(result.getContent()).hasSize(3);
+            assertThat(projection1.getHearit().getId()).isEqualTo(hearit1.getId());
+            assertThat(projection1.getLastPlayTime()).isEqualTo(playingHistory1.getLastPlayTime());
+            assertThat(projection2.getHearit().getId()).isEqualTo(hearit2.getId());
+            assertThat(projection2.getLastPlayTime()).isNull();
+            assertThat(projection3.getHearit().getId()).isEqualTo(hearit3.getId());
+            assertThat(projection3.getLastPlayTime()).isEqualTo(playingHistory2.getLastPlayTime());
         });
     }
 

--- a/backend/src/test/java/com/onair/hearit/fixture/DbHelper.java
+++ b/backend/src/test/java/com/onair/hearit/fixture/DbHelper.java
@@ -8,6 +8,7 @@ import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.RecommendHearit;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -73,5 +74,11 @@ public class DbHelper {
         em.persist(exploreScore);
         em.flush();
         return exploreScore;
+    }
+
+    public PlayingHistory insertPlayingHistory(PlayingHistory playingHistory) {
+        em.persist(playingHistory);
+        em.flush();
+        return playingHistory;
     }
 }

--- a/backend/src/test/resources/dbclean.sql
+++ b/backend/src/test/resources/dbclean.sql
@@ -10,4 +10,5 @@ TRUNCATE TABLE refresh_token;
 TRUNCATE TABLE recommend_hearit;
 TRUNCATE TABLE hearit_source;
 TRUNCATE TABLE explore_score;
+TRUNCATE TABLE playing_history;
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- * 사용자 별 재생 기록을 저장하기 위한 `playing_history` 테이블 생성

컬럼명 | 타입 | 설명
-- | -- | --
id (PK) | BIGINT (PK) | 고유 ID
member_id (FK) | BIGINT (FK) | 회원 ID
hearit_id (FK) | BIGINT | 히어릿 ID
last_play_time | INT | 마지막 재생 위치 (초 단위)
is_finished | BOOLEAN | 콘텐츠 완청 여부 (Default: false)
updated_at | DATETIME | 마지막 청취 시간 (자동 업데이트)

* Create, Update,Read API 구현
   * Create: 사용자(member_id)가 히어릿(hearid_id)를 처음 재생하면 마지막 재생 위치가 요청으로 들어온다.
   * Update: 사용자(member_id)가 히어릿(hearid_id)를 다시 재생하면 마지막 재생 위치가 요청으로 들어온다.
     -> PlayingHistory 데이터 생성
   * Read: 기존 모든 히어릿 조회의 응답에 last_play_time을 추가한다. (기존 히어릿 조회 API 변경)

## 📸 스크린샷 (선택)
JPA Insert 사용 시, 100 이상의 요청만 들어와도 많은 시간이 걸린다는 문제를 확인하여 다음과 같이 개선했습니다.

- JPA Insert 
<img width="445" height="131" alt="스크린샷 2025-09-07 20 13 01" src="https://github.com/user-attachments/assets/12c387a4-242a-4691-acd5-91fdd95330c6" />

- JDBC Bulk Insert
<img width="445" height="131" alt="스크린샷 2025-09-08 17 32 38" src="https://github.com/user-attachments/assets/7c786378-62e4-4936-bdb6-6e8db182af5c" />


## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 재생기록 저장 API 추가(POST /api/v1/playing-histories), PlayingHistoryService/도메인·버퍼·스케줄러 및 bulk upsert 도입.
  - 검색·카테고리·상세·북마크 응답에 사용자 컨텍스트 기반 lastPlayTime·북마크 정보 포함(서비스·컨트롤러 시그니처 변경).

- **문서**
  - API 문서에 lastPlayTime 필드 및 재생기록 성공/권한없음 시나리오 추가.

- **테스트**
  - 도메인·서비스·컨트롤러 테스트에 재생기록·UserContext·lastPlayTime 검증 추가.

- **데이터베이스/운영**
  - playing_history 테이블 추가 및 last_play_time을 BIGINT로 마이그레이션.

- **예외/제한**
  - 버퍼 과부하 에러코드 및 BufferRequestException 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->