### PR TITLE
[BE] chore: 테스트 db 아이디 비번 secretkey로 설정 #494

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -16,7 +16,7 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
         ports:
           - 13307:3306
@@ -27,7 +27,7 @@ jobs:
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -27,7 +27,7 @@ jobs:
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
+      MYSQL_TEST_USER_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 

--- a/.github/workflows/backend-dev-ci.yml
+++ b/.github/workflows/backend-dev-ci.yml
@@ -30,7 +30,7 @@ jobs:
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
+      MYSQL_TEST_USER_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 

--- a/.github/workflows/backend-dev-ci.yml
+++ b/.github/workflows/backend-dev-ci.yml
@@ -19,7 +19,7 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
         ports:
           - 13307:3306
@@ -30,7 +30,7 @@ jobs:
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -16,7 +16,7 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
         ports:
           - 13307:3306
@@ -27,7 +27,7 @@ jobs:
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -27,7 +27,7 @@ jobs:
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
+      MYSQL_TEST_USER_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 

--- a/.github/workflows/backend-prod-ci.yml
+++ b/.github/workflows/backend-prod-ci.yml
@@ -30,7 +30,7 @@ jobs:
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
+      MYSQL_TEST_USER_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 

--- a/.github/workflows/backend-prod-ci.yml
+++ b/.github/workflows/backend-prod-ci.yml
@@ -19,7 +19,7 @@ jobs:
       mysql:
         image: mysql:8.0
         env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
           MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
         ports:
           - 13307:3306
@@ -30,7 +30,7 @@ jobs:
           --health-retries=5
 
     env:
-      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+      MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_TEST_USER_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_TEST_USER}
+      MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       TZ: Asia/Seoul
     volumes:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_TEST_USER_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_USER: ${MYSQL_TEST_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       TZ: Asia/Seoul
     volumes:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "${TEST_MYSQL_PORT}:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: ${MYSQL_TEST_USER_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}

--- a/backend/src/test/resources/application-integration-test.properties
+++ b/backend/src/test/resources/application-integration-test.properties
@@ -4,7 +4,7 @@ spring.config.import=optional:file:.env[.properties]
 # Dev-DataSource
 spring.datasource.url=jdbc:mysql://localhost:13307/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=${MYSQL_ROOT_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA

--- a/backend/src/test/resources/application-integration-test.properties
+++ b/backend/src/test/resources/application-integration-test.properties
@@ -1,7 +1,10 @@
+# secret import
+spring.config.import=optional:file:.env[.properties]
+
 # Dev-DataSource
 spring.datasource.url=jdbc:mysql://localhost:13307/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.username=${MYSQl_TEST_USER}
+spring.datasource.password=${MYSQL_TEST_USER_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA

--- a/backend/src/test/resources/application-integration-test.properties
+++ b/backend/src/test/resources/application-integration-test.properties
@@ -3,7 +3,7 @@ spring.config.import=optional:file:.env[.properties]
 
 # Dev-DataSource
 spring.datasource.url=jdbc:mysql://localhost:13307/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=${MYSQl_TEST_USER}
+spring.datasource.username=${MYSQL_TEST_USER}
 spring.datasource.password=${MYSQL_TEST_USER_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 

--- a/backend/src/test/resources/application-integration-test.properties
+++ b/backend/src/test/resources/application-integration-test.properties
@@ -4,7 +4,7 @@ spring.config.import=optional:file:.env[.properties]
 # Dev-DataSource
 spring.datasource.url=jdbc:mysql://localhost:13307/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=${MYSQL_ROOT_PASSWORD}
+spring.datasource.password=${MYSQL_TEST_USER_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA

--- a/backend/src/test/resources/application-integration-test.properties
+++ b/backend/src/test/resources/application-integration-test.properties
@@ -3,8 +3,8 @@ spring.config.import=optional:file:.env[.properties]
 
 # Dev-DataSource
 spring.datasource.url=jdbc:mysql://localhost:13307/hearit_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=${MYSQL_TEST_USER}
-spring.datasource.password=${MYSQL_TEST_USER_PASSWORD}
+spring.datasource.username=root
+spring.datasource.password=root
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
 -통합 테스트 시 사용하는 testdb의 비밀번호르 secretkey로 설정한다. 
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#491 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 통합 테스트 설정에 선택적 비밀값(.env) 불러오기를 추가하여 테스트 환경 구성의 유연성과 보안성을 향상했습니다.
  * 통합 테스트의 DB 자격 증명이 하드코딩에서 테스트 전용 비밀 참조로 전환되어 비밀 관리가 개선되었습니다.
* **Chores**
  * 로컬 및 CI/CD 실행에서 사용되는 테스트용 DB 비밀번호 참조를 일관되게 테스트 전용 비밀로 교체하여 보안성과 일관성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->