### PR TITLE
[BE] refactor: 버저닝 api controller 코드 가독성 개선 #558

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -96,7 +96,7 @@ swaggerSources {
 
 openapi3 {
     servers = [
-            { url = "http://localhost:80"; description = "로컬 서버" },
+            { url = "http://localhost:8080"; description = "로컬 서버" },
             { url = "https://hearit.o-r.kr"; description = "운영 서버" },
             { url = "https://hearit-dev.o-r.kr"; description = "개발 서버" }
     ]

--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -1,9 +1,8 @@
 package com.onair.hearit.app.application;
 
 import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV2;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
-import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
@@ -31,7 +30,7 @@ public class BookmarkService {
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public PagedResponse<BookmarkHearitResponse> getBookmarkHearits(
+    public Page<BookmarkHearitResponseV2> getBookmarkHearits(
             UserInfo userInfo,
             PagingRequest pagingRequest) {
         Member member = getMemberByUserInfo(userInfo);
@@ -39,12 +38,11 @@ public class BookmarkService {
         Page<BookmarkWithPlaytimeProjection> projections = bookmarkRepository.findAllByMemberOrderByRecent(
                 member.getId(),
                 pageable);
-        Page<BookmarkHearitResponse> response = toBookmarkHearitResponse(projections);
-        return PagedResponse.from(response);
+        return toBookmarkHearitResponse(projections);
     }
 
-    private Page<BookmarkHearitResponse> toBookmarkHearitResponse(Page<BookmarkWithPlaytimeProjection> projections) {
-        return projections.map(p -> BookmarkHearitResponse.of(
+    private Page<BookmarkHearitResponseV2> toBookmarkHearitResponse(Page<BookmarkWithPlaytimeProjection> projections) {
+        return projections.map(p -> BookmarkHearitResponseV2.of(
                 p.getBookmark(),
                 p.getBookmark().getHearit(),
                 p.getLastPlayTime()

--- a/backend/src/main/java/com/onair/hearit/app/application/explore/HearitExploreService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/explore/HearitExploreService.java
@@ -2,7 +2,7 @@ package com.onair.hearit.app.application.explore;
 
 import com.onair.hearit.app.application.explore.scoreprocessor.ExploreScoreProcessor;
 import com.onair.hearit.app.dto.request.CursorRequest;
-import com.onair.hearit.app.dto.response.CursorResponse;
+import com.onair.hearit.app.dto.response.CursorResponseV2;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.common.domain.UserInfo;
 import java.util.List;
@@ -15,15 +15,15 @@ public class HearitExploreService {
 
     private final List<ExploreScoreProcessor> exploreScoreProcessors;
 
-    public CursorResponse<ExploredHearitResponse> getExploredHearits(UserInfo userInfo,
-                                                                     CursorRequest cursorRequest) {
+    public CursorResponseV2<ExploredHearitResponse> getExploredHearits(UserInfo userInfo,
+                                                                       CursorRequest cursorRequest) {
         ExploreScoreProcessor exploreScoreProcessor = getExploreScoreProcessor(userInfo);
         List<ExploredHearitResponse> exploreHearitsResponses =
                 exploreScoreProcessor.getExploreHearitsResponse(
                         userInfo,
                         cursorRequest.cursorId(),
                         cursorRequest.size());
-        return CursorResponse.from(exploreHearitsResponses);
+        return CursorResponseV2.from(exploreHearitsResponses);
     }
 
     private ExploreScoreProcessor getExploreScoreProcessor(UserInfo userInfo) {

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV1.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV1.java
@@ -9,15 +9,15 @@ public record BookmarkHearitResponseV1(
         Long lastPlayTime,
         String categoryColor
 ) {
-    public static BookmarkHearitResponseV1 from(BookmarkHearitResponse bookmarkHearitResponse) {
-        BookmarkHearitResponse.CategoryResponse category = bookmarkHearitResponse.category();
+    public static BookmarkHearitResponseV1 from(BookmarkHearitResponseV2 bookmarkHearitResponseV2) {
+        BookmarkHearitResponseV2.CategoryResponse category = bookmarkHearitResponseV2.category();
         return new BookmarkHearitResponseV1(
-                bookmarkHearitResponse.hearitId(),
-                bookmarkHearitResponse.bookmarkId(),
-                bookmarkHearitResponse.title(),
-                bookmarkHearitResponse.summary(),
-                bookmarkHearitResponse.playTime(),
-                bookmarkHearitResponse.lastPlayTime(),
+                bookmarkHearitResponseV2.hearitId(),
+                bookmarkHearitResponseV2.bookmarkId(),
+                bookmarkHearitResponseV2.title(),
+                bookmarkHearitResponseV2.summary(),
+                bookmarkHearitResponseV2.playTime(),
+                bookmarkHearitResponseV2.lastPlayTime(),
                 category.colorCode()
         );
     }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV2.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV2.java
@@ -4,7 +4,7 @@ import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 
-public record BookmarkHearitResponse(
+public record BookmarkHearitResponseV2(
         Long hearitId,
         Long bookmarkId,
         String title,
@@ -13,8 +13,8 @@ public record BookmarkHearitResponse(
         Long lastPlayTime,
         CategoryResponse category
 ) {
-    public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit, Long lastPlayTime) {
-        return new BookmarkHearitResponse(
+    public static BookmarkHearitResponseV2 of(Bookmark bookmark, Hearit hearit, Long lastPlayTime) {
+        return new BookmarkHearitResponseV2(
                 hearit.getId(),
                 bookmark.getId(),
                 hearit.getTitle(),

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV1.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV1.java
@@ -7,12 +7,12 @@ public record CursorResponseV1<T>(
         boolean isEmpty,
         long cursorId
 ) {
-    public static <T> CursorResponseV1<T> from(CursorResponse<T> cursorResponse) {
-        List<T> contents = cursorResponse.content();
+    public static <T> CursorResponseV1<T> from(CursorResponseV2<T> cursorResponseV2) {
+        List<T> contents = cursorResponseV2.content();
         long cursorId = 0L;
-        if(!contents.isEmpty()) {
+        if (!contents.isEmpty()) {
             ExploredHearitResponse last = (ExploredHearitResponse) contents.getLast();
-            cursorId = last.cursorId();;
+            cursorId = last.cursorId();
         }
         return new CursorResponseV1<>(
                 contents,

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV2.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV2.java
@@ -2,12 +2,12 @@ package com.onair.hearit.app.dto.response;
 
 import java.util.List;
 
-public record CursorResponse<T>(
+public record CursorResponseV2<T>(
         List<T> content,
         boolean isEmpty
 ) {
-    public static <T> CursorResponse<T> from(List<T> cursorResult) {
-        return new CursorResponse<>(
+    public static <T> CursorResponseV2<T> from(List<T> cursorResult) {
+        return new CursorResponseV2<>(
                 cursorResult,
                 cursorResult.isEmpty()
         );

--- a/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
@@ -1,6 +1,5 @@
 package com.onair.hearit.app.presentation;
 
-
 import com.onair.hearit.app.application.BookmarkService;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.BookmarkHearitResponseV1;
@@ -17,18 +16,16 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
-    @GetMapping("/v1/bookmarks/hearits")
+    @GetMapping("/api/v1/bookmarks/hearits")
     public ResponseEntity<PagedResponse<BookmarkHearitResponseV1>> readBookmarkHearitsV1(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
@@ -40,7 +37,7 @@ public class BookmarkController {
         return ResponseEntity.ok(PagedResponse.from(v1Responses));
     }
 
-    @GetMapping("/v2/bookmarks/hearits")
+    @GetMapping("/api/v2/bookmarks/hearits")
     public ResponseEntity<PagedResponse<BookmarkHearitResponseV2>> readBookmarkHearitsV2(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
@@ -52,7 +49,7 @@ public class BookmarkController {
         return ResponseEntity.ok(PagedResponse.from(bookmarkHearits));
     }
 
-    @PostMapping("/v1/bookmarks/hearits/{hearitId}")
+    @PostMapping("/api/v1/bookmarks/hearits/{hearitId}")
     public ResponseEntity<BookmarkInfoResponse> createBookmark(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -60,7 +57,7 @@ public class BookmarkController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @DeleteMapping("/v1/bookmarks/{bookmarkId}")
+    @DeleteMapping("/api/v1/bookmarks/{bookmarkId}")
     public ResponseEntity<Void> deleteBookmark(
             @PathVariable Long bookmarkId,
             @AuthenticationPrincipal RequestUser requestUser) {

--- a/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
@@ -3,13 +3,13 @@ package com.onair.hearit.app.presentation;
 
 import com.onair.hearit.app.application.BookmarkService;
 import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
 import com.onair.hearit.app.dto.response.BookmarkHearitResponseV1;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV2;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.auth.domain.RequestUser;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -34,34 +34,22 @@ public class BookmarkController {
             @RequestParam(name = "size", defaultValue = "20") int size,
             @AuthenticationPrincipal RequestUser requestUser) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        PagedResponse<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(requestUser.getUserInfo(),
-                pagingRequest);
-        List<BookmarkHearitResponse> contents = responses.content();
-        List<BookmarkHearitResponseV1> v1Contents = contents.stream()
-                .map(BookmarkHearitResponseV1::from)
-                .toList();
-        PagedResponse<BookmarkHearitResponseV1> v1Responses =
-                new PagedResponse<>(
-                        v1Contents,
-                        responses.page(),
-                        responses.size(),
-                        responses.totalPages(),
-                        responses.totalElements(),
-                        responses.isFirst(),
-                        responses.isLast()
-                );
-        return ResponseEntity.ok(v1Responses);
+        Page<BookmarkHearitResponseV2> v2Responses = bookmarkService.getBookmarkHearits(
+                requestUser.getUserInfo(), pagingRequest);
+        Page<BookmarkHearitResponseV1> v1Responses = v2Responses.map(BookmarkHearitResponseV1::from);
+        return ResponseEntity.ok(PagedResponse.from(v1Responses));
     }
 
     @GetMapping("/v2/bookmarks/hearits")
-    public ResponseEntity<PagedResponse<BookmarkHearitResponse>> readBookmarkHearitsV2(
+    public ResponseEntity<PagedResponse<BookmarkHearitResponseV2>> readBookmarkHearitsV2(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
             @AuthenticationPrincipal RequestUser requestUser) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        PagedResponse<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(requestUser.getUserInfo(),
+        Page<BookmarkHearitResponseV2> bookmarkHearits = bookmarkService.getBookmarkHearits(
+                requestUser.getUserInfo(),
                 pagingRequest);
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(PagedResponse.from(bookmarkHearits));
     }
 
     @PostMapping("/v1/bookmarks/hearits/{hearitId}")

--- a/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
@@ -69,7 +69,7 @@ public class HearitController {
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/v1/hearits/search")
+    @GetMapping("/api/v1/hearits/search")
     public ResponseEntity<PagedResponse<HearitSearchResponse>> readSearchedHearits(
             @RequestParam(name = "searchTerm") String searchTerm,
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -81,7 +81,7 @@ public class HearitController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v1/hearits/recommend-category")
+    @GetMapping("/api/v1/hearits/recommend-category")
     public ResponseEntity<List<HearitsWithRecommendCategoryResponse>> readHearitsWithRecommendCategory(
             @AuthenticationPrincipal RequestUser requestUser) {
         List<HearitsWithRecommendCategoryResponse> responses =
@@ -89,7 +89,7 @@ public class HearitController {
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/v1/hearits")
+    @GetMapping("/api/v1/hearits")
     public ResponseEntity<PagedResponse<HearitOfCategoryResponse>> readHearitsByCategory(
             @RequestParam(name = "categoryId") Long categoryId,
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
@@ -5,8 +5,8 @@ import com.onair.hearit.app.application.HearitService;
 import com.onair.hearit.app.application.explore.HearitExploreService;
 import com.onair.hearit.app.dto.request.CursorRequest;
 import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.CursorResponse;
 import com.onair.hearit.app.dto.response.CursorResponseV1;
+import com.onair.hearit.app.dto.response.CursorResponseV2;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
 import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
@@ -42,27 +42,27 @@ public class HearitController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v2/hearits/explore")
-    public ResponseEntity<CursorResponse<ExploredHearitResponse>> readExploredHearitsV2(
-            @AuthenticationPrincipal RequestUser requestUser,
-            @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
-            @RequestParam(name = "size", defaultValue = "10") int size) {
-        CursorRequest cursorRequest = new CursorRequest(cursorId, size);
-        CursorResponse<ExploredHearitResponse> responses =
-                hearitExploreService.getExploredHearits(requestUser.getUserInfo(), cursorRequest);
-        return ResponseEntity.ok(responses);
-    }
-
     @GetMapping("/v1/hearits/explore")
     public ResponseEntity<CursorResponseV1<ExploredHearitResponse>> readExploredHearitsV1(
             @AuthenticationPrincipal RequestUser requestUser,
             @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
             @RequestParam(name = "size", defaultValue = "10") int size) {
         CursorRequest cursorRequest = new CursorRequest(cursorId, size);
-        CursorResponse<ExploredHearitResponse> responses =
+        CursorResponseV2<ExploredHearitResponse> responses =
                 hearitExploreService.getExploredHearits(requestUser.getUserInfo(), cursorRequest);
         CursorResponseV1<ExploredHearitResponse> responsesV1 = CursorResponseV1.from(responses);
         return ResponseEntity.ok(responsesV1);
+    }
+
+    @GetMapping("/v2/hearits/explore")
+    public ResponseEntity<CursorResponseV2<ExploredHearitResponse>> readExploredHearitsV2(
+            @AuthenticationPrincipal RequestUser requestUser,
+            @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+        CursorRequest cursorRequest = new CursorRequest(cursorId, size);
+        CursorResponseV2<ExploredHearitResponse> responses =
+                hearitExploreService.getExploredHearits(requestUser.getUserInfo(), cursorRequest);
+        return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/v1/hearits/recommend")

--- a/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
@@ -21,20 +21,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
 public class HearitController {
 
     private final HearitService hearitService;
     private final HearitExploreService hearitExploreService;
     private final HearitSearchService hearitSearchService;
 
-    @GetMapping("/v1/hearits/{hearitId}")
+    @GetMapping("/api/v1/hearits/{hearitId}")
     public ResponseEntity<HearitDetailResponse> readHearit(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -42,7 +40,7 @@ public class HearitController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v1/hearits/explore")
+    @GetMapping("/api/v1/hearits/explore")
     public ResponseEntity<CursorResponseV1<ExploredHearitResponse>> readExploredHearitsV1(
             @AuthenticationPrincipal RequestUser requestUser,
             @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
@@ -54,7 +52,7 @@ public class HearitController {
         return ResponseEntity.ok(responsesV1);
     }
 
-    @GetMapping("/v2/hearits/explore")
+    @GetMapping("/api/v2/hearits/explore")
     public ResponseEntity<CursorResponseV2<ExploredHearitResponse>> readExploredHearitsV2(
             @AuthenticationPrincipal RequestUser requestUser,
             @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
@@ -65,7 +63,7 @@ public class HearitController {
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/v1/hearits/recommend")
+    @GetMapping("/api/v1/hearits/recommend")
     public ResponseEntity<List<RecommendHearitResponse>> readRecommendedHearits() {
         List<RecommendHearitResponse> responses = hearitService.getRecommendedHearits();
         return ResponseEntity.ok(responses);

--- a/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV2;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.auth.domain.RequestUser;
 import com.onair.hearit.common.domain.Bookmark;
@@ -73,8 +73,8 @@ class BookmarkServiceTest {
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
-        List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(
-                RequestUser.member(member.getId()).getUserInfo(), new PagingRequest(0, 20)).content();
+        List<BookmarkHearitResponseV2> responses = bookmarkService.getBookmarkHearits(
+                RequestUser.member(member.getId()).getUserInfo(), new PagingRequest(0, 20)).stream().toList();
 
         // then
         assertAll(() -> {

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitExploreServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitExploreServiceTest.java
@@ -10,7 +10,7 @@ import com.onair.hearit.app.application.explore.scorefactor.RecencyScoreFactor;
 import com.onair.hearit.app.application.explore.scoreprocessor.GuestExploreScoreProcessor;
 import com.onair.hearit.app.application.explore.scoreprocessor.MemberExploreScoreProcessor;
 import com.onair.hearit.app.dto.request.CursorRequest;
-import com.onair.hearit.app.dto.response.CursorResponse;
+import com.onair.hearit.app.dto.response.CursorResponseV2;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.auth.domain.RequestUser;
 import com.onair.hearit.common.domain.Bookmark;
@@ -120,7 +120,7 @@ class HearitExploreServiceTest {
         dbHelper.insertBookmark(new Bookmark(member, hearit));
 
         // when
-        CursorResponse<ExploredHearitResponse> exploredHearits = hearitExploreService.getExploredHearits(
+        CursorResponseV2<ExploredHearitResponse> exploredHearits = hearitExploreService.getExploredHearits(
                 RequestUser.member(member.getId()).getUserInfo(), new CursorRequest(0L, 10));
 
         // then
@@ -149,7 +149,7 @@ class HearitExploreServiceTest {
         dbHelper.insertHearit(createHearitByNameAndCategory("hearit10", category3));
 
         // when
-        CursorResponse<ExploredHearitResponse> exploredHearits = hearitExploreService.getExploredHearits(
+        CursorResponseV2<ExploredHearitResponse> exploredHearits = hearitExploreService.getExploredHearits(
                 RequestUser.guest(UUID.randomUUID().toString()).getUserInfo(), new CursorRequest(0L, 10));
 
         // then

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -9,8 +9,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.app.dto.response.CursorResponse;
 import com.onair.hearit.app.dto.response.CursorResponseV1;
+import com.onair.hearit.app.dto.response.CursorResponseV2;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
 import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
@@ -156,7 +156,7 @@ class HearitControllerTest extends IntegrationTest {
         String token = generateToken(member);
 
         // when
-        CursorResponse<ExploredHearitResponse> responses = RestAssured.given(this.spec)
+        CursorResponseV2<ExploredHearitResponse> responses = RestAssured.given(this.spec)
                 .header("Authorization", "Bearer " + token)
                 .queryParam("cursorId", 0)
                 .queryParam("size", 10)
@@ -204,7 +204,7 @@ class HearitControllerTest extends IntegrationTest {
         assertAll(() -> {
             assertThat(responses.content()).hasSize(3);
             assertThat(responses.content()).extracting(ExploredHearitResponse::cursorId)
-                            .containsExactly(1L, 2L, 3L);
+                    .containsExactly(1L, 2L, 3L);
             assertThat(responses.isEmpty()).isFalse();
         });
     }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

/api/v1/hearits/explore
/api/v1/bookmarks/hearits
controller 코드 개선
- v1, v2 dto class 이름에 명시
- 로직 가독성 개선

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#558 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 북마크 목록 API에 V2 응답 도입: 페이지 기반 응답이 BookmarkHearitResponseV2 형태로 제공됩니다.
  * 탐색 API에 V2 커서 응답 도입: CursorResponseV2로 간소화된 커서 페이징 제공.
  * V2 응답을 직접 제공하는 엔드포인트 추가 및 V1은 변환을 통해 호환 유지.

* Chores
  * 여러 엔드포인트 경로를 /api/... 형식으로 명시적으로 이동했습니다.

* Documentation
  * 로컬 OpenAPI 서버 URL을 http://localhost:8080 으로 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->