### PR TITLE
[AN] bug: 하단 재생바 재생 위치 업데이트 오류 해결

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -39,7 +40,7 @@ class BottomPlayerView
 
         private val window = Timeline.Window()
 
-        private val uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+        private var uiScope: CoroutineScope? = null
         private var progressJob: Job? = null
 
         init {
@@ -83,10 +84,7 @@ class BottomPlayerView
                         position: Long,
                         canceled: Boolean,
                     ) {
-                        player?.let {
-                            it.seekTo(position)
-                            updateProgressOnce()
-                        }
+                        player?.seekTo(position)
                     }
                 },
             )
@@ -98,8 +96,6 @@ class BottomPlayerView
                 updateTimeline(it)
                 updatePlayPauseButton(it)
                 updateTitle(it)
-                // 프로그레스 바 업데이트 루프를 시작하거나 유지함
-                ensureProgress()
             }
         }
 
@@ -143,18 +139,18 @@ class BottomPlayerView
                 if (currentPlayer.duration != C.TIME_UNSET) {
                     currentPlayer.duration
                 } else {
-                    window.durationMs.takeIf { it > 0 }
-                        ?: 0L
+                    window.durationMs.takeIf { it > 0 } ?: 0L
                 }
             binding.exoProgress.setDuration(duration)
             binding.exoProgress.setPosition(currentPlayer.currentPosition)
+            binding.exoProgress.setBufferedPosition(currentPlayer.bufferedPosition)
         }
 
         // 프로그레스 바 업데이트를 위한 코루틴 루프를 시작
         private fun startProgressLoop() {
             progressJob?.cancel()
             progressJob =
-                uiScope.launch {
+                uiScope?.launch {
                     while (isActive && isAttachedToWindow) {
                         updateProgressOnce()
                         val preferred = binding.exoProgress.preferredUpdateDelay
@@ -162,6 +158,12 @@ class BottomPlayerView
                         delay(delayMs)
                     }
                 }
+        }
+
+        // 프로그레스 바 업데이트 루프를 멈춤
+        private fun stopProgressLoop() {
+            progressJob?.cancel()
+            progressJob = null
         }
 
         private fun updatePlayPauseButton(current: Player) {
@@ -195,15 +197,18 @@ class BottomPlayerView
         // 뷰가 화면에 붙을 때 호출되는 콜백.
         override fun onAttachedToWindow() {
             super.onAttachedToWindow()
-            // 뷰가 다시 붙을 때 프로그레스 루프를 다시 시작하도록 함 -> job이 window에서 떨어지면 사라지기 떄문
-            if (progressJob?.isActive != true && player != null) startProgressLoop()
+            uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+            // 뷰가 다시 붙으면 프로그레스 루프를 다시 시작
+            if (player != null && player?.isPlaying == true) {
+                startProgressLoop()
+            }
         }
 
-        // onDetachedFromWindow()는 뷰(View)가 화면에서 분리될 때 호출되는 안드로이드 생명주기 메서드
-        // remove와 같은 정리 작업을 하는 경우에 사용됨.
-        // detachPlayer()는 Player 객체와의 연결을 해제하는 함수
+        // 뷰가 화면에서 분리될 때 호출되는 콜백
         override fun onDetachedFromWindow() {
             super.onDetachedFromWindow()
+            uiScope?.cancel()
+            uiScope = null
             detachPlayer()
         }
 
@@ -229,7 +234,11 @@ class BottomPlayerView
                     )
                 ) {
                     updatePlayPauseButton(player)
-                    ensureProgress()
+                    if (player.isPlaying) {
+                        startProgressLoop()
+                    } else {
+                        stopProgressLoop()
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/BottomPlayerView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.util.UnstableApi
@@ -13,6 +14,7 @@ import com.onair.hearit.databinding.LayoutBottomPlayerControllerBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -36,6 +38,8 @@ class BottomPlayerView
             )
 
         private val window = Timeline.Window()
+
+        private val uiScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
         private var progressJob: Job? = null
 
         init {
@@ -52,11 +56,10 @@ class BottomPlayerView
                 listener = PlayerListener().also { newPlayer.addListener(it) }
                 refresh()
 
-                // post를 이용해서 UI가 완전히 그려진 후에 연결되도록 함.
-                post { updateProgress() }
+                // 뷰가 아직 화면에 그려지지 않았을 경우를 대비해 post로 ensureProgress를 호출
+                post { ensureProgress() }
             }
 
-        // marquee로 길이가 긴경우에는 돌아가도록 하기 위해서 선택된 상태를 줌.
         fun setTitle(title: String) {
             binding.tvBottomPlayerTitle.isSelected = true
             binding.tvBottomPlayerTitle.text = title
@@ -82,18 +85,21 @@ class BottomPlayerView
                     ) {
                         player?.let {
                             it.seekTo(position)
-                            updateProgress()
+                            updateProgressOnce()
                         }
                     }
                 },
             )
         }
 
+        // 전체 UI를 새로고침하여 업데이트 하는 함수
         private fun refresh() {
             player?.let {
                 updateTimeline(it)
                 updatePlayPauseButton(it)
                 updateTitle(it)
+                // 프로그레스 바 업데이트 루프를 시작하거나 유지함
+                ensureProgress()
             }
         }
 
@@ -111,33 +117,49 @@ class BottomPlayerView
             setTitle(title)
         }
 
