### PR TITLE
[BE] refactor: 북마크 목록 조회 응답 CategoryResponse 매핑 #490

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.app.dto.response;
 
 import com.onair.hearit.common.domain.Bookmark;
+import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 
 public record BookmarkHearitResponse(
@@ -9,7 +10,7 @@ public record BookmarkHearitResponse(
         String title,
         String summary,
         Integer playTime,
-        String categoryColor
+        CategoryResponse category
 ) {
     public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit) {
         return new BookmarkHearitResponse(
@@ -18,6 +19,12 @@ public record BookmarkHearitResponse(
                 hearit.getTitle(),
                 hearit.getSummary(),
                 hearit.getPlayTime(),
-                hearit.getCategory().getColorCode());
+                CategoryResponse.from(hearit.getCategory()));
+    }
+
+    private record CategoryResponse(Long id, String name, String colorCode) {
+        public static CategoryResponse from(Category category) {
+            return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
+        }
     }
 }

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -70,8 +70,9 @@ class BookmarkControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].summary").description("히어릿 요약"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
-                                                        fieldWithPath("content[].categoryColor").description(
-                                                                "해당 히어릿 카테고리 ColoCode")
+                                                        fieldWithPath("content[].category.id").description("카테고리 ID"),
+                                                        fieldWithPath("content[].category.name").description("카테고리 이름"),
+                                                        fieldWithPath("content[].category.colorCode").description("카테고리 색상 코드")
                                                 }),
                                                 Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields())
                                         ).toArray(FieldDescriptor[]::new)


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 라이브러리 화면 UI 변경에 따른 카테고리 응답 변경합니다.
- 클라이언트 측 요구사항으로 Category 정보를 Response 로 매핑합니다.

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 북마크된 히어릿 목록 응답에서 기존 단일 색상값 대신 카테고리 객체(아이디, 이름, 색상 코드)를 제공합니다.
- 문서
  - API 문서를 업데이트하여 응답 스키마 변경사항(중첩된 category 객체: id, name, colorCode)을 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->