### PR TITLE
[BE] fix: 히어릿 총 재생 시간에 패딩 1초 추가 #560

### DIFF
--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -61,12 +61,12 @@ public class PlayingHistory {
     }
 
     private boolean checkIsFinished(Hearit hearit, long lastPlayTime) {
-        return lastPlayTime >= (long) (hearit.getPlayTime()
-                + LAST_PLAY_TIME_PADDING - FINISHED_TIME_RANGE) * MILLISECONDS_PER_SECOND;
+        return lastPlayTime >= (long) (hearit.getPlayTime() - FINISHED_TIME_RANGE) * MILLISECONDS_PER_SECOND;
     }
 
     private void validateHearitPlayTime(Hearit hearit, long lastPlayTime) {
-        if (lastPlayTime < 0 || lastPlayTime > hearit.getPlayTime() * MILLISECONDS_PER_SECOND) {
+        if (lastPlayTime < 0 ||
+                lastPlayTime > (long) (hearit.getPlayTime() + LAST_PLAY_TIME_PADDING) * MILLISECONDS_PER_SECOND) {
             throw new InvalidInputException("마지막 재생 시간은 히어릿의 총 재생 시간보다 작아야 합니다");
         }
     }

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -29,6 +29,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class PlayingHistory {
 
     private static final int FINISHED_TIME_RANGE = 10;
+    private static final int LAST_PLAY_TIME_PADDING = 1;
     private static final int MILLISECONDS_PER_SECOND = 1_000;
 
     @Id
@@ -60,7 +61,8 @@ public class PlayingHistory {
     }
 
     private boolean checkIsFinished(Hearit hearit, long lastPlayTime) {
-        return lastPlayTime >= (long) (hearit.getPlayTime() - FINISHED_TIME_RANGE) * MILLISECONDS_PER_SECOND;
+        return lastPlayTime >= (long) (hearit.getPlayTime()
+                + LAST_PLAY_TIME_PADDING - FINISHED_TIME_RANGE) * MILLISECONDS_PER_SECOND;
     }
 
     private void validateHearitPlayTime(Hearit hearit, long lastPlayTime) {

--- a/backend/src/test/java/com/onair/hearit/common/domain/PlayingHistoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/domain/PlayingHistoryTest.java
@@ -10,13 +10,16 @@ import org.junit.jupiter.api.Test;
 class PlayingHistoryTest {
 
     @Test
-    @DisplayName("재생 기록의 마지막 시간은 히어릿의 총 재생 시간보다 작아야 한다")
+    @DisplayName("재생 기록의 마지막 시간은 히어릿의 '총 재생 시간+1초' 보다 작아야 한다")
     void validateHearitPlayTime() {
         // given
-        Hearit hearit = createHearitWith(100);
+        int MILLISECONDS_PER_SECOND = 1_000;
+        int playTime = 100;
+        long lastPlayTime = (playTime + 2) * MILLISECONDS_PER_SECOND;
+        Hearit hearit = createHearitWith(playTime);
 
         // when & then
-        assertThatThrownBy(() -> new PlayingHistory(1L, hearit, 101_000));
+        assertThatThrownBy(() -> new PlayingHistory(1L, hearit, lastPlayTime));
     }
 
     @Test


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- lastPlayTime과 totalPlayTime 시간 단위 불일치로 인한 1초 패딩 추가합니다.

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #560 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 최근 재생 시간 허용 범위를 1초 단위로 소폭 확장하여 경계값에서의 잘못된 미완료 판정을 줄였습니다.
  - 재생 기록의 완료 판정 로직이 경계 상황에서 더 일관되게 처리되어 재생 상태 불일치가 완화됩니다.
  - 히스토리 기반 화면 갱신 및 완료 배지 표시 등 관련 기능의 표시 정확도가 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->