+        // 플레이어의 타임라인(총 길이)을 업데이트
         private fun updateTimeline(player: Player) {
             val timeline = player.currentTimeline
             if (timeline.isEmpty) {
-                binding.exoProgress.setDuration(0)
+                binding.exoProgress.setDuration(0L)
                 return
             }
             timeline.getWindow(player.currentMediaItemIndex, window)
-            val duration = window.durationMs.coerceAtLeast(0)
+            val duration = window.durationMs.coerceAtLeast(0L)
             binding.exoProgress.setDuration(duration)
-            updateProgress()
         }
 
-        private fun updateProgress() {
-            if (!isAttachedToWindow) return
+        // 일단 한 번 바로 업데이트하고, 만약 아직 루프가 시작되지 않았다면 지금 시작해서 계속 업데이트하도록 보장하는 함수
+        private fun ensureProgress() {
+            updateProgressOnce()
+            // 프로그레스 잡이 활성화되어 있지 않으면 새로 시작
+            if (progressJob?.isActive != true) startProgressLoop()
+        }
+
+        // 프로그레스 바를 한 번 업데이트합니다.
+        private fun updateProgressOnce() {
             val currentPlayer = player ?: return
+            val duration =
+                if (currentPlayer.duration != C.TIME_UNSET) {
+                    currentPlayer.duration
+                } else {
+                    window.durationMs.takeIf { it > 0 }
+                        ?: 0L
+                }
+            binding.exoProgress.setDuration(duration)
+            binding.exoProgress.setPosition(currentPlayer.currentPosition)
+        }
 
-            // 이미 실행 중인 경우 다시 시작하지 않음
-            if (progressJob?.isActive == true) return
-
+        // 프로그레스 바 업데이트를 위한 코루틴 루프를 시작
+        private fun startProgressLoop() {
+            progressJob?.cancel()
             progressJob =
-                CoroutineScope(Dispatchers.Main.immediate).launch {
-                    while (isActive) {
-                        if (currentPlayer.playbackState == Player.STATE_READY && currentPlayer.playWhenReady) {
-                            binding.exoProgress.setPosition(currentPlayer.currentPosition)
-                            binding.exoProgress.setBufferedPosition(currentPlayer.bufferedPosition)
-                        }
-                        delay(binding.exoProgress.preferredUpdateDelay)
+                uiScope.launch {
+                    while (isActive && isAttachedToWindow) {
+                        updateProgressOnce()
+                        val preferred = binding.exoProgress.preferredUpdateDelay
+                        val delayMs = if (preferred in 1L..999L) preferred else 50L
+                        delay(delayMs)
                     }
                 }
         }
@@ -162,6 +184,7 @@ class BottomPlayerView
             }
         }
 
+        // 뷰가 분리될 때 모든 리소스를 정리
         private fun detachPlayer() {
             progressJob?.cancel()
             listener?.let { player?.removeListener(it) }
@@ -169,13 +192,18 @@ class BottomPlayerView
             player = null
         }
 
+        // 뷰가 화면에 붙을 때 호출되는 콜백.
+        override fun onAttachedToWindow() {
+            super.onAttachedToWindow()
+            // 뷰가 다시 붙을 때 프로그레스 루프를 다시 시작하도록 함 -> job이 window에서 떨어지면 사라지기 떄문
+            if (progressJob?.isActive != true && player != null) startProgressLoop()
+        }
+
         // onDetachedFromWindow()는 뷰(View)가 화면에서 분리될 때 호출되는 안드로이드 생명주기 메서드
         // remove와 같은 정리 작업을 하는 경우에 사용됨.
         // detachPlayer()는 Player 객체와의 연결을 해제하는 함수
         override fun onDetachedFromWindow() {
             super.onDetachedFromWindow()
-            progressJob?.cancel()
-            progressJob = null
             detachPlayer()
         }
 
@@ -184,20 +212,24 @@ class BottomPlayerView
                 player: Player,
                 events: Player.Events,
             ) {
+                // 메타데이터, 타임라인 등 중요한 이벤트 발생 시에  UI를 새로고침
                 if (events.containsAny(
                         Player.EVENT_MEDIA_METADATA_CHANGED,
                         Player.EVENT_MEDIA_ITEM_TRANSITION,
                         Player.EVENT_TIMELINE_CHANGED,
+                        Player.EVENT_POSITION_DISCONTINUITY,
                     )
                 ) {
                     refresh()
+                    // 재생/일시정지 상태 변경 이벤트 발생 시 버튼과 프로그레스 루프를 업데이트
                 } else if (events.containsAny(
+                        Player.EVENT_PLAYBACK_PARAMETERS_CHANGED,
                         Player.EVENT_PLAYBACK_STATE_CHANGED,
                         Player.EVENT_IS_PLAYING_CHANGED,
                     )
                 ) {
                     updatePlayPauseButton(player)
-                    updateProgress()
+                    ensureProgress()
                 }
             }
         }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 하단 재생바에서 오디오가 실행중인데도, 하단 재생바의 재생 위치가 업데이트되지 않는 오류가 발생
- 이전과 동일하게 하단 재생바가 업데이트 될 수 있도록 개발함

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 없음
- 버그 수정
  - 재생 진행 표시가 가끔 멈추거나 불규칙하게 갱신되던 문제를 개선했습니다.
  - 플레이어 연결/분리 시 진행 정보가 즉시 반영되지 않던 현상을 해결했습니다.
  - 타임라인 길이가 정확히 표시되지 않던 일부 상황을 보정했습니다.
- 리팩터링
  - 화면 수명 주기에 맞춘 주기적 진행 업데이트로 안정성과 일관성을 높였습니다.
  - 스크럽(이동) 후 진행 동기화 및 이벤트 기반 UI 새로고침 범위를 정비해 반응성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->