### PR TITLE
hotfix: 북마크 구버전 호환 가능하도록 v1&v2 버전 추가 #541

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
@@ -24,7 +24,7 @@ public record BookmarkHearitResponse(
                 CategoryResponse.from(hearit.getCategory()));
     }
 
-    private record CategoryResponse(Long id, String name, String colorCode) {
+    public record CategoryResponse(Long id, String name, String colorCode) {
         public static CategoryResponse from(Category category) {
             return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
         }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV1.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV1.java
@@ -1,0 +1,24 @@
+package com.onair.hearit.app.dto.response;
+
+public record BookmarkHearitResponseV1(
+        Long hearitId,
+        Long bookmarkId,
+        String title,
+        String summary,
+        Integer playTime,
+        Long lastPlayTime,
+        String categoryColor
+) {
+    public static BookmarkHearitResponseV1 from(BookmarkHearitResponse bookmarkHearitResponse) {
+        BookmarkHearitResponse.CategoryResponse category = bookmarkHearitResponse.category();
+        return new BookmarkHearitResponseV1(
+                bookmarkHearitResponse.hearitId(),
+                bookmarkHearitResponse.bookmarkId(),
+                bookmarkHearitResponse.title(),
+                bookmarkHearitResponse.summary(),
+                bookmarkHearitResponse.playTime(),
+                bookmarkHearitResponse.lastPlayTime(),
+                category.colorCode()
+        );
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
@@ -1,11 +1,14 @@
 package com.onair.hearit.app.presentation;
 
+
 import com.onair.hearit.app.application.BookmarkService;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV1;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.auth.domain.RequestUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,13 +23,38 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/bookmarks")
+@RequestMapping("/api")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
-    @GetMapping("/hearits")
-    public ResponseEntity<PagedResponse<BookmarkHearitResponse>> readBookmarkHearits(
+    @GetMapping("/v1/bookmarks/hearits")
+    public ResponseEntity<PagedResponse<BookmarkHearitResponseV1>> readBookmarkHearitsV1(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @AuthenticationPrincipal RequestUser requestUser) {
+        PagingRequest pagingRequest = new PagingRequest(page, size);
+        PagedResponse<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(requestUser.getUserInfo(),
+                pagingRequest);
+        List<BookmarkHearitResponse> contents = responses.content();
+        List<BookmarkHearitResponseV1> v1Contents = contents.stream()
+                .map(BookmarkHearitResponseV1::from)
+                .toList();
+        PagedResponse<BookmarkHearitResponseV1> v1Responses =
+                new PagedResponse<>(
+                        v1Contents,
+                        responses.page(),
+                        responses.size(),
+                        responses.totalPages(),
+                        responses.totalElements(),
+                        responses.isFirst(),
+                        responses.isLast()
+                );
+        return ResponseEntity.ok(v1Responses);
+    }
+
+    @GetMapping("/v2/bookmarks/hearits")
+    public ResponseEntity<PagedResponse<BookmarkHearitResponse>> readBookmarkHearitsV2(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -36,7 +64,7 @@ public class BookmarkController {
         return ResponseEntity.ok(responses);
     }
 
-    @PostMapping("/hearits/{hearitId}")
+    @PostMapping("/v1/bookmarks/hearits/{hearitId}")
     public ResponseEntity<BookmarkInfoResponse> createBookmark(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -44,7 +72,7 @@ public class BookmarkController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @DeleteMapping("/{bookmarkId}")
+    @DeleteMapping("/v1/bookmarks/{bookmarkId}")
     public ResponseEntity<Void> deleteBookmark(
             @PathVariable Long bookmarkId,
             @AuthenticationPrincipal RequestUser requestUser) {

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -36,7 +36,7 @@ class BookmarkControllerTest extends IntegrationTest {
 
     @Test
     @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
-    void readBookmarkHearitsTest() {
+    void readBookmarkHearitsTest_v1() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
@@ -52,10 +52,62 @@ class BookmarkControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .param("page", 0)
                 .param("size", 5)
-                .filter(document("bookmark-read-list",
+                .filter(document("bookmark-read-list-v1",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
-                                .summary("북마크 목록 조회")
+                                .summary("북마크 목록 조회 V1")
+                                .description("사용자가 북마크한 히어릿 목록을 페이지별로 조회합니다.")
+                                .queryParameters(
+                                        parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
+                                        parameterWithName("size").description("페이지 당 항목 수 (기본 20)").defaultValue("20")
+                                )
+                                .responseSchema(Schema.schema("PagedBookmarkHearitResponse"))
+                                .responseFields(
+                                        Stream.concat(
+                                                Arrays.stream(new FieldDescriptor[]{
+                                                        fieldWithPath("content[].hearitId").description("히어릿 ID"),
+                                                        fieldWithPath("content[].bookmarkId").description("북마크 ID"),
+                                                        fieldWithPath("content[].title").description("히어릿 제목"),
+                                                        fieldWithPath("content[].summary").description("히어릿 요약"),
+                                                        fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
+                                                        fieldWithPath("content[].lastPlayTime").description(
+                                                                "히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].categoryColor").description("카테고리 색상 코드")
+                                                }),
+                                                Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields())
+                                        ).toArray(FieldDescriptor[]::new)
+                                )
+                                .build())
+                ))
+                .when()
+                .get("/api/v1/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("content.size()", equalTo(5));
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
+    void readBookmarkHearitsTest_v2() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        String token = generateToken(member);
+        int bookmarkCount = 30;
+        for (int i = 0; i < bookmarkCount; i++) {
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        }
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .param("page", 0)
+                .param("size", 5)
+                .filter(document("bookmark-read-list-v2",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Bookmark API")
+                                .summary("북마크 목록 조회 V2")
                                 .description("사용자가 북마크한 히어릿 목록을 페이지별로 조회합니다.")
                                 .queryParameters(
                                         parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
@@ -82,7 +134,7 @@ class BookmarkControllerTest extends IntegrationTest {
                                 .build())
                 ))
                 .when()
-                .get("/api/v1/bookmarks/hearits")
+                .get("/api/v2/bookmarks/hearits")
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .body("content.size()", equalTo(5));


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 북마크 구버전 v1&v2 동시 호환 가능하도록 추가
    - 기존 categoryColorCode를 depth없이 주고있었는데 BE 1.2.0 부터 category depth가 추가됨

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
BookmarkControllerTest의
- readBookmarkHearitsTest_v1
- readBookmarkHearitsTest_v2


## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #541 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 북마크 API 버전화 도입: 
    - GET /api/v1/bookmarks/hearits — 카테고리 정보를 categoryColor로 단순화한 목록 제공
    - GET /api/v2/bookmarks/hearits — 기존 카테고리 상세 포함 목록 제공
  - 엔드포인트 정리:
    - 생성: POST /api/v1/bookmarks/hearits/{hearitId}
    - 삭제: DELETE /api/v1/bookmarks/{bookmarkId}
- Documentation
  - V1/V2 별 API 문서 추가 및 응답 필드 차이 명시
- Tests
  - V1/V2 목록 조회 테스트 추가 및 데이터 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->