### PR TITLE
[BE] fix: Source의 source_url 컬럼 제약조건 500자로 증가 및 도메인 유효성 검사 추가

### DIFF
--- a/backend/src/main/java/com/onair/hearit/common/domain/Source.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/Source.java
@@ -29,6 +29,9 @@ public class Source {
         if (sourceName == null || sourceName.isBlank() || sourceName.length() > 250) {
             throw new InvalidInputException("출처명(sourceName)은 250자 이하의 유효한 문자열이어야 합니다.");
         }
+        if (sourceUrl != null && sourceUrl.length() > 500) {
+            throw new InvalidInputException("출처 링크(sourceUrl)는 500자 이하의 문자열이어야 합니다.");
+        }
     }
 
     @Override
@@ -41,7 +44,7 @@ public class Source {
         }
         Source source = (Source) o;
         return Objects.equals(sourceName, source.sourceName) &&
-                Objects.equals(sourceUrl, source.sourceUrl);
+               Objects.equals(sourceUrl, source.sourceUrl);
     }
 
     @Override

--- a/backend/src/main/resources/db/migration/V2025090121510__hearit_sourceurl_length.sql
+++ b/backend/src/main/resources/db/migration/V2025090121510__hearit_sourceurl_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE hearit_source
+    MODIFY COLUMN source_url VARCHAR(500);

--- a/backend/src/test/java/com/onair/hearit/common/domain/SourceTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/domain/SourceTest.java
@@ -3,7 +3,6 @@ package com.onair.hearit.common.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.common.exception.custom.InvalidInputException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,5 +39,14 @@ class SourceTest {
         assertThatThrownBy(() -> new Source(longName, "https://example.com"))
                 .isInstanceOf(InvalidInputException.class)
                 .hasMessageContaining("sourceName");
+    }
+
+    @Test
+    @DisplayName("sourceUrl이 500자를 초과하면 예외가 발생한다")
+    void createSourceWithTooLongUrl() {
+        String longUrl = "a".repeat(501);
+        assertThatThrownBy(() -> new Source("sourceName", longUrl))
+                .isInstanceOf(InvalidInputException.class)
+                .hasMessageContaining("sourceUrl");
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

- source_url DB 제약 조건 기존 255 -> 500로 증가
    - 이유: 링크 url의 경우 255자가 넘는 경우가 있었고, admin페이지에서 히어릿 등록 시 500 에러 발셍하는 문제 해결 위함
- Source domain 에서 미리 제약조건을 검사하도록 생성자에 validate 추가
    - 이유: application에서 검사하지 않아 DB까지 잘못된 값이 내려옴 -> 400이 아닌 500 에러 발생하는 문제 해결 위함

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#511 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 출처 링크 최대 길이를 500자로 확장해 더 긴 URL 저장을 지원합니다.
  - 500자를 초과하는 출처 링크 입력 시 이해하기 쉬운 검증 오류 메시지를 제공합니다.
  - 스키마 업데이트를 통해 변경사항이 반영되어 기존 데이터와 호환성을 유지합니다.

- Tests
  - 출처 링크 길이 제한(500자)에 대한 단위 테스트를 추가해 검증 로직의 신뢰성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->