### PR TITLE
[BE] fix: actuator 관련 api는 모두 로깅에서 제외되도록 수정 #546

### DIFF
--- a/backend/src/main/java/com/onair/hearit/log/RequestLoggingFilter.java
+++ b/backend/src/main/java/com/onair/hearit/log/RequestLoggingFilter.java
@@ -31,7 +31,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             "/api/v1/admin/**",
             "/favicon.ico",
             "/.well-known/**",
-            "/actuator/health"
+            "/actuator/**"
     );
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
actuator 관련 api 모두 로깅에서 제외하도록 수정
- "actuator/health"는 제외됐었으나 "/actuator/metrics/hikaricp.connections.max"는 계속 찍히고 있었음
- 제외 경로를 /actuator/health -> /actuator/**로 수정함

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 모니터링용 엔드포인트(Actuator) 전체를 요청 로그 수집 대상에서 제외했습니다. 이로써 관리 콘솔/상태 확인 등 빈번한 내부 트래픽이 로그에 기록되지 않아 로그 노이즈와 저장 비용이 감소합니다. 로그 탐색성이 향상되고 운영 환경에서의 성능·안정성에 긍정적인 영향을 줄 수 있습니다. 일반 사용자 기능과 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->