### PR TITLE
[AN] bug: 라이브러리에 하단재생바 안 붙는 문제 수정

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/api/BookmarkService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/BookmarkService.kt
@@ -10,7 +10,7 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface BookmarkService {
-    @GET("api/v1/bookmarks/hearits")
+    @GET("api/v2/bookmarks/hearits")
     suspend fun getBookmarks(
         @Query("page") page: Int?,
         @Query("size") size: Int?,

--- a/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/library/LibraryFragment.kt
@@ -1,13 +1,11 @@
 package com.onair.hearit.presentation.library
 
-import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
@@ -24,8 +22,6 @@ import com.onair.hearit.presentation.detail.PlayerDetailActivity
 import com.onair.hearit.presentation.login.LoginActivity
 import com.onair.hearit.presentation.main.MainActivity
 import com.onair.hearit.presentation.main.MainViewModel
-import com.onair.hearit.presentation.navigate
-import com.onair.hearit.presentation.toDetailResult
 
 class LibraryFragment :
     Fragment(),
@@ -37,14 +33,6 @@ class LibraryFragment :
     private val mainViewModel: MainViewModel by activityViewModels()
     private val viewModel: LibraryViewModel by viewModels { LibraryViewModelFactory() }
     private val bookmarkAdapter: BookmarkAdapter by lazy { BookmarkAdapter(this) }
-
-    private val playerDetailLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            viewModel.refreshBookmarks()
-            if (result.resultCode != Activity.RESULT_OK) return@registerForActivityResult
-            val detailResult = result.data.toDetailResult() ?: return@registerForActivityResult
-            (requireActivity() as MainActivity).apply { detailResult.navigate(this) }
-        }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -143,7 +131,7 @@ class LibraryFragment :
                 putExtra(AnalyticsParamKeys.SOURCE_NAME, PlayerDetailActivity.LIBRARY_SCREEN_ID)
                 putExtra(PREVIOUS_SCREEN_KEY, PlayerDetailActivity.LIBRARY_SCREEN_ID)
             }
-        playerDetailLauncher.launch(intent)
+        (activity as? MainActivity)?.launchDetailActivity(intent)
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 앱 처음 진입했을 때 라이브러리에서 북마크된 히어릿 눌러서 들어가면 하단 재생바 안 붙는 오류 수정

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#543 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 상세 화면 이동을 액티비티 위임 방식으로 단순화하여 화면 전환의 일관성과 안정성을 개선했습니다.
  - 불필요한 결과 콜백을 제거해 북마크 목록 사용 중 성능과 응답성을 향상했습니다.
- Chores
  - 백엔드 API v2와 호환되도록 통신을 업데이트하여 서비스 신뢰성과 향후 확장성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->