### PR TITLE
[BE] feat: 최근 들은 히어릿 조회 API 구현 #559

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/application/CategoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/CategoryService.java
@@ -1,9 +1,9 @@
 package com.onair.hearit.app.application;
 
-import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.CategoryResponse;
 import com.onair.hearit.app.dto.response.PagedResponse;
+import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.infrastructure.jpa.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/backend/src/main/java/com/onair/hearit/app/application/KeywordService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/KeywordService.java
@@ -1,9 +1,9 @@
 package com.onair.hearit.app.application;
 
-import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.app.dto.request.PagingRequest;
 import com.onair.hearit.app.dto.response.KeywordResponse;
+import com.onair.hearit.common.domain.Keyword;
+import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.infrastructure.jpa.KeywordRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/onair/hearit/app/application/MemberService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/MemberService.java
@@ -1,8 +1,8 @@
 package com.onair.hearit.app.application;
 
-import com.onair.hearit.common.exception.custom.NotFoundException;
-import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.app.dto.response.MemberInfoResponse;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -1,12 +1,19 @@
 package com.onair.hearit.app.application;
 
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.app.dto.response.PlayingHistoryResponse;
 import com.onair.hearit.app.infrastructure.scheduler.PlayingHistoryBuffer;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
+import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,8 +21,31 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlayingHistoryService {
 
-    private final PlayingHistoryBuffer playingHistoryBuffer;
+    private static final int PLAYING_HISTORY_MAX_COUNT = 10;
+
     private final HearitRepository hearitRepository;
+    private final PlayingHistoryRepository playingHistoryRepository;
+    private final PlayingHistoryBuffer playingHistoryBuffer;
+
+    public List<PlayingHistoryResponse> getRecentPlayingHistoryOfMember(UserInfo userInfo) {
+        if (userInfo == null || userInfo.isGuest()) {
+            return new ArrayList<>();
+        }
+        return toPlayingHistoryResponseForMember(userInfo.getMemberId());
+    }
+
+    private List<PlayingHistoryResponse> toPlayingHistoryResponseForMember(Long memberId) {
+        List<PlayingHistory> histories = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(
+                memberId, PLAYING_HISTORY_MAX_COUNT);
+        Map<Long, Long> lastPlayTimeByHearitId = histories.stream()
+                .collect(Collectors.toMap(PlayingHistory::getHearitId, PlayingHistory::getLastPlayTime,
+                        (existing, ignored) -> existing, LinkedHashMap::new));
+        Map<Long, Hearit> hearitMap = hearitRepository.findAllByIdIn(lastPlayTimeByHearitId.keySet().stream().toList())
+                .stream().collect(Collectors.toMap(Hearit::getId, h -> h));
+        return lastPlayTimeByHearitId.entrySet().stream()
+                .map(e -> PlayingHistoryResponse.from(hearitMap.get(e.getKey()), e.getValue()))
+                .toList();
+    }
 
     public void addPlayingHistory(UserInfo userInfo, PlayingHistoryRequest request) {
         if (userInfo == null || userInfo.isGuest()) {

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -9,10 +9,11 @@ import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.PlayingHistoryRepository;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,22 +30,37 @@ public class PlayingHistoryService {
 
     public List<RecentlyPlayedHearitResponse> getRecentPlayingHistoryOfMember(UserInfo userInfo) {
         if (userInfo == null || userInfo.isGuest()) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
-        return toPlayingHistoryResponseForMember(userInfo.getMemberId());
+        return toPlayingHistoryResponse(userInfo.getMemberId());
     }
 
-    private List<RecentlyPlayedHearitResponse> toPlayingHistoryResponseForMember(Long memberId) {
+    private List<RecentlyPlayedHearitResponse> toPlayingHistoryResponse(Long memberId) {
         List<PlayingHistory> histories = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(
                 memberId, PLAYING_HISTORY_MAX_COUNT);
-        Map<Long, Long> lastPlayTimeByHearitId = histories.stream()
-                .collect(Collectors.toMap(PlayingHistory::getHearitId, PlayingHistory::getLastPlayTime,
-                        (existing, ignored) -> existing, LinkedHashMap::new));
-        Map<Long, Hearit> hearitMap = hearitRepository.findAllByIdIn(lastPlayTimeByHearitId.keySet().stream().toList())
-                .stream().collect(Collectors.toMap(Hearit::getId, h -> h));
+        Map<Long, Long> lastPlayTimeByHearitId = mapHearitIdToLastPlayTime(histories);
+        Map<Long, Hearit> hearitMap = mapHearitIdToHearit(lastPlayTimeByHearitId.keySet());
         return lastPlayTimeByHearitId.entrySet().stream()
-                .map(e -> RecentlyPlayedHearitResponse.from(hearitMap.get(e.getKey()), e.getValue()))
+                .map(entry -> RecentlyPlayedHearitResponse.from(hearitMap.get(entry.getKey()), entry.getValue()))
                 .toList();
+    }
+
+    private Map<Long, Long> mapHearitIdToLastPlayTime(List<PlayingHistory> histories) {
+        return histories.stream()
+                .collect(Collectors.toMap(
+                        PlayingHistory::getHearitId,      // Key: hearitId
+                        PlayingHistory::getLastPlayTime,  // Value: lastPlayTime
+                        (existing, ignored) -> existing,  // 중복 key 처리
+                        LinkedHashMap::new // DB에서 가져온 순서(최신순) 유지
+                ));
+    }
+
+    private Map<Long, Hearit> mapHearitIdToHearit(Set<Long> hearitIds) {
+        return hearitRepository.findAllByIdIn(hearitIds.stream().toList()).stream()
+                .collect(Collectors.toMap(
+                        Hearit::getId, // Key: hearitId
+                        hearit -> hearit // Value: Hearit 객체
+                ));
     }
 
     public void addPlayingHistory(UserInfo userInfo, PlayingHistoryRequest request) {

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -1,7 +1,7 @@
 package com.onair.hearit.app.application;
 
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
-import com.onair.hearit.app.dto.response.PlayingHistoryResponse;
+import com.onair.hearit.app.dto.response.RecentlyPlayedHearitResponse;
 import com.onair.hearit.app.infrastructure.scheduler.PlayingHistoryBuffer;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.PlayingHistory;
@@ -27,14 +27,14 @@ public class PlayingHistoryService {
     private final PlayingHistoryRepository playingHistoryRepository;
     private final PlayingHistoryBuffer playingHistoryBuffer;
 
-    public List<PlayingHistoryResponse> getRecentPlayingHistoryOfMember(UserInfo userInfo) {
+    public List<RecentlyPlayedHearitResponse> getRecentPlayingHistoryOfMember(UserInfo userInfo) {
         if (userInfo == null || userInfo.isGuest()) {
             return new ArrayList<>();
         }
         return toPlayingHistoryResponseForMember(userInfo.getMemberId());
     }
 
-    private List<PlayingHistoryResponse> toPlayingHistoryResponseForMember(Long memberId) {
+    private List<RecentlyPlayedHearitResponse> toPlayingHistoryResponseForMember(Long memberId) {
         List<PlayingHistory> histories = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(
                 memberId, PLAYING_HISTORY_MAX_COUNT);
         Map<Long, Long> lastPlayTimeByHearitId = histories.stream()
@@ -43,7 +43,7 @@ public class PlayingHistoryService {
         Map<Long, Hearit> hearitMap = hearitRepository.findAllByIdIn(lastPlayTimeByHearitId.keySet().stream().toList())
                 .stream().collect(Collectors.toMap(Hearit::getId, h -> h));
         return lastPlayTimeByHearitId.entrySet().stream()
-                .map(e -> PlayingHistoryResponse.from(hearitMap.get(e.getKey()), e.getValue()))
+                .map(e -> RecentlyPlayedHearitResponse.from(hearitMap.get(e.getKey()), e.getValue()))
                 .toList();
     }
 

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/PlayingHistoryResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/PlayingHistoryResponse.java
@@ -1,0 +1,31 @@
+package com.onair.hearit.app.dto.response;
+
+import com.onair.hearit.common.domain.Category;
+import com.onair.hearit.common.domain.Hearit;
+import java.time.LocalDateTime;
+
+public record PlayingHistoryResponse(
+        Long id,
+        String title,
+        Integer playTime,
+        Long lastPlayTime,
+        LocalDateTime createdAt,
+        CategoryResponse category
+) {
+    public static PlayingHistoryResponse from(Hearit hearit, Long lastPlayTime) {
+        return new PlayingHistoryResponse(
+                hearit.getId(),
+                hearit.getTitle(),
+                hearit.getPlayTime(),
+                lastPlayTime,
+                hearit.getCreatedAt(),
+                CategoryResponse.from(hearit.getCategory())
+        );
+    }
+
+    private record CategoryResponse(Long id, String name, String colorCode) {
+        public static CategoryResponse from(Category category) {
+            return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
+        }
+    }
+}

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/RecentlyPlayedHearitResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/RecentlyPlayedHearitResponse.java
@@ -4,7 +4,7 @@ import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import java.time.LocalDateTime;
 
-public record PlayingHistoryResponse(
+public record RecentlyPlayedHearitResponse(
         Long id,
         String title,
         Integer playTime,
@@ -12,8 +12,8 @@ public record PlayingHistoryResponse(
         LocalDateTime createdAt,
         CategoryResponse category
 ) {
-    public static PlayingHistoryResponse from(Hearit hearit, Long lastPlayTime) {
-        return new PlayingHistoryResponse(
+    public static RecentlyPlayedHearitResponse from(Hearit hearit, Long lastPlayTime) {
+        return new RecentlyPlayedHearitResponse(
                 hearit.getId(),
                 hearit.getTitle(),
                 hearit.getPlayTime(),

--- a/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
+++ b/backend/src/main/java/com/onair/hearit/app/infrastructure/scheduler/PlayingHistoryBuffer.java
@@ -28,11 +28,11 @@ public class PlayingHistoryBuffer {
     }
 
     @Transactional
-    @Scheduled(fixedDelay = 2000)
+    @Scheduled(fixedDelay = 1_000)
     public void flush() {
         if (!queue.isEmpty()) {
             List<PlayingHistory> batchRecords = new ArrayList<>();
-            queue.drainTo(batchRecords, 500);
+            queue.drainTo(batchRecords, 5_000);
             if (!batchRecords.isEmpty()) {
                 playingHistoryCommandRepository.bulkInsert(batchRecords);
             }

--- a/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
@@ -22,7 +22,7 @@ public class PlayingHistoryController {
 
     private final PlayingHistoryService playingHistoryService;
 
-    @GetMapping
+    @GetMapping("/hearits")
     public ResponseEntity<List<RecentlyPlayedHearitResponse>> readPlayingHistoriesOfMember(
             @AuthenticationPrincipal RequestUser requestUser) {
         List<RecentlyPlayedHearitResponse> responses =

--- a/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
@@ -2,7 +2,7 @@ package com.onair.hearit.app.presentation;
 
 import com.onair.hearit.app.application.PlayingHistoryService;
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
-import com.onair.hearit.app.dto.response.PlayingHistoryResponse;
+import com.onair.hearit.app.dto.response.RecentlyPlayedHearitResponse;
 import com.onair.hearit.auth.domain.RequestUser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,9 +23,9 @@ public class PlayingHistoryController {
     private final PlayingHistoryService playingHistoryService;
 
     @GetMapping
-    public ResponseEntity<List<PlayingHistoryResponse>> readPlayingHistoriesOfMember(
+    public ResponseEntity<List<RecentlyPlayedHearitResponse>> readPlayingHistoriesOfMember(
             @AuthenticationPrincipal RequestUser requestUser) {
-        List<PlayingHistoryResponse> responses =
+        List<RecentlyPlayedHearitResponse> responses =
                 playingHistoryService.getRecentPlayingHistoryOfMember(requestUser.getUserInfo());
         return ResponseEntity.ok(responses);
     }

--- a/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
@@ -2,11 +2,14 @@ package com.onair.hearit.app.presentation;
 
 import com.onair.hearit.app.application.PlayingHistoryService;
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.app.dto.response.PlayingHistoryResponse;
 import com.onair.hearit.auth.domain.RequestUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlayingHistoryController {
 
     private final PlayingHistoryService playingHistoryService;
+
+    @GetMapping
+    public ResponseEntity<List<PlayingHistoryResponse>> readPlayingHistoriesOfMember(
+            @AuthenticationPrincipal RequestUser requestUser) {
+        List<PlayingHistoryResponse> responses =
+                playingHistoryService.getRecentPlayingHistoryOfMember(requestUser.getUserInfo());
+        return ResponseEntity.ok(responses);
+    }
 
     @PostMapping
     public ResponseEntity<Void> createPlayingHistory(

--- a/backend/src/main/java/com/onair/hearit/auth/config/ApiSecurityConfig.java
+++ b/backend/src/main/java/com/onair/hearit/auth/config/ApiSecurityConfig.java
@@ -37,7 +37,7 @@ public class ApiSecurityConfig {
             "/api/*/hearits/**",
             "/api/*/categories/**",
             "/api/*/keywords/**",
-            "/api/*/playing-histories"
+            "/api/*/playing-histories/**"
     };
 
     private final ObjectMapper objectMapper;

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
@@ -61,9 +61,6 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
             """)
     List<Hearit> findByCategory(@Param("categoryId") Long categoryId, @Param("size") int size);
 
-    @Query("SELECT h FROM Hearit h JOIN FETCH h.category WHERE h.id IN :hearitIds")
-    List<Hearit> findAllByIdInWithCategory(@Param("hearitIds") List<Long> hearitIds);
-
     @Query("""
             SELECT h
             FROM Hearit h

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
@@ -4,12 +4,19 @@ import com.onair.hearit.common.domain.PlayingHistory;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PlayingHistoryRepository extends JpaRepository<PlayingHistory, Long> {
 
     Optional<PlayingHistory> findByHearitIdAndMemberId(Long hearitId, Long memberId);
 
-    boolean existsByHearitIdAndMemberId(Long hearitId, Long memberId);
-
-    List<PlayingHistory> findByMemberIdAndHearitIdIn(Long memberId, List<Long> hearitIds);
+    @Query("""
+            SELECT ph
+            FROM PlayingHistory ph
+            WHERE ph.memberId = :memberId
+            ORDER BY ph.updatedAt DESC
+            LIMIT :size
+            """)
+    List<PlayingHistory> findByMemberIdOrderByUpdatedAtDesc(@Param("memberId") Long memberId, @Param("size") int size);
 }

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepository.java
@@ -19,4 +19,6 @@ public interface PlayingHistoryRepository extends JpaRepository<PlayingHistory, 
             LIMIT :size
             """)
     List<PlayingHistory> findByMemberIdOrderByUpdatedAtDesc(@Param("memberId") Long memberId, @Param("size") int size);
+
+    List<PlayingHistory> findByMemberIdAndHearitIdIn(Long memberId, List<Long> hearitIds);
 }

--- a/backend/src/main/resources/db/migration/V2025090222217__playing_history_index.sql
+++ b/backend/src/main/resources/db/migration/V2025090222217__playing_history_index.sql
@@ -1,0 +1,2 @@
+-- 최근 들은 재생 기록 조회
+CREATE INDEX idx_member_updated_at ON playing_history(member_id, updated_at DESC);

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -5,12 +5,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.app.dto.response.PlayingHistoryResponse;
 import com.onair.hearit.app.infrastructure.scheduler.PlayingHistoryBuffer;
+import com.onair.hearit.auth.domain.RequestUser;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
 import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.Source;
+import com.onair.hearit.common.domain.UserInfo;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.infrastructure.jdbc.PlayingHistoryCommandRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
@@ -55,7 +58,48 @@ class PlayingHistoryServiceTest {
 
     @BeforeEach
     void setup() {
-        playingHistoryService = new PlayingHistoryService(playingHistoryBuffer, hearitRepository);
+        playingHistoryService = new PlayingHistoryService(
+                hearitRepository,
+                playingHistoryRepository,
+                playingHistoryBuffer);
+    }
+
+    @Test
+    @DisplayName("회원은 최근 재생 기록을 조회할 수 있다.")
+    void getRecentPlayingHistoryOfMember_whenMember() throws InterruptedException {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        UserInfo memberInfo = RequestUser.member(member.getId()).getUserInfo();
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        dbHelper.insertPlayingHistory(new PlayingHistory(memberInfo.getMemberId(), hearit1, 10));
+        Thread.sleep(1000);
+        dbHelper.insertPlayingHistory(new PlayingHistory(memberInfo.getMemberId(), hearit2, 20));
+
+        // when
+        List<PlayingHistoryResponse> result = playingHistoryService.getRecentPlayingHistoryOfMember(memberInfo);
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(2),
+                () -> assertThat(result.get(0).id()).isEqualTo(hearit2.getId()),
+                () -> assertThat(result.get(1).id()).isEqualTo(hearit1.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("회원이 아닌 유저는 빈 재생 기록을 반환한다.")
+    void getRecentPlayingHistoryOfMember_whenGuestOrNull_thenReturnEmpty() {
+        // given
+        UserInfo guestInfo = RequestUser.guest(UUID.randomUUID().toString()).getUserInfo();
+
+        // when
+        List<PlayingHistoryResponse> guestResult = playingHistoryService.getRecentPlayingHistoryOfMember(guestInfo);
+
+        // then
+        assertThat(guestResult).isEmpty();
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
-import com.onair.hearit.app.dto.response.PlayingHistoryResponse;
+import com.onair.hearit.app.dto.response.RecentlyPlayedHearitResponse;
 import com.onair.hearit.app.infrastructure.scheduler.PlayingHistoryBuffer;
 import com.onair.hearit.auth.domain.RequestUser;
 import com.onair.hearit.common.domain.Category;
@@ -79,7 +79,7 @@ class PlayingHistoryServiceTest {
         dbHelper.insertPlayingHistory(new PlayingHistory(memberInfo.getMemberId(), hearit2, 20));
 
         // when
-        List<PlayingHistoryResponse> result = playingHistoryService.getRecentPlayingHistoryOfMember(memberInfo);
+        List<RecentlyPlayedHearitResponse> result = playingHistoryService.getRecentPlayingHistoryOfMember(memberInfo);
 
         // then
         assertAll(
@@ -96,7 +96,7 @@ class PlayingHistoryServiceTest {
         UserInfo guestInfo = RequestUser.guest(UUID.randomUUID().toString()).getUserInfo();
 
         // when
-        List<PlayingHistoryResponse> guestResult = playingHistoryService.getRecentPlayingHistoryOfMember(guestInfo);
+        List<RecentlyPlayedHearitResponse> guestResult = playingHistoryService.getRecentPlayingHistoryOfMember(guestInfo);
 
         // then
         assertThat(guestResult).isEmpty();

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
-import com.onair.hearit.app.dto.response.PlayingHistoryResponse;
+import com.onair.hearit.app.dto.response.RecentlyPlayedHearitResponse;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
@@ -43,7 +43,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
         }
 
         // when & then
-        List<PlayingHistoryResponse> response = RestAssured.given(this.spec)
+        List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
                 .header("Authorization", "Bearer " + token)
                 .contentType("application/json")
                 .filter(document("playing-history-read-member",
@@ -85,7 +85,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
         }
 
         // when & then
-        List<PlayingHistoryResponse> response = RestAssured.given(this.spec)
+        List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
                 .contentType("application/json")
                 .filter(document("playing-history-read-guest",
                         resource(ResourceSnippetParameters.builder()

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -2,10 +2,12 @@ package com.onair.hearit.app.presentation;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.app.dto.response.PlayingHistoryResponse;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
@@ -15,6 +17,7 @@ import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.fixture.IntegrationTest;
 import com.onair.hearit.fixture.TestFixture;
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +28,84 @@ class PlayingHistoryControllerTest extends IntegrationTest {
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("로그인한 사용자는 최근 재생 기록 최대 10개와 200 OK를 반환한다.")
+    void getRecentPlayingHistories_whenMember() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+
+        for (int i = 0; i < 12; i++) {
+            Hearit hearit = dbHelper.insertHearit(createHearitWith(100 + i, category));
+            dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L * i));
+        }
+
+        // when & then
+        List<PlayingHistoryResponse> response = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .filter(document("playing-history-read-member",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Playing History API")
+                                .summary("최근 재생 기록 조회")
+                                .description("로그인한 사용자는 최근 재생 기록을 최대 10개까지 조회할 수 있습니다.\n\n"
+                                        + "로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
+                                .responseFields(
+                                        fieldWithPath("[].id").description("히어릿 ID"),
+                                        fieldWithPath("[].title").description("히어릿 제목"),
+                                        fieldWithPath("[].playTime").description("히어릿 전체 재생 시간(s)"),
+                                        fieldWithPath("[].lastPlayTime").description("사용자가 마지막으로 재생한 시간(ms)"),
+                                        fieldWithPath("[].createdAt").description("히어릿 생성일"),
+                                        fieldWithPath("[].category.id").description("카테고리 ID"),
+                                        fieldWithPath("[].category.name").description("카테고리 이름"),
+                                        fieldWithPath("[].category.colorCode").description("카테고리 색상 코드")
+                                ).build())
+                ))
+                .when()
+                .get("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(new TypeRef<>() {
+                });
+
+        assertThat(response).hasSize(10);
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 최근 재생 기록 조회 시 빈 리스트와 200 OK를 반환한다.")
+    void getRecentPlayingHistories_whenGuest() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        for (int i = 0; i < 2; i++) {
+            Hearit hearit = dbHelper.insertHearit(createHearitWith(100 + i, category));
+            dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L * i));
+        }
+
+        // when & then
+        List<PlayingHistoryResponse> response = RestAssured.given(this.spec)
+                .contentType("application/json")
+                .filter(document("playing-history-read-guest",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Playing History API")
+                                .summary("최근 재생 기록 조회")
+                                .description("로그인한 사용자는 최근 재생 기록을 최대 10개까지 조회할 수 있습니다.\n\n"
+                                        + "로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
+                                .responseFields(
+                                        fieldWithPath("[]").description("빈 리스트")
+                                ).build())
+                ))
+                .when()
+                .get("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(new TypeRef<>() {
+                });
+
+        assertThat(response).hasSize(0);
+    }
 
     @Test
     @DisplayName("로그인한 사용자가 처음 재생기록 저장 시, 200 OK를 반환한다.")

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -64,7 +64,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 ).build())
                 ))
                 .when()
-                .get("/api/v1/playing-histories")
+                .get("/api/v1/playing-histories/hearits")
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract().as(new TypeRef<>() {
@@ -98,7 +98,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 ).build())
                 ))
                 .when()
-                .get("/api/v1/playing-histories")
+                .get("/api/v1/playing-histories/hearits")
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract().as(new TypeRef<>() {

--- a/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/HearitRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/HearitRepositoryTest.java
@@ -80,28 +80,6 @@ class HearitRepositoryTest {
     }
 
     @Test
-    @DisplayName("히어릿 아이디들로 히어릿 리스트를 카테고리와 함께 조회한다.")
-    void findAllByIdInWithCategoryTest() {
-        // given
-        Category category1 = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
-        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
-        List<Long> hearitIds = List.of(hearit1.getId(), hearit2.getId(), hearit3.getId());
-
-        // when
-        List<Hearit> hearits = hearitRepository.findAllByIdInWithCategory(hearitIds);
-
-        // then
-        assertAll(() -> {
-            assertThat(hearits).hasSize(3);
-            assertThat(hearits.get(0).getId()).isEqualTo(hearit1.getId());
-            assertThat(hearits.get(1).getId()).isEqualTo(hearit2.getId());
-            assertThat(hearits.get(2).getId()).isEqualTo(hearit3.getId());
-        });
-    }
-
-    @Test
     @DisplayName("멤버별 카테고리 내 히어릿 조회 시 마지막 재생 시간도 포함된다.")
     void findWithPlayTimeByCategoryIdTest() {
         // given

--- a/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/PlayingHistoryRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.onair.hearit.common.infrastructure.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.common.domain.Category;
+import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.TestFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("fake-test")
+@Import({DbHelper.class, TestJpaAuditingConfig.class})
+class PlayingHistoryRepositoryTest {
+
+    @Autowired
+    private DbHelper dbHelper;
+
+    @Autowired
+    private PlayingHistoryRepository playingHistoryRepository;
+
+    @Test
+    @DisplayName("회원의 재생 기록을 업데이트 날짜를 기준으로 내림차순 정렬하여 10개 조회한다.")
+    void findByMemberIdOrderByUpdatedAtDesc() throws InterruptedException {
+        // given
+        Member member1 = dbHelper.insertMember(TestFixture.createFixedMember());
+        Member member2 = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        dbHelper.insertPlayingHistory(new PlayingHistory(member1.getId(), hearit1, 10));
+        Thread.sleep(10);
+        dbHelper.insertPlayingHistory(new PlayingHistory(member1.getId(), hearit2, 20));
+        Thread.sleep(10);
+        dbHelper.insertPlayingHistory(new PlayingHistory(member2.getId(), hearit2, 20));
+
+        // when
+        List<PlayingHistory> result = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(member1.getId(), 10);
+
+        // then
+        assertAll(() -> {
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getHearitId()).isEqualTo(hearit2.getId());
+            assertThat(result.get(1).getHearitId()).isEqualTo(hearit1.getId());
+        });
+    }
+}


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 재생 기록 테이블에서 멤버에 대한 최근에 들은 히어릿 조회 API
- 재생 기록 테이블 조회 시, 복합 index 생성으로 1.1ms -> 0.283ms 조회 성능 최적화
- 재생 기록 저장 Buffer 파라미터 변경

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
- 최근 재생  기록 조회에 대한 테스트 작성해 두었습니다. 
- Controller 테스트에 API 문서화 진행했습니다.

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->
현재 Member가 아닌 경우에는 클라이언트 측 요구사항을 반영하여 빈 리스트를 반환하도록 구현해두었습니다. 

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #559 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 최근 재생 기록 조회 API 추가: 로그인 사용자는 최근 최대 N개(기본 10) 항목을 받고, 비로그인은 빈 목록을 반환. 항목에 콘텐츠 정보·카테고리·마지막 재생 시각 포함.

- Performance
  - 버퍼 플러시 주기 단축(2s→1s) 및 배치 크기 확대으로 처리량 향상.
  - 최근 이력 조회용 DB 인덱스 추가로 조회 속도 개선.

- Tests
  - 서비스·컨트롤러·저장소 대상 최근 재생 기록 관련 테스트 추가 및 보강.

- Chores
  - 저장소 쿼리 및 공개 API 호출 경로/시그니처 일부 조정.
- Security
  - 재생 기록 관련 공개 GET 경로 범위 확장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->