### PR TITLE
[BE] refactor: 재생 기록 저장 주기를 5초에서 2초로 수정 #555

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
@@ -28,7 +28,7 @@ public class PlayingHistoryBuffer {
     }
 
     @Transactional
-    @Scheduled(fixedDelay = 5000)
+    @Scheduled(fixedDelay = 2000)
     public void flush() {
         if (!queue.isEmpty()) {
             List<PlayingHistory> batchRecords = new ArrayList<>();


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
재생 기록 저장 주기를 5초에서 2초로 변경
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#555 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 서버 측 처리 주기를 단축해 플레이 기록이 더 자주 반영됩니다. 앱의 재생 이력, 통계, 최근 재생 화면이 한층 빠르게 최신 상태로 업데이트되어 실시간성이 개선됩니다. 기능 동작 변화는 없으며 안정성 영향 없이 처리 빈도만 증가했습니다. 대량 삽입 단위와 처리량은 기존과 동일하고, 사용자는 별도 조치 없이 개선 효과를 누릴 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->