### PR TITLE
[BE] feat: 탐색 API에서 구버전 호환 가능하도록 버저닝 추가

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV1.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV1.java
@@ -1,0 +1,23 @@
+package com.onair.hearit.app.dto.response;
+
+import java.util.List;
+
+public record CursorResponseV1<T>(
+        List<T> content,
+        boolean isEmpty,
+        long cursorId
+) {
+    public static <T> CursorResponseV1<T> from(CursorResponse<T> cursorResponse) {
+        List<T> contents = cursorResponse.content();
+        long cursorId = 0L;
+        if(!contents.isEmpty()) {
+            ExploredHearitResponse last = (ExploredHearitResponse) contents.getLast();
+            cursorId = last.cursorId();;
+        }
+        return new CursorResponseV1<>(
+                contents,
+                contents.isEmpty(),
+                cursorId
+        );
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
@@ -6,6 +6,7 @@ import com.onair.hearit.app.application.explore.HearitExploreService;
 import com.onair.hearit.app.dto.request.CursorRequest;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.CursorResponse;
+import com.onair.hearit.app.dto.response.CursorResponseV1;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
 import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
@@ -26,14 +27,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/hearits")
+@RequestMapping("/api")
 public class HearitController {
 
     private final HearitService hearitService;
     private final HearitExploreService hearitExploreService;
     private final HearitSearchService hearitSearchService;
 
-    @GetMapping("/{hearitId}")
+    @GetMapping("/v1/hearits/{hearitId}")
     public ResponseEntity<HearitDetailResponse> readHearit(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -41,8 +42,8 @@ public class HearitController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/explore")
-    public ResponseEntity<CursorResponse<ExploredHearitResponse>> readExploredHearits(
+    @GetMapping("/v2/hearits/explore")
+    public ResponseEntity<CursorResponse<ExploredHearitResponse>> readExploredHearitsV2(
             @AuthenticationPrincipal RequestUser requestUser,
             @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
             @RequestParam(name = "size", defaultValue = "10") int size) {
@@ -52,13 +53,25 @@ public class HearitController {
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/recommend")
+    @GetMapping("/v1/hearits/explore")
+    public ResponseEntity<CursorResponseV1<ExploredHearitResponse>> readExploredHearitsV1(
+            @AuthenticationPrincipal RequestUser requestUser,
+            @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+        CursorRequest cursorRequest = new CursorRequest(cursorId, size);
+        CursorResponse<ExploredHearitResponse> responses =
+                hearitExploreService.getExploredHearits(requestUser.getUserInfo(), cursorRequest);
+        CursorResponseV1<ExploredHearitResponse> responsesV1 = CursorResponseV1.from(responses);
+        return ResponseEntity.ok(responsesV1);
+    }
+
+    @GetMapping("/v1/hearits/recommend")
     public ResponseEntity<List<RecommendHearitResponse>> readRecommendedHearits() {
         List<RecommendHearitResponse> responses = hearitService.getRecommendedHearits();
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/search")
+    @GetMapping("/v1/hearits/search")
     public ResponseEntity<PagedResponse<HearitSearchResponse>> readSearchedHearits(
             @RequestParam(name = "searchTerm") String searchTerm,
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -70,7 +83,7 @@ public class HearitController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/recommend-category")
+    @GetMapping("/v1/hearits/recommend-category")
     public ResponseEntity<List<HearitsWithRecommendCategoryResponse>> readHearitsWithRecommendCategory(
             @AuthenticationPrincipal RequestUser requestUser) {
         List<HearitsWithRecommendCategoryResponse> responses =
@@ -78,7 +91,7 @@ public class HearitController {
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping
+    @GetMapping("/v1/hearits")
     public ResponseEntity<PagedResponse<HearitOfCategoryResponse>> readHearitsByCategory(
             @RequestParam(name = "categoryId") Long categoryId,
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/backend/src/main/java/com/onair/hearit/auth/config/ApiSecurityConfig.java
+++ b/backend/src/main/java/com/onair/hearit/auth/config/ApiSecurityConfig.java
@@ -27,17 +27,17 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class ApiSecurityConfig {
 
     private static final String[] PUBLIC_AUTH_ENDPOINTS = {
-            "/api/v1/auth/login",
-            "/api/v1/auth/kakao-login",
-            "/api/v1/auth/signup",
-            "/api/v1/auth/token/refresh",
+            "/api/*/auth/login",
+            "/api/*/auth/kakao-login",
+            "/api/*/auth/signup",
+            "/api/*/auth/token/refresh",
     };
 
     private static final String[] PUBLIC_GET_ENDPOINTS = {
-            "/api/v1/hearits/**",
-            "/api/v1/categories/**",
-            "/api/v1/keywords/**",
-            "/api/v1/playing-histories"
+            "/api/*/hearits/**",
+            "/api/*/categories/**",
+            "/api/*/keywords/**",
+            "/api/*/playing-histories"
     };
 
     private final ObjectMapper objectMapper;

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.onair.hearit.app.dto.response.CursorResponse;
+import com.onair.hearit.app.dto.response.CursorResponseV1;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
 import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
@@ -36,7 +37,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -140,7 +140,7 @@ class HearitControllerTest extends IntegrationTest {
 
     @Test
     @DisplayName("탐색 히어릿을 조회 시, 200 OK 및 최대 10개 히어릿 정보 목록을 제공한다.")
-    void readExploredHearits_byMember() {
+    void readExploredHearits_byMember_v2() {
         // given
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Keyword keyword = dbHelper.insertKeyword(new Keyword("Keyword"));
@@ -163,7 +163,7 @@ class HearitControllerTest extends IntegrationTest {
                 .filter(document("hearit-read-explore-member",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
-                                .summary("탐색 히어릿 목록 조회")
+                                .summary("탐색 히어릿 목록 조회 V2")
                                 .description("사용자 별 최대 10개의 히어릿 목록을 조회합니다.")
                                 .queryParameters(
                                         parameterWithName("cursorId").description("시작 Cursor ID").defaultValue("0"),
@@ -193,6 +193,77 @@ class HearitControllerTest extends IntegrationTest {
                                 .build())
                 ))
                 .when()
+                .get("/api/v2/hearits/explore")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertAll(() -> {
+            assertThat(responses.content()).hasSize(3);
+            assertThat(responses.content()).extracting(ExploredHearitResponse::cursorId)
+                            .containsExactly(1L, 2L, 3L);
+            assertThat(responses.isEmpty()).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("탐색 히어릿을 조회 시, 200 OK 및 최대 10개 히어릿 정보 목록을 제공한다.")
+    void readExploredHearits_byMember_v1() {
+        // given
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Keyword keyword = dbHelper.insertKeyword(new Keyword("Keyword"));
+
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit1, keyword));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit2, keyword));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit3, keyword));
+
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+
+        // when
+        CursorResponseV1<ExploredHearitResponse> responses = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .queryParam("cursorId", 0)
+                .queryParam("size", 10)
+                .filter(document("hearit-read-explore-member",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Hearit API")
+                                .summary("탐색 히어릿 목록 조회 V1")
+                                .description("사용자 별 최대 10개의 히어릿 목록을 조회합니다.")
+                                .queryParameters(
+                                        parameterWithName("cursorId").description("시작 Cursor ID").defaultValue("0"),
+                                        parameterWithName("size").description("필요한 히어릿 항목 수").defaultValue("10")
+                                )
+                                .responseSchema(Schema.schema("CursorExploredHearitResponse"))
+                                .responseFields(
+                                        Stream.concat(
+                                                Arrays.stream(new FieldDescriptor[]{
+                                                        fieldWithPath("content[].id").description("히어릿 ID"),
+                                                        fieldWithPath("content[].title").description("히어릿 제목"),
+                                                        fieldWithPath("content[].categoryColorCode").description(
+                                                                "카테고리 색상"),
+                                                        fieldWithPath("content[].isBookmarked").description("북마크 여부"),
+                                                        fieldWithPath("content[].bookmarkId").description(
+                                                                "북마크 ID (북마크된 경우)").optional(),
+                                                        fieldWithPath("content[].keywords").description(
+                                                                "히어릿에 포함된 키워드 목록"),
+                                                        fieldWithPath("content[].keywords[].id").description("키워드 ID"),
+                                                        fieldWithPath("content[].keywords[].name").description(
+                                                                "키워드 이름"),
+                                                        fieldWithPath("content[].cursorId").description("커서 ID"),
+                                                }),
+                                                Arrays.stream(ApiDocSnippets.getCustomCursorResponseV1Fields())
+                                        ).toArray(FieldDescriptor[]::new)
+                                )
+                                .build())
+                ))
+                .when()
                 .get("/api/v1/hearits/explore")
                 .then()
                 .statusCode(HttpStatus.OK.value())
@@ -203,6 +274,7 @@ class HearitControllerTest extends IntegrationTest {
         // then
         assertAll(() -> {
             assertThat(responses.content()).hasSize(3);
+            assertThat(responses.cursorId()).isEqualTo(3L);
             assertThat(responses.isEmpty()).isFalse();
         });
     }

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -160,7 +160,7 @@ class HearitControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .queryParam("cursorId", 0)
                 .queryParam("size", 10)
-                .filter(document("hearit-read-explore-member",
+                .filter(document("hearit-read-explore-member-v2",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
                                 .summary("탐색 히어릿 목록 조회 V2")
@@ -231,7 +231,7 @@ class HearitControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .queryParam("cursorId", 0)
                 .queryParam("size", 10)
-                .filter(document("hearit-read-explore-member",
+                .filter(document("hearit-read-explore-member-v1",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
                                 .summary("탐색 히어릿 목록 조회 V1")

--- a/backend/src/test/java/com/onair/hearit/docs/ApiDocSnippets.java
+++ b/backend/src/test/java/com/onair/hearit/docs/ApiDocSnippets.java
@@ -26,6 +26,14 @@ public class ApiDocSnippets {
         };
     }
 
+    public static FieldDescriptor[] getCustomCursorResponseV1Fields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("content").description("페이지의 실제 컨텐츠 목록"),
+                fieldWithPath("isEmpty").type(JsonFieldType.BOOLEAN).description("컨텐츠 존재 여부"),
+                fieldWithPath("cursorId").type(JsonFieldType.NUMBER).description("커서 ID"),
+        };
+    }
+
     public static FieldDescriptor[] getProblemDetailResponseFields() {
         return new FieldDescriptor[]{
                 fieldWithPath("type").type(JsonFieldType.STRING).description("문제 유형을 식별하는 URI (요청 경로)"),


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 삭제한 기존 api의 응답을 제공할 수 있도록 v1 & v2 api 모두 구현
    - 탐색api 응답값 변경으로 인한 기존 api와 새로운 api 모두 유지해야함.

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부
<img width="696" height="365" alt="image" src="https://github.com/user-attachments/assets/ae4d74fe-875f-4d09-8fcd-d5346095e2ae" />
<img width="683" height="375" alt="스크린샷 2025-09-17 오후 1 26 58" src="https://github.com/user-attachments/assets/8fa66134-749b-42b0-9197-ea15add473a4" />


## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
HearitControllerTest의 
- readExploredHearits_byMember_v1
- readExploredHearits_byMember_v2

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #536 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - Hearit API에 버전 관리 도입: /api/v1, /api/v2 경로로 분리
  - 탐색(Explore) 엔드포인트 v1과 v2 제공: v1은 단순화된 커서 응답 형식, v2는 기존 확장 형식 유지
  - 검색, 추천, 카테고리 기반 목록 등 읽기 엔드포인트를 /api/v1 경로로 정리

- 보안/운영
  - 인증/공개 엔드포인트 화이트리스트를 버전 와일드카드(/api/*/...)로 확장

- 문서
  - v1/v2 엔드포인트 및 응답 스키마 예시 추가 및 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->