### PR TITLE
[AN] refactor: 하단 재생바 Runnable 코드 개선

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
@@ -10,6 +10,12 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.TimeBar
 import com.onair.hearit.R
 import com.onair.hearit.databinding.LayoutBottomPlayerControllerBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 
 @UnstableApi
 class BottomPlayerView
@@ -30,7 +36,7 @@ class BottomPlayerView
             )
 
         private val window = Timeline.Window()
-        private val progressRunnable = Runnable { updateProgress() }
+        private var progressJob: Job? = null
 
         init {
             setupScrubListener()
@@ -45,6 +51,7 @@ class BottomPlayerView
                 player = newPlayer
                 listener = PlayerListener().also { newPlayer.addListener(it) }
                 refresh()
+
                 // post를 이용해서 UI가 완전히 그려진 후에 연결되도록 함.
                 post { updateProgress() }
             }
@@ -61,14 +68,12 @@ class BottomPlayerView
                     override fun onScrubStart(
                         timeBar: TimeBar,
                         position: Long,
-                    ) {
-                    }
+                    ) = Unit
 
                     override fun onScrubMove(
                         timeBar: TimeBar,
                         position: Long,
-                    ) {
-                    }
+                    ) = Unit
 
                     override fun onScrubStop(
                         timeBar: TimeBar,
@@ -122,16 +127,19 @@ class BottomPlayerView
             if (!isAttachedToWindow) return
             val currentPlayer = player ?: return
 
-            removeCallbacks(progressRunnable)
+            // 이미 실행 중인 경우 다시 시작하지 않음
+            if (progressJob?.isActive == true) return
 
-            if (currentPlayer.playbackState == Player.STATE_READY) {
-                binding.exoProgress.setPosition(currentPlayer.currentPosition)
-                binding.exoProgress.setBufferedPosition(currentPlayer.bufferedPosition)
-            }
-
-            if (currentPlayer.playWhenReady && currentPlayer.playbackState == Player.STATE_READY) {
-                postDelayed(progressRunnable, binding.exoProgress.preferredUpdateDelay)
-            }
+            progressJob =
+                CoroutineScope(Dispatchers.Main.immediate).launch {
+                    while (isActive) {
+                        if (currentPlayer.playbackState == Player.STATE_READY && currentPlayer.playWhenReady) {
+                            binding.exoProgress.setPosition(currentPlayer.currentPosition)
+                            binding.exoProgress.setBufferedPosition(currentPlayer.bufferedPosition)
+                        }
+                        delay(binding.exoProgress.preferredUpdateDelay)
+                    }
+                }
         }
 
         private fun updatePlayPauseButton(current: Player) {
@@ -155,6 +163,7 @@ class BottomPlayerView
         }
 
         private fun detachPlayer() {
+            progressJob?.cancel()
             listener?.let { player?.removeListener(it) }
             listener = null
             player = null
@@ -165,7 +174,8 @@ class BottomPlayerView
         // detachPlayer()는 Player 객체와의 연결을 해제하는 함수
         override fun onDetachedFromWindow() {
             super.onDetachedFromWindow()
-            removeCallbacks(progressRunnable)
+            progressJob?.cancel()
+            progressJob = null
             detachPlayer()
         }
 
@@ -174,20 +184,18 @@ class BottomPlayerView
                 player: Player,
                 events: Player.Events,
             ) {
-                if (events.contains(Player.EVENT_MEDIA_METADATA_CHANGED) ||
-                    events.contains(Player.EVENT_MEDIA_ITEM_TRANSITION) ||
-                    events.contains(Player.EVENT_TIMELINE_CHANGED)
+                if (events.containsAny(
+                        Player.EVENT_MEDIA_METADATA_CHANGED,
+                        Player.EVENT_MEDIA_ITEM_TRANSITION,
+                        Player.EVENT_TIMELINE_CHANGED,
+                    )
                 ) {
-                    updateTitle(player)
-                }
-                if (events.contains(Player.EVENT_TIMELINE_CHANGED)) {
-                    updateTimeline(player)
-                }
-                if (
-                    events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED) ||
-                    events.contains(Player.EVENT_IS_PLAYING_CHANGED)
+                    refresh()
+                } else if (events.containsAny(
+                        Player.EVENT_PLAYBACK_STATE_CHANGED,
+                        Player.EVENT_IS_PLAYING_CHANGED,
+                    )
                 ) {
-                    updateTitle(player)
                     updatePlayPauseButton(player)
                     updateProgress()
                 }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- BottomPlayerVIew에서 Runnable로 돌아가고 있는 코드를 개선하고자 함

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#496 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 플레이어 연결 직후 진행 상태가 즉시 갱신되어 초기 화면 응답성이 향상되었습니다.
- 버그 수정
  - 화면 전환·뷰 분리 시 진행 표시 업데이트가 중단되거나 잔존하던 문제를 방지하여 안정성이 높아졌습니다.
  - 시킹(스크럽) 중 불필요한 갱신을 줄여 튐 현상을 완화했습니다.
- 성능
  - 재생 중에만 진행 표시를 갱신해 배터리와 성능 효율을 개선했습니다.
  - 메인 스레드 즉시 반영으로 재생/일시정지 버튼과 타이틀 갱신이 더 빠르고 일관됩니다.
- 리팩터
  - 진행 업데이트 로직을 라이프사이클 친화적으로 재구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->