### PR TITLE
[BE] fix: explore_score uk 추가 (#514)

### DIFF
--- a/backend/src/main/resources/db/migration/V2025090151046__explore_score_uk.sql
+++ b/backend/src/main/resources/db/migration/V2025090151046__explore_score_uk.sql
@@ -1,0 +1,5 @@
+-- explore_score 테이블의 기존 데이터 삭제
+TRUNCATE TABLE explore_score;
+
+-- explore_score user_uuid, hearit_id uk 추가
+CREATE UNIQUE INDEX ux_user_uuid_hearit_id ON explore_score (user_uuid, hearit_id);


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

        String insertSql = """
                INSERT INTO explore_score (user_uuid, hearit_id, score, cursor_id)
                VALUES (?, ?, ?, NULL)
                ON DUPLICATE KEY UPDATE
                    score = VALUES(score),
                    cursor_id = NULL
                """;

여기서 Duplicate key의 기준이 uk or pk인데 기존 member_id, hearit_id의 uk를 제거해서 현재 요청이 올때마다 동일한 히어릿이 insert 되는 문제 발생

그래서 기존 explore score data 삭제하고, user_uuid, hearit_id 의 unique key 추가하는 flyway migration sql 문 작성

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 사용자-콘텐츠 조합의 중복 점수를 방지하기 위해 고유 제약을 적용했습니다.
- 작업
  - 탐색 점수 데이터베이스를 정리하고 인덱스를 최적화했습니다. 기존 탐색 점수 데이터가 초기화되며, 이후 시스템에서 자동으로 재생성됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->