### PR TITLE
[BE] release version 1.2.1

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.onair'
-version = '1.2.0'
+version = '1.2.1'
 
 java {
     toolchain {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -96,7 +96,7 @@ swaggerSources {
 
 openapi3 {
     servers = [
-            { url = "http://localhost:80"; description = "로컬 서버" },
+            { url = "http://localhost:8080"; description = "로컬 서버" },
             { url = "https://hearit.o-r.kr"; description = "운영 서버" },
             { url = "https://hearit-dev.o-r.kr"; description = "개발 서버" }
     ]

--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -1,9 +1,8 @@
 package com.onair.hearit.app.application;
 
 import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV2;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
-import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
@@ -31,7 +30,7 @@ public class BookmarkService {
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
 
-    public PagedResponse<BookmarkHearitResponse> getBookmarkHearits(
+    public Page<BookmarkHearitResponseV2> getBookmarkHearits(
             UserInfo userInfo,
             PagingRequest pagingRequest) {
         Member member = getMemberByUserInfo(userInfo);
@@ -39,12 +38,11 @@ public class BookmarkService {
         Page<BookmarkWithPlaytimeProjection> projections = bookmarkRepository.findAllByMemberOrderByRecent(
                 member.getId(),
                 pageable);
-        Page<BookmarkHearitResponse> response = toBookmarkHearitResponse(projections);
-        return PagedResponse.from(response);
+        return toBookmarkHearitResponse(projections);
     }
 
-    private Page<BookmarkHearitResponse> toBookmarkHearitResponse(Page<BookmarkWithPlaytimeProjection> projections) {
-        return projections.map(p -> BookmarkHearitResponse.of(
+    private Page<BookmarkHearitResponseV2> toBookmarkHearitResponse(Page<BookmarkWithPlaytimeProjection> projections) {
+        return projections.map(p -> BookmarkHearitResponseV2.of(
                 p.getBookmark(),
                 p.getBookmark().getHearit(),
                 p.getLastPlayTime()

--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -9,8 +9,9 @@ import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
+import com.onair.hearit.common.exception.custom.ForbiddenException;
 import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.exception.custom.UnauthenticatedException;
 import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlaytimeProjection;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
@@ -67,14 +68,14 @@ public class BookmarkService {
         Bookmark bookmark = getBookmarkById(bookmarkId);
         Member member = getMemberByUserInfo(userInfo);
         if (!bookmark.isCreatedBy(member)) {
-            throw new UnauthorizedException("북마크를 삭제할 권한이 없습니다.");
+            throw new ForbiddenException("북마크를 삭제할 권한이 없습니다.");
         }
         bookmarkRepository.delete(bookmark);
     }
 
     private Member getMemberByUserInfo(UserInfo userInfo) {
         if (userInfo == null || userInfo.isGuest()) {
-            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+            throw new UnauthenticatedException();
         }
         return getMemberById(userInfo.getMemberId());
     }

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
@@ -4,6 +4,7 @@ import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.HearitSearchResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
@@ -16,6 +17,7 @@ import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,8 +29,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class HearitSearchService {
 
-    private static final int KEYWORD_PER_HEARIT = 3;
-
     private final HearitRepository hearitRepository;
     private final HearitKeywordRepository hearitKeywordRepository;
     private final MemberRepository memberRepository;
@@ -39,11 +39,10 @@ public class HearitSearchService {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> hearits = hearitRepository.searchByTerm(toBooleanModeQuery(searchTerm), pageable);
         if (userInfo == null || userInfo.isGuest()) {
-            return PagedResponse.from(hearits.map(this::toHearitSearchResponseForGuest));
+            return PagedResponse.from(toHearitSearchResponseForGuest(hearits));
         }
-
         Member member = getMemberByUserInfo(userInfo);
-        return PagedResponse.from(hearits.map(hearit -> toHearitSearchResponseForMember(hearit, member)));
+        return PagedResponse.from(toHearitSearchResponseForMember(hearits, member));
     }
 
     private String toBooleanModeQuery(String searchTerm) {
@@ -58,19 +57,32 @@ public class HearitSearchService {
         return token.replaceAll("[+\\-~<>()\"*@]", "");
     }
 
-    private HearitSearchResponse toHearitSearchResponseForGuest(Hearit hearit) {
-        List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
-                KEYWORD_PER_HEARIT);
-        return HearitSearchResponse.of(hearit, keywords, null);
+    private Page<HearitSearchResponse> toHearitSearchResponseForGuest(Page<Hearit> hearits) {
+        List<Long> hearitIds = hearits.getContent().stream().map(Hearit::getId).toList();
+        Map<Long, List<Keyword>> hearitKeywords = getHearitKeywords(hearitIds);
+        return hearits.map(hearit -> HearitSearchResponse.of(hearit, hearitKeywords.get(hearit.getId()), null));
     }
 
-    private HearitSearchResponse toHearitSearchResponseForMember(Hearit hearit, Member member) {
-        Long lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
-                .map(PlayingHistory::getLastPlayTime)
-                .orElse(null);
-        List<Keyword> keywords = hearitKeywordRepository.findRecentKeywordsByHearitId(hearit.getId(),
-                KEYWORD_PER_HEARIT);
-        return HearitSearchResponse.of(hearit, keywords, lastPlayTime);
+    private Page<HearitSearchResponse> toHearitSearchResponseForMember(Page<Hearit> hearits, Member member) {
+        List<Long> hearitIds = hearits.getContent().stream().map(Hearit::getId).toList();
+        Map<Long, List<Keyword>> hearitKeywords = getHearitKeywords(hearitIds);
+        Map<Long, Long> playingHistories =
+                playingHistoryRepository.findByMemberIdAndHearitIdIn(member.getId(), hearitIds)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                PlayingHistory::getHearitId,
+                                PlayingHistory::getLastPlayTime));
+        return hearits.map(hearit -> HearitSearchResponse.of(
+                hearit,
+                hearitKeywords.get(hearit.getId()),
+                playingHistories.get(hearit.getId())));
+    }
+
+    private Map<Long, List<Keyword>> getHearitKeywords(List<Long> hearitIds) {
+        return hearitKeywordRepository.findByHearitIdIn(hearitIds)
+                .stream()
+                .collect(Collectors.groupingBy(hk -> hk.getHearit().getId(),
+                        Collectors.mapping(HearitKeyword::getKeyword, Collectors.toList())));
     }
 
     private Member getMemberByUserInfo(UserInfo useruserInfo) {

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
@@ -9,7 +9,7 @@ import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.exception.custom.UnauthenticatedException;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
@@ -75,7 +75,7 @@ public class HearitSearchService {
 
     private Member getMemberByUserInfo(UserInfo useruserInfo) {
         if (useruserInfo == null || useruserInfo.isGuest()) {
-            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+            throw new UnauthenticatedException();
         }
         return getMemberById(useruserInfo.getMemberId());
     }

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -16,7 +16,7 @@ import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.exception.custom.UnauthenticatedException;
 import com.onair.hearit.common.infrastructure.dto.HearitWithPlayTimeProjection;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
@@ -107,7 +107,7 @@ public class HearitService {
 
     private Member getMemberByUserInfo(UserInfo userInfo) {
         if (userInfo == null || userInfo.isGuest()) {
-            throw new UnauthorizedException("로그인한 회원이 아닙니다.");
+            throw new UnauthenticatedException();
         }
         return getMemberById(userInfo.getMemberId());
     }

--- a/backend/src/main/java/com/onair/hearit/app/application/explore/HearitExploreService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/explore/HearitExploreService.java
@@ -2,7 +2,7 @@ package com.onair.hearit.app.application.explore;
 
 import com.onair.hearit.app.application.explore.scoreprocessor.ExploreScoreProcessor;
 import com.onair.hearit.app.dto.request.CursorRequest;
-import com.onair.hearit.app.dto.response.CursorResponse;
+import com.onair.hearit.app.dto.response.CursorResponseV2;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.common.domain.UserInfo;
 import java.util.List;
@@ -15,15 +15,15 @@ public class HearitExploreService {
 
     private final List<ExploreScoreProcessor> exploreScoreProcessors;
 
-    public CursorResponse<ExploredHearitResponse> getExploredHearits(UserInfo userInfo,
-                                                                     CursorRequest cursorRequest) {
+    public CursorResponseV2<ExploredHearitResponse> getExploredHearits(UserInfo userInfo,
+                                                                       CursorRequest cursorRequest) {
         ExploreScoreProcessor exploreScoreProcessor = getExploreScoreProcessor(userInfo);
         List<ExploredHearitResponse> exploreHearitsResponses =
                 exploreScoreProcessor.getExploreHearitsResponse(
                         userInfo,
                         cursorRequest.cursorId(),
                         cursorRequest.size());
-        return CursorResponse.from(exploreHearitsResponses);
+        return CursorResponseV2.from(exploreHearitsResponses);
     }
 
     private ExploreScoreProcessor getExploreScoreProcessor(UserInfo userInfo) {

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponse.java
@@ -24,7 +24,7 @@ public record BookmarkHearitResponse(
                 CategoryResponse.from(hearit.getCategory()));
     }
 
-    private record CategoryResponse(Long id, String name, String colorCode) {
+    public record CategoryResponse(Long id, String name, String colorCode) {
         public static CategoryResponse from(Category category) {
             return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
         }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV1.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV1.java
@@ -9,15 +9,15 @@ public record BookmarkHearitResponseV1(
         Long lastPlayTime,
         String categoryColor
 ) {
-    public static BookmarkHearitResponseV1 from(BookmarkHearitResponse bookmarkHearitResponse) {
-        BookmarkHearitResponse.CategoryResponse category = bookmarkHearitResponse.category();
+    public static BookmarkHearitResponseV1 from(BookmarkHearitResponseV2 bookmarkHearitResponseV2) {
+        BookmarkHearitResponseV2.CategoryResponse category = bookmarkHearitResponseV2.category();
         return new BookmarkHearitResponseV1(
-                bookmarkHearitResponse.hearitId(),
-                bookmarkHearitResponse.bookmarkId(),
-                bookmarkHearitResponse.title(),
-                bookmarkHearitResponse.summary(),
-                bookmarkHearitResponse.playTime(),
-                bookmarkHearitResponse.lastPlayTime(),
+                bookmarkHearitResponseV2.hearitId(),
+                bookmarkHearitResponseV2.bookmarkId(),
+                bookmarkHearitResponseV2.title(),
+                bookmarkHearitResponseV2.summary(),
+                bookmarkHearitResponseV2.playTime(),
+                bookmarkHearitResponseV2.lastPlayTime(),
                 category.colorCode()
         );
     }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV1.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV1.java
@@ -1,0 +1,24 @@
+package com.onair.hearit.app.dto.response;
+
+public record BookmarkHearitResponseV1(
+        Long hearitId,
+        Long bookmarkId,
+        String title,
+        String summary,
+        Integer playTime,
+        Long lastPlayTime,
+        String categoryColor
+) {
+    public static BookmarkHearitResponseV1 from(BookmarkHearitResponse bookmarkHearitResponse) {
+        BookmarkHearitResponse.CategoryResponse category = bookmarkHearitResponse.category();
+        return new BookmarkHearitResponseV1(
+                bookmarkHearitResponse.hearitId(),
+                bookmarkHearitResponse.bookmarkId(),
+                bookmarkHearitResponse.title(),
+                bookmarkHearitResponse.summary(),
+                bookmarkHearitResponse.playTime(),
+                bookmarkHearitResponse.lastPlayTime(),
+                category.colorCode()
+        );
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV2.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV2.java
@@ -4,7 +4,7 @@ import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 
-public record BookmarkHearitResponse(
+public record BookmarkHearitResponseV2(
         Long hearitId,
         Long bookmarkId,
         String title,
@@ -13,8 +13,8 @@ public record BookmarkHearitResponse(
         Long lastPlayTime,
         CategoryResponse category
 ) {
-    public static BookmarkHearitResponse of(Bookmark bookmark, Hearit hearit, Long lastPlayTime) {
-        return new BookmarkHearitResponse(
+    public static BookmarkHearitResponseV2 of(Bookmark bookmark, Hearit hearit, Long lastPlayTime) {
+        return new BookmarkHearitResponseV2(
                 hearit.getId(),
                 bookmark.getId(),
                 hearit.getTitle(),

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV1.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV1.java
@@ -7,12 +7,12 @@ public record CursorResponseV1<T>(
         boolean isEmpty,
         long cursorId
 ) {
-    public static <T> CursorResponseV1<T> from(CursorResponse<T> cursorResponse) {
-        List<T> contents = cursorResponse.content();
+    public static <T> CursorResponseV1<T> from(CursorResponseV2<T> cursorResponseV2) {
+        List<T> contents = cursorResponseV2.content();
         long cursorId = 0L;
-        if(!contents.isEmpty()) {
+        if (!contents.isEmpty()) {
             ExploredHearitResponse last = (ExploredHearitResponse) contents.getLast();
-            cursorId = last.cursorId();;
+            cursorId = last.cursorId();
         }
         return new CursorResponseV1<>(
                 contents,

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV2.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/CursorResponseV2.java
@@ -2,12 +2,12 @@ package com.onair.hearit.app.dto.response;
 
 import java.util.List;
 
-public record CursorResponse<T>(
+public record CursorResponseV2<T>(
         List<T> content,
         boolean isEmpty
 ) {
-    public static <T> CursorResponse<T> from(List<T> cursorResult) {
-        return new CursorResponse<>(
+    public static <T> CursorResponseV2<T> from(List<T> cursorResult) {
+        return new CursorResponseV2<>(
                 cursorResult,
                 cursorResult.isEmpty()
         );

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
@@ -11,6 +11,8 @@ public record HearitSearchResponse(
         Long lastPlayTime,
         List<KeywordResponse> keywords
 ) {
+    private static final int KEYWORD_PER_HEARIT = 3;
+
     public static HearitSearchResponse of(Hearit hearit, List<Keyword> keywords, Long lastPlayTime) {
         List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         return new HearitSearchResponse(
@@ -23,7 +25,7 @@ public record HearitSearchResponse(
     }
 
     private static List<KeywordResponse> getKeywordNames(List<Keyword> keywords) {
-        return keywords.stream().map(KeywordResponse::from).toList();
+        return keywords.stream().limit(KEYWORD_PER_HEARIT).map(KeywordResponse::from).toList();
     }
 
     public record KeywordResponse(

--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
@@ -28,7 +28,7 @@ public class PlayingHistoryBuffer {
     }
 
     @Transactional
-    @Scheduled(fixedDelay = 5000)
+    @Scheduled(fixedDelay = 2000)
     public void flush() {
         if (!queue.isEmpty()) {
             List<PlayingHistory> batchRecords = new ArrayList<>();

--- a/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
@@ -1,11 +1,14 @@
 package com.onair.hearit.app.presentation;
 
+
 import com.onair.hearit.app.application.BookmarkService;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV1;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.auth.domain.RequestUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,13 +23,38 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/bookmarks")
+@RequestMapping("/api")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
-    @GetMapping("/hearits")
-    public ResponseEntity<PagedResponse<BookmarkHearitResponse>> readBookmarkHearits(
+    @GetMapping("/v1/bookmarks/hearits")
+    public ResponseEntity<PagedResponse<BookmarkHearitResponseV1>> readBookmarkHearitsV1(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "20") int size,
+            @AuthenticationPrincipal RequestUser requestUser) {
+        PagingRequest pagingRequest = new PagingRequest(page, size);
+        PagedResponse<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(requestUser.getUserInfo(),
+                pagingRequest);
+        List<BookmarkHearitResponse> contents = responses.content();
+        List<BookmarkHearitResponseV1> v1Contents = contents.stream()
+                .map(BookmarkHearitResponseV1::from)
+                .toList();
+        PagedResponse<BookmarkHearitResponseV1> v1Responses =
+                new PagedResponse<>(
+                        v1Contents,
+                        responses.page(),
+                        responses.size(),
+                        responses.totalPages(),
+                        responses.totalElements(),
+                        responses.isFirst(),
+                        responses.isLast()
+                );
+        return ResponseEntity.ok(v1Responses);
+    }
+
+    @GetMapping("/v2/bookmarks/hearits")
+    public ResponseEntity<PagedResponse<BookmarkHearitResponse>> readBookmarkHearitsV2(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -36,7 +64,7 @@ public class BookmarkController {
         return ResponseEntity.ok(responses);
     }
 
-    @PostMapping("/hearits/{hearitId}")
+    @PostMapping("/v1/bookmarks/hearits/{hearitId}")
     public ResponseEntity<BookmarkInfoResponse> createBookmark(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -44,7 +72,7 @@ public class BookmarkController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @DeleteMapping("/{bookmarkId}")
+    @DeleteMapping("/v1/bookmarks/{bookmarkId}")
     public ResponseEntity<Void> deleteBookmark(
             @PathVariable Long bookmarkId,
             @AuthenticationPrincipal RequestUser requestUser) {

--- a/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/BookmarkController.java
@@ -1,15 +1,14 @@
 package com.onair.hearit.app.presentation;
 
-
 import com.onair.hearit.app.application.BookmarkService;
 import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
 import com.onair.hearit.app.dto.response.BookmarkHearitResponseV1;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV2;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.auth.domain.RequestUser;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,54 +16,40 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
-    @GetMapping("/v1/bookmarks/hearits")
+    @GetMapping("/api/v1/bookmarks/hearits")
     public ResponseEntity<PagedResponse<BookmarkHearitResponseV1>> readBookmarkHearitsV1(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
             @AuthenticationPrincipal RequestUser requestUser) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        PagedResponse<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(requestUser.getUserInfo(),
-                pagingRequest);
-        List<BookmarkHearitResponse> contents = responses.content();
-        List<BookmarkHearitResponseV1> v1Contents = contents.stream()
-                .map(BookmarkHearitResponseV1::from)
-                .toList();
-        PagedResponse<BookmarkHearitResponseV1> v1Responses =
-                new PagedResponse<>(
-                        v1Contents,
-                        responses.page(),
-                        responses.size(),
-                        responses.totalPages(),
-                        responses.totalElements(),
-                        responses.isFirst(),
-                        responses.isLast()
-                );
-        return ResponseEntity.ok(v1Responses);
+        Page<BookmarkHearitResponseV2> v2Responses = bookmarkService.getBookmarkHearits(
+                requestUser.getUserInfo(), pagingRequest);
+        Page<BookmarkHearitResponseV1> v1Responses = v2Responses.map(BookmarkHearitResponseV1::from);
+        return ResponseEntity.ok(PagedResponse.from(v1Responses));
     }
 
-    @GetMapping("/v2/bookmarks/hearits")
-    public ResponseEntity<PagedResponse<BookmarkHearitResponse>> readBookmarkHearitsV2(
+    @GetMapping("/api/v2/bookmarks/hearits")
+    public ResponseEntity<PagedResponse<BookmarkHearitResponseV2>> readBookmarkHearitsV2(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "20") int size,
             @AuthenticationPrincipal RequestUser requestUser) {
         PagingRequest pagingRequest = new PagingRequest(page, size);
-        PagedResponse<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(requestUser.getUserInfo(),
+        Page<BookmarkHearitResponseV2> bookmarkHearits = bookmarkService.getBookmarkHearits(
+                requestUser.getUserInfo(),
                 pagingRequest);
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(PagedResponse.from(bookmarkHearits));
     }
 
-    @PostMapping("/v1/bookmarks/hearits/{hearitId}")
+    @PostMapping("/api/v1/bookmarks/hearits/{hearitId}")
     public ResponseEntity<BookmarkInfoResponse> createBookmark(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -72,7 +57,7 @@ public class BookmarkController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @DeleteMapping("/v1/bookmarks/{bookmarkId}")
+    @DeleteMapping("/api/v1/bookmarks/{bookmarkId}")
     public ResponseEntity<Void> deleteBookmark(
             @PathVariable Long bookmarkId,
             @AuthenticationPrincipal RequestUser requestUser) {

--- a/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/HearitController.java
@@ -5,8 +5,8 @@ import com.onair.hearit.app.application.HearitService;
 import com.onair.hearit.app.application.explore.HearitExploreService;
 import com.onair.hearit.app.dto.request.CursorRequest;
 import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.CursorResponse;
 import com.onair.hearit.app.dto.response.CursorResponseV1;
+import com.onair.hearit.app.dto.response.CursorResponseV2;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
 import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
@@ -21,20 +21,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
 public class HearitController {
 
     private final HearitService hearitService;
     private final HearitExploreService hearitExploreService;
     private final HearitSearchService hearitSearchService;
 
-    @GetMapping("/v1/hearits/{hearitId}")
+    @GetMapping("/api/v1/hearits/{hearitId}")
     public ResponseEntity<HearitDetailResponse> readHearit(
             @PathVariable Long hearitId,
             @AuthenticationPrincipal RequestUser requestUser) {
@@ -42,36 +40,36 @@ public class HearitController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v2/hearits/explore")
-    public ResponseEntity<CursorResponse<ExploredHearitResponse>> readExploredHearitsV2(
-            @AuthenticationPrincipal RequestUser requestUser,
-            @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
-            @RequestParam(name = "size", defaultValue = "10") int size) {
-        CursorRequest cursorRequest = new CursorRequest(cursorId, size);
-        CursorResponse<ExploredHearitResponse> responses =
-                hearitExploreService.getExploredHearits(requestUser.getUserInfo(), cursorRequest);
-        return ResponseEntity.ok(responses);
-    }
-
-    @GetMapping("/v1/hearits/explore")
+    @GetMapping("/api/v1/hearits/explore")
     public ResponseEntity<CursorResponseV1<ExploredHearitResponse>> readExploredHearitsV1(
             @AuthenticationPrincipal RequestUser requestUser,
             @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
             @RequestParam(name = "size", defaultValue = "10") int size) {
         CursorRequest cursorRequest = new CursorRequest(cursorId, size);
-        CursorResponse<ExploredHearitResponse> responses =
+        CursorResponseV2<ExploredHearitResponse> responses =
                 hearitExploreService.getExploredHearits(requestUser.getUserInfo(), cursorRequest);
         CursorResponseV1<ExploredHearitResponse> responsesV1 = CursorResponseV1.from(responses);
         return ResponseEntity.ok(responsesV1);
     }
 
-    @GetMapping("/v1/hearits/recommend")
+    @GetMapping("/api/v2/hearits/explore")
+    public ResponseEntity<CursorResponseV2<ExploredHearitResponse>> readExploredHearitsV2(
+            @AuthenticationPrincipal RequestUser requestUser,
+            @RequestParam(name = "cursorId", defaultValue = "0") long cursorId,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+        CursorRequest cursorRequest = new CursorRequest(cursorId, size);
+        CursorResponseV2<ExploredHearitResponse> responses =
+                hearitExploreService.getExploredHearits(requestUser.getUserInfo(), cursorRequest);
+        return ResponseEntity.ok(responses);
+    }
+
+    @GetMapping("/api/v1/hearits/recommend")
     public ResponseEntity<List<RecommendHearitResponse>> readRecommendedHearits() {
         List<RecommendHearitResponse> responses = hearitService.getRecommendedHearits();
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/v1/hearits/search")
+    @GetMapping("/api/v1/hearits/search")
     public ResponseEntity<PagedResponse<HearitSearchResponse>> readSearchedHearits(
             @RequestParam(name = "searchTerm") String searchTerm,
             @RequestParam(name = "page", defaultValue = "0") int page,
@@ -83,7 +81,7 @@ public class HearitController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/v1/hearits/recommend-category")
+    @GetMapping("/api/v1/hearits/recommend-category")
     public ResponseEntity<List<HearitsWithRecommendCategoryResponse>> readHearitsWithRecommendCategory(
             @AuthenticationPrincipal RequestUser requestUser) {
         List<HearitsWithRecommendCategoryResponse> responses =
@@ -91,7 +89,7 @@ public class HearitController {
         return ResponseEntity.ok(responses);
     }
 
-    @GetMapping("/v1/hearits")
+    @GetMapping("/api/v1/hearits")
     public ResponseEntity<PagedResponse<HearitOfCategoryResponse>> readHearitsByCategory(
             @RequestParam(name = "categoryId") Long categoryId,
             @RequestParam(name = "page", defaultValue = "0") int page,

--- a/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
+++ b/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
@@ -75,7 +75,9 @@ public class AuthService {
         OAuthUserInfoResponse userInfo = oAuthService.fetchUser(request.accessToken());
         Member member = memberRepository.findBySocialIdAndOAuthProvider(userInfo.id(), provider)
                 .orElseGet(() -> signupWithUserInfo(userInfo, provider));
-        return createTokenResponseFrom(member);
+        LoginTokenResponse loginTokenResponse = createTokenResponseFrom(member);
+        log.warn("memberId:{}가 {} 로그인 성공", member.getId(), provider.name());
+        return loginTokenResponse;
     }
 
     private Member signupWithUserInfo(OAuthUserInfoResponse userInfo, OAuthProvider provider) {
@@ -103,10 +105,11 @@ public class AuthService {
     public String reissue(String refreshToken) {
         validateRefreshTokenExpired(refreshToken);
         Long memberId = jwtTokenProvider.getMemberId(refreshToken);
-        RefreshToken stored = refreshTokenRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new UnauthorizedException("저장된 토큰이 없습니다."));
-        validateRefreshTokenValue(refreshToken, stored);
-        return jwtTokenProvider.createAccessToken(memberId);
+        log.info("memberId:{}가 reissue 요청 수신", memberId);
+        validateRefreshToken(refreshToken, memberId);
+        String newAccessToken = jwtTokenProvider.createAccessToken(memberId);
+        log.info("memberId:{}의 token reissue 성공", memberId);
+        return newAccessToken;
     }
 
     private void validateRefreshTokenExpired(String refreshToken) {
@@ -115,8 +118,15 @@ public class AuthService {
         }
     }
 
-    private void validateRefreshTokenValue(String refreshToken, RefreshToken stored) {
+    private void validateRefreshToken(String refreshToken, Long memberId) {
+        RefreshToken stored = refreshTokenRepository.findByMemberId(memberId)
+                .orElseThrow(() -> {
+                    log.warn("memberId={} 저장된 리프레시토큰 없음", memberId);
+                    return new UnauthorizedException("저장된 토큰이 없습니다.");
+                });
+
         if (!stored.getToken().equals(refreshToken)) {
+            log.warn("memberId={} 저장된 토큰과 요청 토큰 불일치", memberId);
             throw new UnauthorizedException("리프레시 토큰이 불일치합니다.");
         }
     }

--- a/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
+++ b/backend/src/main/java/com/onair/hearit/auth/application/AuthService.java
@@ -76,7 +76,7 @@ public class AuthService {
         Member member = memberRepository.findBySocialIdAndOAuthProvider(userInfo.id(), provider)
                 .orElseGet(() -> signupWithUserInfo(userInfo, provider));
         LoginTokenResponse loginTokenResponse = createTokenResponseFrom(member);
-        log.warn("memberId:{}가 {} 로그인 성공", member.getId(), provider.name());
+        log.info("memberId:{}가 {} 로그인 성공", member.getId(), provider.name());
         return loginTokenResponse;
     }
 
@@ -120,14 +120,10 @@ public class AuthService {
 
     private void validateRefreshToken(String refreshToken, Long memberId) {
         RefreshToken stored = refreshTokenRepository.findByMemberId(memberId)
-                .orElseThrow(() -> {
-                    log.warn("memberId={} 저장된 리프레시토큰 없음", memberId);
-                    return new UnauthorizedException("저장된 토큰이 없습니다.");
-                });
+                .orElseThrow(() -> new UnauthorizedException("memberId:" + memberId + "의 저장된 토큰이 없습니다."));
 
         if (!stored.getToken().equals(refreshToken)) {
-            log.warn("memberId={} 저장된 토큰과 요청 토큰 불일치", memberId);
-            throw new UnauthorizedException("리프레시 토큰이 불일치합니다.");
+            throw new UnauthorizedException("memberId:" + memberId + "의 리프레시 토큰이 불일치합니다.");
         }
     }
 

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -36,39 +36,40 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
-        String header = request.getHeader("Authorization");
-        String token = extractTokenFromHeader(header);
+        String token = extractTokenFromHeader(request.getHeader("Authorization"));
 
         // 화이트리스트면 그냥 통과
-        if ((token == null || token.isBlank()) && isWhitelisted(request)) {
-            String deviceUuid = request.getHeader(DEVICE_UUID_HEADER);
-            UsernamePasswordAuthenticationToken auth =
-                    new UsernamePasswordAuthenticationToken(RequestUser.guest(deviceUuid), null, null);
-            SecurityContextHolder.getContext().setAuthentication(auth);
+        if (isWhitelisted(request)) {
+            handleWhitelistedRequest(request, token);
             chain.doFilter(request, response);
             return;
         }
 
-        if (!jwtTokenProvider.validateToken(token)) {
-            ProblemDetail problemDetail = buildProblemDetail(ErrorCode.UNAUTHORIZED, "유효하지 않은 토큰입니다.", request);
-            writeProblemDetailResponse(response, problemDetail);
-            filterExceptionLogger.warn(problemDetail);
+        //인증이 필요한 엔드포인트 처리
+        if (token == null) {
+            handleUnauthenticatedError(response, request);
             return;
         }
 
-        Long memberId = jwtTokenProvider.getMemberId(token);
-        RequestUser requestUser = RequestUser.member(memberId);
-
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(requestUser, null, Collections.emptyList());
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        chain.doFilter(request, response);
+        TokenStatus tokenStatus = jwtTokenProvider.getTokenStatus(token);
+        switch (tokenStatus) {
+            case EXPIRED -> handleTokenExpiredError(response, request);
+            case INVALID -> handleInvalidTokenError(response, request);
+            case VALID -> {
+                authenticateAsMember(token);
+                chain.doFilter(request, response);
+            }
+        }
     }
 
-    private boolean isWhitelisted(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return whitelist.stream().anyMatch(pattern -> pathMatcher.match(pattern, path));
+    private void handleWhitelistedRequest(HttpServletRequest request, String token) {
+        if (token == null || token.isBlank() || !jwtTokenProvider.validateToken(token)) {
+            // 토큰이 없거나 잘못된 토큰 → 게스트로 인증
+            authenticateAsGuest(request);
+            return;
+        }
+        // 유효한 토큰 → 회원으로 인증
+        authenticateAsMember(token);
     }
 
     private String extractTokenFromHeader(String header) {
@@ -78,10 +79,50 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return header.substring("Bearer ".length());
     }
 
+    private boolean isWhitelisted(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return whitelist.stream().anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
+
+    private void authenticateAsGuest(HttpServletRequest request) {
+        String deviceUuid = request.getHeader(DEVICE_UUID_HEADER);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(RequestUser.guest(deviceUuid), null, null);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    private void handleUnauthenticatedError(HttpServletResponse response, HttpServletRequest request)
+            throws IOException {
+        ProblemDetail problemDetail = buildProblemDetail(ErrorCode.AUTHENTICATION_REQUIRED, "인증이 필요한 요청입니다.", request);
+        writeProblemDetailResponse(response, problemDetail);
+        filterExceptionLogger.warn(problemDetail);
+    }
+
+    private void handleTokenExpiredError(HttpServletResponse response, HttpServletRequest request) throws IOException {
+        ProblemDetail problemDetail = buildProblemDetail(ErrorCode.ACCESS_TOKEN_EXPIRED, "만료된 토큰입니다.", request);
+        writeProblemDetailResponse(response, problemDetail);
+        filterExceptionLogger.warn(problemDetail);
+    }
+
+    private void handleInvalidTokenError(HttpServletResponse response, HttpServletRequest request) throws IOException {
+        ProblemDetail problemDetail = buildProblemDetail(ErrorCode.INVALID_ACCESS_TOKEN, "유효하지 않은 토큰입니다.", request);
+        writeProblemDetailResponse(response, problemDetail);
+        filterExceptionLogger.warn(problemDetail);
+    }
+
+    private void authenticateAsMember(String token) {
+        Long memberId = jwtTokenProvider.getMemberId(token);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(RequestUser.member(memberId), null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
     private ProblemDetail buildProblemDetail(ErrorCode errorCode, String detail, HttpServletRequest request) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(errorCode.getHttpStatus(), detail);
         problemDetail.setTitle(errorCode.getTitle());
         problemDetail.setType(URI.create(request.getRequestURI()));
+        problemDetail.setProperty("code", errorCode.name());
+        problemDetail.setProperty("reissuable", errorCode == ErrorCode.ACCESS_TOKEN_EXPIRED);
         return problemDetail;
     }
 

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -75,6 +75,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UsernamePasswordAuthenticationToken auth =
                 new UsernamePasswordAuthenticationToken(RequestUser.guest(deviceUuid), null, null);
         SecurityContextHolder.getContext().setAuthentication(auth);
+        log.info("비회원으로 접속 완료, deviceUuid={}", deviceUuid);
+    }
+
+    private void authenticateAsMember(String token) {
+        Long memberId = jwtTokenProvider.getMemberId(token);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(RequestUser.member(memberId), null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        log.info("회원으로 인증 완료, memberId={}", memberId);
     }
 
     private void handleAuthenticatedRequiredError(HttpServletResponse response, HttpServletRequest request)
@@ -94,13 +103,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         ProblemDetail problemDetail = buildProblemDetail(ErrorCode.INVALID_ACCESS_TOKEN, "유효하지 않은 토큰입니다.", request);
         writeProblemDetailResponse(response, problemDetail);
         filterExceptionLogger.warn(problemDetail);
-    }
-
-    private void authenticateAsMember(String token) {
-        Long memberId = jwtTokenProvider.getMemberId(token);
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(RequestUser.member(memberId), null, Collections.emptyList());
-        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
     private ProblemDetail buildProblemDetail(ErrorCode errorCode, String detail, HttpServletRequest request) {

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -39,20 +39,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = extractTokenFromHeader(request.getHeader("Authorization"));
 
         // 화이트리스트면 그냥 통과
-        if (isWhitelisted(request)) {
-            handleWhitelistedRequest(request, token);
+        if ((token == null || token.isBlank()) && isWhitelisted(request)) {
+            authenticateAsGuest(request);
             chain.doFilter(request, response);
             return;
         }
 
-        //인증이 필요한 엔드포인트 처리
-        if (token == null) {
-            handleUnauthenticatedError(response, request);
-            return;
-        }
-
+        // 토큰이 헤더에 존재하거나 인증이 필요한 엔드포인트 처리
         TokenStatus tokenStatus = jwtTokenProvider.getTokenStatus(token);
         switch (tokenStatus) {
+            case NOT_EXIST -> handleAuthenticatedRequiredError(response, request);
             case EXPIRED -> handleTokenExpiredError(response, request);
             case INVALID -> handleInvalidTokenError(response, request);
             case VALID -> {
@@ -60,16 +56,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 chain.doFilter(request, response);
             }
         }
-    }
-
-    private void handleWhitelistedRequest(HttpServletRequest request, String token) {
-        if (token == null || token.isBlank() || !jwtTokenProvider.validateToken(token)) {
-            // 토큰이 없거나 잘못된 토큰 → 게스트로 인증
-            authenticateAsGuest(request);
-            return;
-        }
-        // 유효한 토큰 → 회원으로 인증
-        authenticateAsMember(token);
     }
 
     private String extractTokenFromHeader(String header) {
@@ -91,7 +77,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
-    private void handleUnauthenticatedError(HttpServletResponse response, HttpServletRequest request)
+    private void handleAuthenticatedRequiredError(HttpServletResponse response, HttpServletRequest request)
             throws IOException {
         ProblemDetail problemDetail = buildProblemDetail(ErrorCode.AUTHENTICATION_REQUIRED, "인증이 필요한 요청입니다.", request);
         writeProblemDetailResponse(response, problemDetail);

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.onair.hearit.auth.infrastructure.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -9,9 +10,11 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class JwtTokenProvider {
 
@@ -69,7 +72,27 @@ public class JwtTokenProvider {
             parseClaims(token);
             return true;
         } catch (JwtException e) {
+            log.warn("validateToken() failed: {}", e.getMessage());
             return false;
+        }
+    }
+
+    public TokenStatus getTokenStatus(String token) {
+        if (token == null || token.isBlank()) {
+            return TokenStatus.INVALID;
+        }
+
+        try {
+            Claims claims = parseClaims(token);
+            Date expiration = claims.getExpiration();
+            if (expiration.before(new Date())) {
+                return TokenStatus.EXPIRED;
+            }
+            return TokenStatus.VALID;
+        } catch (ExpiredJwtException e) {
+            return TokenStatus.EXPIRED;
+        } catch (JwtException e) {
+            return TokenStatus.INVALID;
         }
     }
 

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -79,7 +79,7 @@ public class JwtTokenProvider {
 
     public TokenStatus getTokenStatus(String token) {
         if (token == null || token.isBlank()) {
-            return TokenStatus.INVALID;
+            return TokenStatus.NOT_EXIST;
         }
 
         try {

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/JwtTokenProvider.java
@@ -72,7 +72,7 @@ public class JwtTokenProvider {
             parseClaims(token);
             return true;
         } catch (JwtException e) {
-            log.warn("validateToken() failed: {}", e.getMessage());
+            log.info("validateToken() failed: {}", e.getMessage());
             return false;
         }
     }

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/TokenStatus.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/TokenStatus.java
@@ -1,0 +1,5 @@
+package com.onair.hearit.auth.infrastructure.jwt;
+
+public enum TokenStatus {
+    VALID, INVALID, EXPIRED
+}

--- a/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/TokenStatus.java
+++ b/backend/src/main/java/com/onair/hearit/auth/infrastructure/jwt/TokenStatus.java
@@ -1,5 +1,5 @@
 package com.onair.hearit.auth.infrastructure.jwt;
 
 public enum TokenStatus {
-    VALID, INVALID, EXPIRED
+    VALID, INVALID, EXPIRED, NOT_EXIST
 }

--- a/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
+++ b/backend/src/main/java/com/onair/hearit/common/domain/PlayingHistory.java
@@ -29,6 +29,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class PlayingHistory {
 
     private static final int FINISHED_TIME_RANGE = 10;
+    private static final int LAST_PLAY_TIME_PADDING = 1;
     private static final int MILLISECONDS_PER_SECOND = 1_000;
 
     @Id
@@ -64,7 +65,8 @@ public class PlayingHistory {
     }
 
     private void validateHearitPlayTime(Hearit hearit, long lastPlayTime) {
-        if (lastPlayTime < 0 || lastPlayTime > hearit.getPlayTime() * MILLISECONDS_PER_SECOND) {
+        if (lastPlayTime < 0 ||
+                lastPlayTime > (long) (hearit.getPlayTime() + LAST_PLAY_TIME_PADDING) * MILLISECONDS_PER_SECOND) {
             throw new InvalidInputException("마지막 재생 시간은 히어릿의 총 재생 시간보다 작아야 합니다");
         }
     }

--- a/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/ErrorCode.java
@@ -8,11 +8,17 @@ public enum ErrorCode {
 
     //CLIENT ERROR
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "해당 정보를 찾을 수 없습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
     ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
     BUFFER_OVERFLOW(HttpStatus.TOO_MANY_REQUESTS, "대기 중인 요청이 너무 많습니다."),
+
+    //CLIENT UNAUTHORIZED ERROR
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 요청입니다."),
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요한 요청입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 유효하지 않습니다."),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "엑세스 토큰이 만료되었습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
     //SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),

--- a/backend/src/main/java/com/onair/hearit/common/exception/custom/ForbiddenException.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/custom/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.onair.hearit.common.exception.custom;
+
+import com.onair.hearit.common.exception.ErrorCode;
+
+public class ForbiddenException extends HearitException {
+
+    public ForbiddenException(String detail) {
+        super(ErrorCode.FORBIDDEN, detail);
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/common/exception/custom/UnauthenticatedException.java
+++ b/backend/src/main/java/com/onair/hearit/common/exception/custom/UnauthenticatedException.java
@@ -1,0 +1,10 @@
+package com.onair.hearit.common.exception.custom;
+
+import com.onair.hearit.common.exception.ErrorCode;
+
+public class UnauthenticatedException extends HearitException {
+
+    public UnauthenticatedException() {
+        super(ErrorCode.AUTHENTICATION_REQUIRED, "로그인한 회원이 아닙니다.");
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/log/RequestLoggingFilter.java
+++ b/backend/src/main/java/com/onair/hearit/log/RequestLoggingFilter.java
@@ -31,7 +31,7 @@ public class RequestLoggingFilter extends OncePerRequestFilter {
             "/api/v1/admin/**",
             "/favicon.ico",
             "/.well-known/**",
-            "/actuator/health"
+            "/actuator/**"
     );
 
     private final AntPathMatcher pathMatcher = new AntPathMatcher();

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -64,8 +64,7 @@ CREATE TABLE `explore_score` (
                                  `hearit_id` bigint NOT NULL,
                                  `score` double NOT NULL,
                                  `cursor_id` bigint DEFAULT NULL,
-                                 PRIMARY KEY (`id`),
-                                 CONSTRAINT `uq_explore_score_member_hearit` UNIQUE (`member_id`, `hearit_id`)
+                                 PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `hearit_keyword` (

--- a/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
@@ -15,7 +15,8 @@ import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.AlreadyExistException;
-import com.onair.hearit.common.exception.custom.UnauthorizedException;
+import com.onair.hearit.common.exception.custom.ForbiddenException;
+import com.onair.hearit.common.exception.custom.UnauthenticatedException;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
@@ -97,7 +98,7 @@ class BookmarkServiceTest {
 
         // when
         assertThatThrownBy(() -> bookmarkService.getBookmarkHearits(guestInfo, pagingRequest))
-                .isInstanceOf(UnauthorizedException.class);
+                .isInstanceOf(UnauthenticatedException.class);
     }
 
     @Test
@@ -157,7 +158,7 @@ class BookmarkServiceTest {
     }
 
     @Test
-    @DisplayName("북마크 삭제 시, 북마크를 한 멤버가 아니라면 UnauthorizedException을 던진다.")
+    @DisplayName("북마크 삭제 시, 북마크를 한 멤버가 아니라면 Forbidden을 던진다.")
     void deleteBookmark_UnauthorizedTest() {
         // given
         Member bookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
@@ -172,7 +173,7 @@ class BookmarkServiceTest {
         // when & then
         assertThatThrownBy(
                 () -> bookmarkService.deleteBookmark(bookmarkId, notBookmarkMemberInfo))
-                .isInstanceOf(UnauthorizedException.class)
+                .isInstanceOf(ForbiddenException.class)
                 .hasMessageContaining("북마크를 삭제할 권한이 없습니다.");
     }
 }

--- a/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/BookmarkServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.dto.request.PagingRequest;
-import com.onair.hearit.app.dto.response.BookmarkHearitResponse;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV2;
 import com.onair.hearit.app.dto.response.BookmarkInfoResponse;
 import com.onair.hearit.auth.domain.RequestUser;
 import com.onair.hearit.common.domain.Bookmark;
@@ -73,8 +73,8 @@ class BookmarkServiceTest {
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
         // when
-        List<BookmarkHearitResponse> responses = bookmarkService.getBookmarkHearits(
-                RequestUser.member(member.getId()).getUserInfo(), new PagingRequest(0, 20)).content();
+        List<BookmarkHearitResponseV2> responses = bookmarkService.getBookmarkHearits(
+                RequestUser.member(member.getId()).getUserInfo(), new PagingRequest(0, 20)).stream().toList();
 
         // then
         assertAll(() -> {

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitExploreServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitExploreServiceTest.java
@@ -10,7 +10,7 @@ import com.onair.hearit.app.application.explore.scorefactor.RecencyScoreFactor;
 import com.onair.hearit.app.application.explore.scoreprocessor.GuestExploreScoreProcessor;
 import com.onair.hearit.app.application.explore.scoreprocessor.MemberExploreScoreProcessor;
 import com.onair.hearit.app.dto.request.CursorRequest;
-import com.onair.hearit.app.dto.response.CursorResponse;
+import com.onair.hearit.app.dto.response.CursorResponseV2;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.auth.domain.RequestUser;
 import com.onair.hearit.common.domain.Bookmark;
@@ -120,7 +120,7 @@ class HearitExploreServiceTest {
         dbHelper.insertBookmark(new Bookmark(member, hearit));
 
         // when
-        CursorResponse<ExploredHearitResponse> exploredHearits = hearitExploreService.getExploredHearits(
+        CursorResponseV2<ExploredHearitResponse> exploredHearits = hearitExploreService.getExploredHearits(
                 RequestUser.member(member.getId()).getUserInfo(), new CursorRequest(0L, 10));
 
         // then
@@ -149,7 +149,7 @@ class HearitExploreServiceTest {
         dbHelper.insertHearit(createHearitByNameAndCategory("hearit10", category3));
 
         // when
-        CursorResponse<ExploredHearitResponse> exploredHearits = hearitExploreService.getExploredHearits(
+        CursorResponseV2<ExploredHearitResponse> exploredHearits = hearitExploreService.getExploredHearits(
                 RequestUser.guest(UUID.randomUUID().toString()).getUserInfo(), new CursorRequest(0L, 10));
 
         // then

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -36,7 +36,7 @@ class BookmarkControllerTest extends IntegrationTest {
 
     @Test
     @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
-    void readBookmarkHearitsTest() {
+    void readBookmarkHearitsTest_v1() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
@@ -52,10 +52,62 @@ class BookmarkControllerTest extends IntegrationTest {
                 .header("Authorization", "Bearer " + token)
                 .param("page", 0)
                 .param("size", 5)
-                .filter(document("bookmark-read-list",
+                .filter(document("bookmark-read-list-v1",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
-                                .summary("북마크 목록 조회")
+                                .summary("북마크 목록 조회 V1")
+                                .description("사용자가 북마크한 히어릿 목록을 페이지별로 조회합니다.")
+                                .queryParameters(
+                                        parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
+                                        parameterWithName("size").description("페이지 당 항목 수 (기본 20)").defaultValue("20")
+                                )
+                                .responseSchema(Schema.schema("PagedBookmarkHearitResponse"))
+                                .responseFields(
+                                        Stream.concat(
+                                                Arrays.stream(new FieldDescriptor[]{
+                                                        fieldWithPath("content[].hearitId").description("히어릿 ID"),
+                                                        fieldWithPath("content[].bookmarkId").description("북마크 ID"),
+                                                        fieldWithPath("content[].title").description("히어릿 제목"),
+                                                        fieldWithPath("content[].summary").description("히어릿 요약"),
+                                                        fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
+                                                        fieldWithPath("content[].lastPlayTime").description(
+                                                                "히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].categoryColor").description("카테고리 색상 코드")
+                                                }),
+                                                Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields())
+                                        ).toArray(FieldDescriptor[]::new)
+                                )
+                                .build())
+                ))
+                .when()
+                .get("/api/v1/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("content.size()", equalTo(5));
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
+    void readBookmarkHearitsTest_v2() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        String token = generateToken(member);
+        int bookmarkCount = 30;
+        for (int i = 0; i < bookmarkCount; i++) {
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        }
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .param("page", 0)
+                .param("size", 5)
+                .filter(document("bookmark-read-list-v2",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Bookmark API")
+                                .summary("북마크 목록 조회 V2")
                                 .description("사용자가 북마크한 히어릿 목록을 페이지별로 조회합니다.")
                                 .queryParameters(
                                         parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
@@ -82,7 +134,7 @@ class BookmarkControllerTest extends IntegrationTest {
                                 .build())
                 ))
                 .when()
-                .get("/api/v1/bookmarks/hearits")
+                .get("/api/v2/bookmarks/hearits")
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .body("content.size()", equalTo(5));

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -211,7 +211,7 @@ class BookmarkControllerTest extends IntegrationTest {
                                 .tag("Bookmark API")
                                 .summary("북마크 목록 조회")
                                 .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
                                 .build())
                 ))
                 .when()
@@ -312,7 +312,7 @@ class BookmarkControllerTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("자신의 북마크가 아닌 북마크 삭제 시, 401 UNAUTHORIZED를 반환한다.")
+    @DisplayName("자신의 북마크가 아닌 북마크 삭제 시, 403 FORBIDDEN을 반환한다.")
     void notFoundHearitId() {
         // given
         Member bookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
@@ -336,7 +336,7 @@ class BookmarkControllerTest extends IntegrationTest {
                 .when()
                 .delete("/api/v1/bookmarks/{bookmarkId}", bookmark.getId())
                 .then()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
     }
 
     private String generateToken(Member member) {

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -9,8 +9,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.app.dto.response.CursorResponse;
 import com.onair.hearit.app.dto.response.CursorResponseV1;
+import com.onair.hearit.app.dto.response.CursorResponseV2;
 import com.onair.hearit.app.dto.response.ExploredHearitResponse;
 import com.onair.hearit.app.dto.response.HearitDetailResponse;
 import com.onair.hearit.app.dto.response.HearitOfCategoryResponse;
@@ -156,7 +156,7 @@ class HearitControllerTest extends IntegrationTest {
         String token = generateToken(member);
 
         // when
-        CursorResponse<ExploredHearitResponse> responses = RestAssured.given(this.spec)
+        CursorResponseV2<ExploredHearitResponse> responses = RestAssured.given(this.spec)
                 .header("Authorization", "Bearer " + token)
                 .queryParam("cursorId", 0)
                 .queryParam("size", 10)
@@ -204,7 +204,7 @@ class HearitControllerTest extends IntegrationTest {
         assertAll(() -> {
             assertThat(responses.content()).hasSize(3);
             assertThat(responses.content()).extracting(ExploredHearitResponse::cursorId)
-                            .containsExactly(1L, 2L, 3L);
+                    .containsExactly(1L, 2L, 3L);
             assertThat(responses.isEmpty()).isFalse();
         });
     }

--- a/backend/src/test/java/com/onair/hearit/app/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/MemberControllerTest.java
@@ -78,7 +78,7 @@ class MemberControllerTest extends IntegrationTest {
                                 .summary("내 정보 조회")
                                 .description("현재 로그인한 사용자의 정보를 조회합니다.")
                                 .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
                                 .build()))
                 )
                 .when()

--- a/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/application/AuthServiceTest.java
@@ -230,7 +230,7 @@ class AuthServiceTest {
                 // when & then
                 assertThatThrownBy(() -> authService.reissue(refreshTokenValue))
                         .isInstanceOf(UnauthorizedException.class)
-                        .hasMessage("저장된 토큰이 없습니다.");
+                        .hasMessageContaining("저장된 토큰이 없습니다.");
             }
 
             @Test
@@ -249,7 +249,7 @@ class AuthServiceTest {
                 // when & then
                 assertThatThrownBy(() -> authService.reissue(refreshTokenValue))
                         .isInstanceOf(UnauthorizedException.class)
-                        .hasMessage("리프레시 토큰이 불일치합니다.");
+                        .hasMessageContaining("리프레시 토큰이 불일치합니다.");
             }
         }
     }

--- a/backend/src/test/java/com/onair/hearit/auth/config/ApiSecurityConfigTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/config/ApiSecurityConfigTest.java
@@ -1,7 +1,9 @@
 package com.onair.hearit.auth.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.domain.Member;
@@ -13,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.contract.spec.internal.HttpStatus;
+import org.springframework.http.ProblemDetail;
 
 class ApiSecurityConfigTest extends IntegrationTest {
 
@@ -39,7 +42,7 @@ class ApiSecurityConfigTest extends IntegrationTest {
                 .get("/api/v1/bookmarks/hearits") // 인증 필요한 경로
                 .then().log().all()
                 .statusCode(HttpStatus.UNAUTHORIZED)
-                .body("detail", equalTo("유효하지 않은 토큰입니다."));
+                .body("detail", equalTo("인증이 필요한 요청입니다."));
     }
 
     @Test
@@ -62,7 +65,7 @@ class ApiSecurityConfigTest extends IntegrationTest {
                 .get("/api/v1/bookmarks/hearits") // 인증 필요한 경로
                 .then().log().all()
                 .statusCode(HttpStatus.UNAUTHORIZED)
-                .body("detail", equalTo("유효하지 않은 토큰입니다."));
+                .body("detail", equalTo("인증이 필요한 요청입니다."));
     }
 
     @Test
@@ -80,17 +83,24 @@ class ApiSecurityConfigTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("인증 실패 시 application/problem+json 형식으로 응답한다")
+    @DisplayName("인증 실패 시 application/problem+json 형식으로 응답하며 토큰재발급 여부를 위한 properties를 포함한다.")
     void returnProblemDetailOnAuthFailure() {
-        RestAssured.given().log().all()
+        ProblemDetail problemDetail = RestAssured.given().log().all()
                 .header("Authorization", "Bearer invalid-token")
                 .when()
                 .get("/api/v1/bookmarks/hearits") // 인증 필요한 경로
                 .then().log().all()
                 .statusCode(401)
                 .header("Content-Type", containsString("application/problem+json"))
-                .body("title", equalTo("인증되지 않은 요청입니다."))
-                .body("detail", equalTo("유효하지 않은 토큰입니다."));
+                .extract()
+                .as(ProblemDetail.class);
+
+        assertAll(
+                () -> assertThat(problemDetail.getTitle()).isEqualTo("엑세스 토큰이 유효하지 않습니다."),
+                () -> assertThat(problemDetail.getDetail()).isEqualTo("유효하지 않은 토큰입니다."),
+                () -> assertThat(problemDetail.getProperties().get("code")).isNotNull(),
+                () -> assertThat(problemDetail.getProperties().get("reissuable")).isNotNull()
+        );
     }
 
     private String generateToken(Member member) {

--- a/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -294,7 +294,7 @@ class AuthControllerTest extends IntegrationTest {
                                 .summary("엑세스토큰 유효성 검증")
                                 .description("엑세스토큰의 유효성을 검증합니다.")
                                 .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
                                 .build())
                 ))
                 .when()

--- a/backend/src/test/java/com/onair/hearit/common/domain/PlayingHistoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/domain/PlayingHistoryTest.java
@@ -10,13 +10,16 @@ import org.junit.jupiter.api.Test;
 class PlayingHistoryTest {
 
     @Test
-    @DisplayName("재생 기록의 마지막 시간은 히어릿의 총 재생 시간보다 작아야 한다")
+    @DisplayName("재생 기록의 마지막 시간은 히어릿의 '총 재생 시간+1초' 보다 작아야 한다")
     void validateHearitPlayTime() {
         // given
-        Hearit hearit = createHearitWith(100);
+        int MILLISECONDS_PER_SECOND = 1_000;
+        int playTime = 100;
+        long lastPlayTime = (playTime + 2) * MILLISECONDS_PER_SECOND;
+        Hearit hearit = createHearitWith(playTime);
 
         // when & then
-        assertThatThrownBy(() -> new PlayingHistory(1L, hearit, 101_000));
+        assertThatThrownBy(() -> new PlayingHistory(1L, hearit, lastPlayTime));
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/docs/ApiDocSnippets.java
+++ b/backend/src/test/java/com/onair/hearit/docs/ApiDocSnippets.java
@@ -46,4 +46,21 @@ public class ApiDocSnippets {
                         .description("문제 유형에 대한 추가 세부 정보 (현재는 사용되지 않아 null)").optional()
         };
     }
+
+    public static FieldDescriptor[] getProblemDetailResponseFieldsWithAuthProperties() {
+        return new FieldDescriptor[]{
+                fieldWithPath("type").type(JsonFieldType.STRING).description("문제 유형을 식별하는 URI (요청 경로)"),
+                fieldWithPath("title").type(JsonFieldType.STRING).description("문제 유형에 대한 요약 (에러 코드 제목)"),
+                fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                fieldWithPath("detail").type(JsonFieldType.STRING).description("문제 발생에 대한 상세 설명"),
+                fieldWithPath("instance").type(JsonFieldType.STRING)
+                        .description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
+                fieldWithPath("properties").type(JsonFieldType.OBJECT)
+                        .description("문제 유형에 대한 추가 세부 정보").optional(),
+                fieldWithPath("properties.code").type(JsonFieldType.STRING)
+                        .description("에러 코드 (예: UNAUTHENTICATED)"),
+                fieldWithPath("properties.reissuable").type(JsonFieldType.BOOLEAN)
+                        .description("토큰 재발급 가능 여부")
+        };
+    }
 }


### PR DESCRIPTION
release version 1.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 북마크/탐색 API를 V1/V2로 분리 제공하고, V2에서 카테고리 정보와 응답 포맷을 확장
  - 인증 응답 고도화: 게스트 허용 경로, 토큰 상태별 오류 처리, ProblemDetail에 code/reissuable 포함
- Refactor
  - 엔드포인트에 /api 접두어 적용 및 경로 정리
  - 검색 결과 키워드 최대 3개 제한
  - 재생 이력 허용 범위 +1초로 완화
  - 버퍼 flush 주기 5초→2초로 단축
- Documentation
  - V1/V2 분리 및 인증 오류 스키마(추가 속성) 반영
- Chores
  - 버전 1.2.1로 업데이트
  - OpenAPI 로컬 서버 URL을 8080으로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->