### PR TITLE
[BE] chore: 인증 관련 로그 추가 및 로그레벨 조정 #553

### DIFF
--- a/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
+++ b/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
@@ -76,7 +76,7 @@ public class AuthService {
         Member member = memberRepository.findBySocialIdAndOAuthProvider(userInfo.id(), provider)
                 .orElseGet(() -> signupWithUserInfo(userInfo, provider));
         LoginTokenResponse loginTokenResponse = createTokenResponseFrom(member);
-        log.warn("memberId:{}가 {} 로그인 성공", member.getId(), provider.name());
+        log.info("memberId:{}가 {} 로그인 성공", member.getId(), provider.name());
         return loginTokenResponse;
     }
 
@@ -120,14 +120,10 @@ public class AuthService {
 
     private void validateRefreshToken(String refreshToken, Long memberId) {
         RefreshToken stored = refreshTokenRepository.findByMemberId(memberId)
-                .orElseThrow(() -> {
-                    log.warn("memberId={} 저장된 리프레시토큰 없음", memberId);
-                    return new UnauthorizedException("저장된 토큰이 없습니다.");
-                });
+                .orElseThrow(() -> new UnauthorizedException("memberId:" + memberId + "의 저장된 토큰이 없습니다."));
 
         if (!stored.getToken().equals(refreshToken)) {
-            log.warn("memberId={} 저장된 토큰과 요청 토큰 불일치", memberId);
-            throw new UnauthorizedException("리프레시 토큰이 불일치합니다.");
+            throw new UnauthorizedException("memberId:" + memberId + "의 리프레시 토큰이 불일치합니다.");
         }
     }
 

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -89,6 +89,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UsernamePasswordAuthenticationToken auth =
                 new UsernamePasswordAuthenticationToken(RequestUser.guest(deviceUuid), null, null);
         SecurityContextHolder.getContext().setAuthentication(auth);
+        log.info("비회원으로 접속 완료, deviceUuid={}", deviceUuid);
+    }
+
+    private void authenticateAsMember(String token) {
+        Long memberId = jwtTokenProvider.getMemberId(token);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(RequestUser.member(memberId), null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        log.info("회원으로 인증 완료, memberId={}", memberId);
     }
 
     private void handleUnauthenticatedError(HttpServletResponse response, HttpServletRequest request)
@@ -108,13 +117,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         ProblemDetail problemDetail = buildProblemDetail(ErrorCode.INVALID_ACCESS_TOKEN, "유효하지 않은 토큰입니다.", request);
         writeProblemDetailResponse(response, problemDetail);
         filterExceptionLogger.warn(problemDetail);
-    }
-
-    private void authenticateAsMember(String token) {
-        Long memberId = jwtTokenProvider.getMemberId(token);
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(RequestUser.member(memberId), null, Collections.emptyList());
-        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     private ProblemDetail buildProblemDetail(ErrorCode errorCode, String detail, HttpServletRequest request) {

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -72,7 +72,7 @@ public class JwtTokenProvider {
             parseClaims(token);
             return true;
         } catch (JwtException e) {
-            log.warn("validateToken() failed: {}", e.getMessage());
+            log.info("validateToken() failed: {}", e.getMessage());
             return false;
         }
     }

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
@@ -230,7 +230,7 @@ class AuthServiceTest {
                 // when & then
                 assertThatThrownBy(() -> authService.reissue(refreshTokenValue))
                         .isInstanceOf(UnauthorizedException.class)
-                        .hasMessage("저장된 토큰이 없습니다.");
+                        .hasMessageContaining("저장된 토큰이 없습니다.");
             }
 
             @Test
@@ -249,7 +249,7 @@ class AuthServiceTest {
                 // when & then
                 assertThatThrownBy(() -> authService.reissue(refreshTokenValue))
                         .isInstanceOf(UnauthorizedException.class)
-                        .hasMessage("리프레시 토큰이 불일치합니다.");
+                        .hasMessageContaining("리프레시 토큰이 불일치합니다.");
             }
         }
     }


### PR DESCRIPTION


<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->


## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- JwtAuthenticationFilter + AuthService 로깅 추가
- 로그레벨 잘못되어있는 부분 수정, 중복로깅 제거

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #553 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 토큰 검증 실패 시 예외 메시지에 memberId를 포함해 오류 응답이 더 구체적으로 표시됩니다.
  - 로그인 성공 및 일부 토큰 검증 관련 로그 레벨을 정리해 메시지 가독성을 개선했습니다.
- Chores
  - 게스트/회원 인증 시 식별 정보(deviceUuid/memberId) 로그를 추가해 관찰성을 높였습니다.
  - 불필요한 경고 로그를 제거해 로그 노이즈를 감소시켰습니다.
- Tests
  - 관련 단위테스트의 오류 메시지 검증을 부분 일치로 완화해 테스트 유연성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->