### PR TITLE
[BE] fix: 화이트리스트면 그냥 통과가 아닌 token이 비어있을 때만 통과하도록 수정 #563

### DIFF
--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -39,20 +39,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = extractTokenFromHeader(request.getHeader("Authorization"));
 
         // 화이트리스트면 그냥 통과
-        if (isWhitelisted(request)) {
-            handleWhitelistedRequest(request, token);
+        if ((token == null || token.isBlank()) && isWhitelisted(request)) {
+            authenticateAsGuest(request);
             chain.doFilter(request, response);
             return;
         }
 
-        //인증이 필요한 엔드포인트 처리
-        if (token == null) {
-            handleUnauthenticatedError(response, request);
-            return;
-        }
-
+        // 토큰이 헤더에 존재하거나 인증이 필요한 엔드포인트 처리
         TokenStatus tokenStatus = jwtTokenProvider.getTokenStatus(token);
         switch (tokenStatus) {
+            case NOT_EXIST -> handleAuthenticatedRequiredError(response, request);
             case EXPIRED -> handleTokenExpiredError(response, request);
             case INVALID -> handleInvalidTokenError(response, request);
             case VALID -> {
@@ -60,16 +56,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 chain.doFilter(request, response);
             }
         }
-    }
-
-    private void handleWhitelistedRequest(HttpServletRequest request, String token) {
-        if (token == null || token.isBlank() || !jwtTokenProvider.validateToken(token)) {
-            // 토큰이 없거나 잘못된 토큰 → 게스트로 인증
-            authenticateAsGuest(request);
-            return;
-        }
-        // 유효한 토큰 → 회원으로 인증
-        authenticateAsMember(token);
     }
 
     private String extractTokenFromHeader(String header) {
@@ -91,7 +77,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
-    private void handleUnauthenticatedError(HttpServletResponse response, HttpServletRequest request)
+    private void handleAuthenticatedRequiredError(HttpServletResponse response, HttpServletRequest request)
             throws IOException {
         ProblemDetail problemDetail = buildProblemDetail(ErrorCode.AUTHENTICATION_REQUIRED, "인증이 필요한 요청입니다.", request);
         writeProblemDetailResponse(response, problemDetail);

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -79,7 +79,7 @@ public class JwtTokenProvider {
 
     public TokenStatus getTokenStatus(String token) {
         if (token == null || token.isBlank()) {
-            return TokenStatus.INVALID;
+            return TokenStatus.NOT_EXIST;
         }
 
         try {

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/TokenStatus.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/TokenStatus.java
@@ -1,5 +1,5 @@
 package com.onair.hearit.auth.infrastructure.jwt;
 
 public enum TokenStatus {
-    VALID, INVALID, EXPIRED
+    VALID, INVALID, EXPIRED, NOT_EXIST
 }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
회원이 만료된 액세스 토큰을 헤더에 담아 요청할 경우 일관적으로 401 Unauthorized 를 반환하도록 개선

- TokenStatus enum에 NOT_EXIST 상태 추가
- JwtTokenProvider.getTokenStatus()에서 null 또는 blank 토큰은 INVALID → NOT_EXIST 으로 반환하도록 수정
- JwtAuthenticationFilter에서 토큰 상태에 따라 분기 처리:
    - NOT_EXIST: 인증 필요 에러 처리
    - EXPIRED: 만료된 토큰 에러 처리
    - INVALID: 잘못된 토큰 에러 처리
    - VALID: 정상 처리

## 📸 스크린샷 (선택)
- whilelist api인 /api/v1/hearits/explore에서 토큰 담아 보내면 이제 401 뜸요 
<img width="593" height="570" alt="image" src="https://github.com/user-attachments/assets/cd7a0e81-e7f5-4a53-9626-065d9309869b" />

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #563 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 공개 엔드포인트에서 토큰이 없으면 자동으로 게스트로 접근이 허용됩니다.
  - 토큰 부재 상태를 별도로 인식해 “인증 필요” 응답을 명확히 제공합니다.
- Bug Fixes
  - 유효하지 않은 토큰으로 공개 엔드포인트 접근 시 게스트로 처리되던 문제를 수정하여 적절한 오류를 반환합니다.
  - 오류 응답 로깅을 개선해 문제 진단이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->