### PR TITLE
[BE] feat: 비회원/회원 인증예외 메시지에 구분 필드 추가 #549 - 아직머지금지

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -9,8 +9,9 @@ import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
+import com.onair.hearit.common.exception.custom.ForbiddenException;
 import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.exception.custom.UnauthenticatedException;
 import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlaytimeProjection;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
@@ -67,14 +68,14 @@ public class BookmarkService {
         Bookmark bookmark = getBookmarkById(bookmarkId);
         Member member = getMemberByUserInfo(userInfo);
         if (!bookmark.isCreatedBy(member)) {
-            throw new UnauthorizedException("북마크를 삭제할 권한이 없습니다.");
+            throw new ForbiddenException("북마크를 삭제할 권한이 없습니다.");
         }
         bookmarkRepository.delete(bookmark);
     }
 
     private Member getMemberByUserInfo(UserInfo userInfo) {
         if (userInfo == null || userInfo.isGuest()) {
-            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+            throw new UnauthenticatedException();
         }
         return getMemberById(userInfo.getMemberId());
     }

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
@@ -9,7 +9,7 @@ import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.exception.custom.UnauthenticatedException;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
@@ -75,7 +75,7 @@ public class HearitSearchService {
 
     private Member getMemberByUserInfo(UserInfo useruserInfo) {
         if (useruserInfo == null || useruserInfo.isGuest()) {
-            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+            throw new UnauthenticatedException();
         }
         return getMemberById(useruserInfo.getMemberId());
     }

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -16,7 +16,7 @@ import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.exception.custom.UnauthenticatedException;
 import com.onair.hearit.common.infrastructure.dto.HearitWithPlayTimeProjection;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
@@ -107,7 +107,7 @@ public class HearitService {
 
     private Member getMemberByUserInfo(UserInfo userInfo) {
         if (userInfo == null || userInfo.isGuest()) {
-            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+            throw new UnauthenticatedException();
         }
         return getMemberById(userInfo.getMemberId());
     }

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -36,39 +36,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
-        String header = request.getHeader("Authorization");
-        String token = extractTokenFromHeader(header);
+        String token = extractTokenFromHeader(request.getHeader("Authorization"));
 
         // 화이트리스트면 그냥 통과
-        if ((token == null || token.isBlank()) && isWhitelisted(request)) {
-            String deviceUuid = request.getHeader(DEVICE_UUID_HEADER);
-            UsernamePasswordAuthenticationToken auth =
-                    new UsernamePasswordAuthenticationToken(RequestUser.guest(deviceUuid), null, null);
-            SecurityContextHolder.getContext().setAuthentication(auth);
+        if (isWhitelisted(request) && (token == null || token.isBlank())) {
+            authenticateAsGuest(request);
             chain.doFilter(request, response);
             return;
         }
 
+        if (token == null) {
+            handleUnauthenticatedError(response, request);
+            return;
+        }
         if (!jwtTokenProvider.validateToken(token)) {
-            ProblemDetail problemDetail = buildProblemDetail(ErrorCode.UNAUTHORIZED, "유효하지 않은 토큰입니다.", request);
-            writeProblemDetailResponse(response, problemDetail);
-            filterExceptionLogger.warn(problemDetail);
+            handleInvalidTokenError(response, request);
             return;
         }
 
-        Long memberId = jwtTokenProvider.getMemberId(token);
-        RequestUser requestUser = RequestUser.member(memberId);
-
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(requestUser, null, Collections.emptyList());
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
+        authenticateAsMember(token);
         chain.doFilter(request, response);
-    }
-
-    private boolean isWhitelisted(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return whitelist.stream().anyMatch(pattern -> pathMatcher.match(pattern, path));
     }
 
     private String extractTokenFromHeader(String header) {
@@ -78,10 +65,44 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return header.substring("Bearer ".length());
     }
 
+    private boolean isWhitelisted(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return whitelist.stream().anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+    private void authenticateAsGuest(HttpServletRequest request) {
+        String deviceUuid = request.getHeader(DEVICE_UUID_HEADER);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(RequestUser.guest(deviceUuid), null, null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    private void handleUnauthenticatedError(HttpServletResponse response, HttpServletRequest request)
+            throws IOException {
+        ProblemDetail problemDetail = buildProblemDetail(ErrorCode.UNAUTHENTICATED, "토큰이 존재하지 않습니다.", request);
+        writeProblemDetailResponse(response, problemDetail);
+        filterExceptionLogger.warn(problemDetail);
+    }
+
+    private void handleInvalidTokenError(HttpServletResponse response, HttpServletRequest request) throws IOException {
+        ProblemDetail problemDetail = buildProblemDetail(ErrorCode.INVALID_ACCESS_TOKEN, "유효하지 않은 토큰입니다.", request);
+        writeProblemDetailResponse(response, problemDetail);
+        filterExceptionLogger.warn(problemDetail);
+    }
+
+    private void authenticateAsMember(String token) {
+        Long memberId = jwtTokenProvider.getMemberId(token);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(RequestUser.member(memberId), null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
     private ProblemDetail buildProblemDetail(ErrorCode errorCode, String detail, HttpServletRequest request) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(errorCode.getHttpStatus(), detail);
         problemDetail.setTitle(errorCode.getTitle());
         problemDetail.setType(URI.create(request.getRequestURI()));
+        problemDetail.setProperty("code", errorCode.name());
+        problemDetail.setProperty("reissuable", errorCode == ErrorCode.INVALID_ACCESS_TOKEN);
         return problemDetail;
     }
 

--- a/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
@@ -8,11 +8,16 @@ public enum ErrorCode {
 
     //CLIENT ERROR
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정보를 찾을 수 없습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
     BUFFER_OVERFLOW(HttpStatus.TOO_MANY_REQUESTS, "대기 중인 요청이 너무 많습니다."),
+
+    //CLIENT UNAUTHORIZED ERROR
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
+    UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 존재하지 않습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되거나 유효하지 않습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     //SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),

--- a/backend/src/main/java/com/onair/hearit/common/exception/custom/ForbiddenException.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/custom/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.onair.hearit.common.exception.custom;
+
+import com.onair.hearit.common.exception.ErrorCode;
+
+public class ForbiddenException extends HearitException {
+
+    public ForbiddenException(String detail) {
+        super(ErrorCode.FORBIDDEN, detail);
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/common/exception/custom/UnauthenticatedException.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/custom/UnauthenticatedException.java
@@ -1,0 +1,10 @@
+package com.onair.hearit.common.exception.custom;
+
+import com.onair.hearit.common.exception.ErrorCode;
+
+public class UnauthenticatedException extends HearitException {
+
+    public UnauthenticatedException() {
+        super(ErrorCode.UNAUTHENTICATED, "로그인한 회원이 아닙니다.");
+    }
+}

--- a/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
@@ -15,7 +15,8 @@ import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.exception.custom.ForbiddenException;
+import com.onair.hearit.common.exception.custom.UnauthenticatedException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
@@ -97,7 +98,7 @@ class BookmarkServiceTest {
 
         // when
         assertThatThrownBy(() -> bookmarkService.getBookmarkHearits(guestInfo, pagingRequest))
-                .isInstanceOf(UnauthorizedException.class);
+                .isInstanceOf(UnauthenticatedException.class);
     }
 
     @Test
@@ -157,7 +158,7 @@ class BookmarkServiceTest {
     }
 
     @Test
-    @DisplayName("북마크 삭제 시, 북마크를 한 멤버가 아니라면 UnauthorizedException을 던진다.")
+    @DisplayName("북마크 삭제 시, 북마크를 한 멤버가 아니라면 Forbidden을 던진다.")
     void deleteBookmark_UnauthorizedTest() {
         // given
         Member bookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
@@ -172,7 +173,7 @@ class BookmarkServiceTest {
         // when & then
         assertThatThrownBy(
                 () -> bookmarkService.deleteBookmark(bookmarkId, notBookmarkMemberInfo))
-                .isInstanceOf(UnauthorizedException.class)
+                .isInstanceOf(ForbiddenException.class)
                 .hasMessageContaining("북마크를 삭제할 권한이 없습니다.");
     }
 }

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -211,7 +211,7 @@ class BookmarkControllerTest extends IntegrationTest {
                                 .tag("Bookmark API")
                                 .summary("북마크 목록 조회")
                                 .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
                                 .build())
                 ))
                 .when()
@@ -312,7 +312,7 @@ class BookmarkControllerTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("자신의 북마크가 아닌 북마크 삭제 시, 401 UNAUTHORIZED를 반환한다.")
+    @DisplayName("자신의 북마크가 아닌 북마크 삭제 시, 403 FORBIDDEN을 반환한다.")
     void notFoundHearitId() {
         // given
         Member bookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
@@ -336,7 +336,7 @@ class BookmarkControllerTest extends IntegrationTest {
                 .when()
                 .delete("/api/v1/bookmarks/{bookmarkId}", bookmark.getId())
                 .then()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     private String generateToken(Member member) {

--- a/backend/src/test/java/com/onair/hearit/app/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/MemberControllerTest.java
@@ -78,7 +78,7 @@ class MemberControllerTest extends IntegrationTest {
                                 .summary("내 정보 조회")
                                 .description("현재 로그인한 사용자의 정보를 조회합니다.")
                                 .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
                                 .build()))
                 )
                 .when()

--- a/backend/src/test/java/com/onair/hearit/auth/config/ApiSecurityConfigTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/config/ApiSecurityConfigTest.java
@@ -1,7 +1,9 @@
 package com.onair.hearit.auth.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.domain.Member;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.contract.spec.internal.HttpStatus;
+import org.springframework.http.ProblemDetail;
 
 class ApiSecurityConfigTest extends IntegrationTest {
 
@@ -39,7 +42,7 @@ class ApiSecurityConfigTest extends IntegrationTest {
                 .get("/api/v1/bookmarks/hearits") // 인증 필요한 경로
                 .then().log().all()
                 .statusCode(HttpStatus.UNAUTHORIZED)
-                .body("detail", equalTo("유효하지 않은 토큰입니다."));
+                .body("detail", equalTo("토큰이 존재하지 않습니다."));
     }
 
     @Test
@@ -62,7 +65,7 @@ class ApiSecurityConfigTest extends IntegrationTest {
                 .get("/api/v1/bookmarks/hearits") // 인증 필요한 경로
                 .then().log().all()
                 .statusCode(HttpStatus.UNAUTHORIZED)
-                .body("detail", equalTo("유효하지 않은 토큰입니다."));
+                .body("detail", equalTo("토큰이 존재하지 않습니다."));
     }
 
     @Test
@@ -80,17 +83,24 @@ class ApiSecurityConfigTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("인증 실패 시 application/problem+json 형식으로 응답한다")
+    @DisplayName("인증 실패 시 application/problem+json 형식으로 응답하며 토큰재발급 여부를 위한 properties를 포함한다.")
     void returnProblemDetailOnAuthFailure() {
-        RestAssured.given().log().all()
+        ProblemDetail problemDetail = RestAssured.given().log().all()
                 .header("Authorization", "Bearer invalid-token")
                 .when()
                 .get("/api/v1/bookmarks/hearits") // 인증 필요한 경로
                 .then().log().all()
                 .statusCode(401)
                 .header("Content-Type", containsString("application/problem+json"))
-                .body("title", equalTo("인증되지 않은 요청입니다."))
-                .body("detail", equalTo("유효하지 않은 토큰입니다."));
+                .extract()
+                .as(ProblemDetail.class);
+
+        assertAll(
+                () -> assertThat(problemDetail.getTitle()).isEqualTo("엑세스 토큰이 만료되거나 유효하지 않습니다."),
+                () -> assertThat(problemDetail.getDetail()).isEqualTo("유효하지 않은 토큰입니다."),
+                () -> assertThat(problemDetail.getProperties().get("code")).isNotNull(),
+                () -> assertThat(problemDetail.getProperties().get("reissuable")).isNotNull()
+        );
     }
 
     private String generateToken(Member member) {

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -294,7 +294,7 @@ class AuthControllerTest extends IntegrationTest {
                                 .summary("엑세스토큰 유효성 검증")
                                 .description("엑세스토큰의 유효성을 검증합니다.")
                                 .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
                                 .build())
                 ))
                 .when()

--- a/backend/src/test/java/com/onair/hearit/docs/ApiDocSnippets.java
+++ b/backend/src/test/java/com/onair/hearit/docs/ApiDocSnippets.java
@@ -46,4 +46,21 @@ public class ApiDocSnippets {
                         .description("문제 유형에 대한 추가 세부 정보 (현재는 사용되지 않아 null)").optional()
         };
     }
+
+    public static FieldDescriptor[] getProblemDetailResponseFieldsWithAuthProperties() {
+        return new FieldDescriptor[]{
+                fieldWithPath("type").type(JsonFieldType.STRING).description("문제 유형을 식별하는 URI (요청 경로)"),
+                fieldWithPath("title").type(JsonFieldType.STRING).description("문제 유형에 대한 요약 (에러 코드 제목)"),
+                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                fieldWithPath("detail").type(JsonFieldType.STRING).description("문제 발생에 대한 상세 설명"),
+                fieldWithPath("instance").type(JsonFieldType.STRING)
+                        .description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
+                fieldWithPath("properties").type(JsonFieldType.OBJECT)
+                        .description("문제 유형에 대한 추가 세부 정보").optional(),
+                fieldWithPath("properties.code").type(JsonFieldType.STRING)
+                        .description("에러 코드 (예: UNAUTHENTICATED)"),
+                fieldWithPath("properties.reissuable").type(JsonFieldType.BOOLEAN)
+                        .description("토큰 재발급 가능 여부")
+        };
+    }
 }


### PR DESCRIPTION


<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- JwtAuthenticationFilter에서 회원/비회원 구분 시 ProblemDetail에 code, reissuable 필드 추가
- UnauthenticatedException, ForbiddenException 추가
  - 회원 예외(토큰이 있는데 만료되거나 유효하지 않은 경우)와 비회원 예외(토큰이 없는 경우)를 구분하기 위함
  - 권한이 없는 경우를 구분하기 위함

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부
<img width="595" height="582" alt="스크린샷 2025-09-18 오후 6 24 20" src="https://github.com/user-attachments/assets/91603dd1-2b95-4541-b6a9-03eacb15ca95" />
<img width="594" height="567" alt="스크린샷 2025-09-18 오후 6 24 11" src="https://github.com/user-attachments/assets/bb89adb6-70f5-4cea-b406-15010fc7daeb" />
<img width="596" height="499" alt="스크린샷 2025-09-18 오후 6 26 01" src="https://github.com/user-attachments/assets/74064c95-7460-4a23-a808-dc44a1a653eb" />

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #549 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 인증/인가 오류 유형을 세분화하여 미인증, 유효하지 않은 토큰, 권한 없음 등 명확한 상태 코드·메시지를 제공합니다.
- 버그 수정
  - 미인증 요청에 401, 권한 없는 동작에 403을 정확히 반환하도록 수정하고 누락된 토큰 처리와 오류 응답 일관성을 개선했습니다.
- 문서/테스트
  - 문제 응답 스펙에 인증 관련 속성(code, reissuable)을 추가하고 관련 테스트·문서 스니펫을 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->