### PR TITLE
[AN] refactor: 히어릿 응답에 사용자별 시청 기록 추가

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/dto/BookmarkResponse.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/dto/BookmarkResponse.kt
@@ -32,6 +32,8 @@ data class BookmarkResponse(
         val summary: String,
         @SerialName("playTime")
         val playTime: Int,
+        @SerialName("lastPlayTime")
+        val lastPlayTime: Long? = null,
         @SerialName("category")
         val category: CategoryResponse.Content,
     )

--- a/android/app/src/main/java/com/onair/hearit/data/dto/HearitResponse.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/dto/HearitResponse.kt
@@ -15,6 +15,8 @@ data class HearitResponse(
     val sources: List<SourceResponse>,
     @SerialName("playTime")
     val playTime: Int,
+    @SerialName("lastPlayTime")
+    val lastPlayTime: Long? = null,
     @SerialName("createdAt")
     val createdAt: String,
     @SerialName("isBookmarked")

--- a/android/app/src/main/java/com/onair/hearit/data/dto/SearchHearitResponse.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/dto/SearchHearitResponse.kt
@@ -28,6 +28,8 @@ data class SearchHearitResponse(
         val title: String,
         @SerialName("playTime")
         val playTime: Int,
+        @SerialName("lastPlayTime")
+        val lastPlayTime: Long? = null,
         @SerialName("keywords")
         val keywords: List<KeywordResponse>,
     )

--- a/android/app/src/main/java/com/onair/hearit/data/mapper/BookmarkMapper.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/mapper/BookmarkMapper.kt
@@ -12,6 +12,7 @@ fun BookmarkResponse.Content.toDomain(): Bookmark =
         title = title,
         summary = summary,
         playTime = playTime,
+        lastPlayTime = lastPlayTime,
         category = category.toDomain(),
         audioUrl = null,
     )

--- a/android/app/src/main/java/com/onair/hearit/data/mapper/HearitMapper.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/mapper/HearitMapper.kt
@@ -36,6 +36,7 @@ private fun SearchHearitResponse.Content.toDomain(): SearchedHearit =
         id = this.id,
         title = this.title,
         playTime = this.playTime,
+        lastPlayTime = this.lastPlayTime,
         keywords = this.keywords.map { it.toDomain() },
     )
 
@@ -84,6 +85,7 @@ fun HearitResponse.toDomain(): SingleHearit =
         summary = this.summary,
         sources = this.sources.map { it.toDomain() },
         playTime = this.playTime,
+        lastPlayTime = this.lastPlayTime,
         createdAt = this.createdAt,
         isBookmarked = this.isBookmarked,
         bookmarkId = this.bookmarkId,

--- a/android/app/src/main/java/com/onair/hearit/domain/Mapper.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/Mapper.kt
@@ -35,6 +35,7 @@ fun SingleHearit.toHearit(
         audioUrl = audioUrl,
         script = script,
         playTime = this.playTime,
+        lastPlayTime = this.lastPlayTime,
         createdAt = this.createdAt,
         isBookmarked = this.isBookmarked,
         bookmarkId = this.bookmarkId,

--- a/android/app/src/main/java/com/onair/hearit/domain/model/Bookmark.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/model/Bookmark.kt
@@ -6,6 +6,7 @@ data class Bookmark(
     val title: String,
     val summary: String,
     val playTime: Int,
+    val lastPlayTime: Long? = null,
     val category: Category,
     val audioUrl: String?,
 )

--- a/android/app/src/main/java/com/onair/hearit/domain/model/Hearit.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/model/Hearit.kt
@@ -8,6 +8,7 @@ data class Hearit(
     val audioUrl: String,
     val script: List<ScriptLine>,
     val playTime: Int,
+    val lastPlayTime: Long? = null,
     val createdAt: String,
     val isBookmarked: Boolean,
     val bookmarkId: Long?,

--- a/android/app/src/main/java/com/onair/hearit/domain/model/SearchedHearit.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/model/SearchedHearit.kt
@@ -4,5 +4,6 @@ data class SearchedHearit(
     val id: Long,
     val title: String,
     val playTime: Int,
+    val lastPlayTime: Long? = null,
     val keywords: List<Keyword>,
 )

--- a/android/app/src/main/java/com/onair/hearit/domain/model/SingleHearit.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/model/SingleHearit.kt
@@ -6,6 +6,7 @@ data class SingleHearit(
     val summary: String,
     val sources: List<Source>,
     val playTime: Int,
+    val lastPlayTime: Long? = null,
     val createdAt: String,
     val isBookmarked: Boolean,
     val bookmarkId: Long?,

--- a/android/app/src/main/java/com/onair/hearit/presentation/BindingAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/BindingAdapter.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.GradientDrawable
 import android.util.TypedValue
 import android.view.View
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
@@ -14,6 +15,7 @@ import androidx.databinding.BindingAdapter
 import coil.load
 import com.onair.hearit.R
 import com.onair.hearit.domain.model.Keyword
+import com.onair.hearit.domain.model.SearchedHearit
 import com.onair.hearit.presentation.library.BookmarkUiState
 import com.onair.hearit.presentation.search.SearchUiState
 import java.text.SimpleDateFormat
@@ -175,4 +177,20 @@ fun setShimmerVisibility(
     isLoading: Boolean,
 ) {
     view.isVisible = isLoading
+}
+
+@BindingAdapter("progressRatio")
+fun setProgressBarRatio(
+    progressBar: ProgressBar,
+    item: SearchedHearit?,
+) {
+    val ratio =
+        item
+            ?.lastPlayTime
+            ?.takeIf { item.playTime > 0 }
+            ?.toFloat()
+            ?.div(item.playTime) ?: 0f
+
+    val percent = (ratio.coerceIn(0f, 1f) * 100).toInt()
+    progressBar.progress = percent
 }

--- a/android/app/src/main/res/layout/item_searched_hearit.xml
+++ b/android/app/src/main/res/layout/item_searched_hearit.xml
@@ -73,5 +73,19 @@
             app:playTimeFormatted="@{item.playTime}"
             tools:text="08:21" />
 
+        <ProgressBar
+            android:id="@+id/pb_hearit_progress"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="0dp"
+            android:layout_height="8dp"
+            android:layout_marginTop="8dp"
+            android:max="100"
+            android:progress="20"
+            android:progressTint="@color/hearit_purple2"
+            app:layout_constraintEnd_toEndOf="@id/tv_searched_hearit_time"
+            app:layout_constraintStart_toStartOf="@id/tv_searched_hearit_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_keywords"
+            app:progressRatio="@{item}" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 히어릿 응답에 lastPlayTime 추가
- 검색 결과 히어릿에 lastPlayTime 화면 표시

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

<img width="280" alt="Screenshot_1757581249" src="https://github.com/user-attachments/assets/fa231bb8-3594-45a9-b4b9-225fd6765904" />

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#503 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 검색 결과 카드에 오디오 재생 진행률을 보여주는 프로그레스 바가 추가되었습니다.
  - lastPlayTime 정보를 활용해 이어듣기 진행률을 계산·표시합니다(데이터가 없는 경우 자동 처리).
  - 북마크/검색/상세 항목 전반에서 진행 상태를 전달할 준비가 되었습니다.

- UI
  - 검색 아이템 레이아웃에 수평 진행 바를 추가하여 재생 진행 상황을 직관적으로 확인할 수 있습니다.
  - 앱 테마 색상을 적용하고, 전체 길이 대비 퍼센트로 자동 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->