### PR TITLE
[AN] bug: 탐색화면 destroy 오류 해결

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -123,7 +123,6 @@ class ExploreFragment :
     }
 
     override fun onDestroyView() {
-        super.onDestroyView()
         animator?.removeAllListeners()
         animator?.cancel()
         animator?.setTarget(null)
@@ -133,6 +132,8 @@ class ExploreFragment :
         playerManager.stop()
         _binding = null
         lastPlayingIndex = RecyclerView.NO_POSITION
+
+        super.onDestroyView()
     }
 
     override fun onDestroy() {
@@ -149,13 +150,10 @@ class ExploreFragment :
     }
 
     private fun setupRecyclerView() {
-        _binding?.rvExplore?.adapter = adapter
-        _binding?.rvExplore?.let {
-            snapHelper.attachToRecyclerView(it)
-        }
-        snapHelper.attachToRecyclerView(binding.rvExplore)
-
         val bindingSafe = _binding ?: return
+        bindingSafe.rvExplore.adapter = adapter
+        bindingSafe.rvExplore.let { snapHelper.attachToRecyclerView(it) }
+
         bindingSafe.rvExplore.addOnScrollListener(
             object : RecyclerView.OnScrollListener() {
                 override fun onScrollStateChanged(
@@ -249,14 +247,15 @@ class ExploreFragment :
         val currentPosition = currentIndex()
         val nextPosition = currentPosition + 1
         if (nextPosition < adapter.itemCount) {
-            binding.rvExplore.smoothScrollToPosition(nextPosition)
+            _binding?.rvExplore?.smoothScrollToPosition(nextPosition)
         }
     }
 
     private fun startSwipeAnimation() {
-        binding.lavExploreSwipeUp.visibility = View.VISIBLE
+        val bindingSafe = _binding ?: return
+        bindingSafe.lavExploreSwipeUp.visibility = View.VISIBLE
         animator =
-            ObjectAnimator.ofFloat(binding.rvExplore, "translationY", 0f, -100f, 0f).apply {
+            ObjectAnimator.ofFloat(bindingSafe.rvExplore, "translationY", 0f, -100f, 0f).apply {
                 duration = 1300
                 repeatCount = 1
                 repeatMode = ObjectAnimator.RESTART

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -123,6 +123,7 @@ class ExploreFragment :
     }
 
     override fun onDestroyView() {
+        super.onDestroyView()
         animator?.removeAllListeners()
         animator?.cancel()
         animator?.setTarget(null)
@@ -132,8 +133,6 @@ class ExploreFragment :
         playerManager.stop()
         _binding = null
         lastPlayingIndex = RecyclerView.NO_POSITION
-
-        super.onDestroyView()
     }
 
     override fun onDestroy() {
@@ -150,11 +149,10 @@ class ExploreFragment :
     }
 
     private fun setupRecyclerView() {
-        val bindingSafe = _binding ?: return
-        bindingSafe.rvExplore.adapter = adapter
-        bindingSafe.rvExplore.let { snapHelper.attachToRecyclerView(it) }
+        binding.rvExplore.adapter = adapter
+        snapHelper.attachToRecyclerView(binding.rvExplore)
 
-        bindingSafe.rvExplore.addOnScrollListener(
+        binding.rvExplore.addOnScrollListener(
             object : RecyclerView.OnScrollListener() {
                 override fun onScrollStateChanged(
                     recyclerView: RecyclerView,
@@ -213,7 +211,7 @@ class ExploreFragment :
 
     private fun currentIndex(): Int {
         val layoutManager =
-            _binding?.rvExplore?.layoutManager as? LinearLayoutManager
+            binding.rvExplore.layoutManager as? LinearLayoutManager
                 ?: return RecyclerView.NO_POSITION
         val snapView = snapHelper.findSnapView(layoutManager) ?: return RecyclerView.NO_POSITION
         return layoutManager.getPosition(snapView)
@@ -247,15 +245,14 @@ class ExploreFragment :
         val currentPosition = currentIndex()
         val nextPosition = currentPosition + 1
         if (nextPosition < adapter.itemCount) {
-            _binding?.rvExplore?.smoothScrollToPosition(nextPosition)
+            binding.rvExplore.smoothScrollToPosition(nextPosition)
         }
     }
 
     private fun startSwipeAnimation() {
-        val bindingSafe = _binding ?: return
-        bindingSafe.lavExploreSwipeUp.visibility = View.VISIBLE
+        binding.lavExploreSwipeUp.visibility = View.VISIBLE
         animator =
-            ObjectAnimator.ofFloat(bindingSafe.rvExplore, "translationY", 0f, -100f, 0f).apply {
+            ObjectAnimator.ofFloat(binding.rvExplore, "translationY", 0f, -100f, 0f).apply {
                 duration = 1300
                 repeatCount = 1
                 repeatMode = ObjectAnimator.RESTART

--- a/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/explore/ExploreFragment.kt
@@ -45,7 +45,14 @@ class ExploreFragment :
 
     private val viewModel: ExploreViewModel by activityViewModels { ExploreViewModelFactory() }
 
-    private lateinit var playerManager: ExplorePlayerManager
+    private val playerManager by lazy {
+        ExplorePlayerManager(
+            context = requireContext().applicationContext,
+            lifecycleScope = viewLifecycleOwner.lifecycleScope,
+            onPlaybackEnded = { scrollToNextItem() },
+            onPositionUpdated = { position -> highlightScript(position) },
+        )
+    }
     private val player get() = playerManager.player
 
     private val adapter by lazy { ShortsAdapter(player, this) }
@@ -88,14 +95,6 @@ class ExploreFragment :
         binding.lifecycleOwner = viewLifecycleOwner
         binding.viewModel = viewModel
         setupWindowInsets()
-
-        playerManager =
-            ExplorePlayerManager(
-                context = requireContext().applicationContext,
-                lifecycleScope = viewLifecycleOwner.lifecycleScope,
-                onPlaybackEnded = { scrollToNextItem() },
-                onPositionUpdated = { position -> highlightScript(position) },
-            )
 
         setupRecyclerView()
         observeViewModel()
@@ -150,10 +149,14 @@ class ExploreFragment :
     }
 
     private fun setupRecyclerView() {
-        binding.rvExplore.adapter = adapter
+        _binding?.rvExplore?.adapter = adapter
+        _binding?.rvExplore?.let {
+            snapHelper.attachToRecyclerView(it)
+        }
         snapHelper.attachToRecyclerView(binding.rvExplore)
 
-        binding.rvExplore.addOnScrollListener(
+        val bindingSafe = _binding ?: return
+        bindingSafe.rvExplore.addOnScrollListener(
             object : RecyclerView.OnScrollListener() {
                 override fun onScrollStateChanged(
                     recyclerView: RecyclerView,
@@ -212,7 +215,7 @@ class ExploreFragment :
 
     private fun currentIndex(): Int {
         val layoutManager =
-            binding.rvExplore.layoutManager as? LinearLayoutManager
+            _binding?.rvExplore?.layoutManager as? LinearLayoutManager
                 ?: return RecyclerView.NO_POSITION
         val snapView = snapHelper.findSnapView(layoutManager) ?: return RecyclerView.NO_POSITION
         return layoutManager.getPosition(snapView)


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- Crashlytics에서 발견된 탐색화면 오류 수정
- 탐색 화면 destroy시에 player가 initialize 오류 해결이 필요함


## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#581 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 재생 종료 시 다음 항목으로 자연스럽게 스크롤되어 끊김이 줄었습니다.
  - 스크립트 하이라이트 위치 갱신의 정확도가 향상되었습니다.
  - 화면 전환/프래그먼트 수명주기 중 발생하던 널 참조 관련 충돌 가능성을 추가로 줄였습니다.
  - 현재 항목 인식 로직 안정성을 개선해 잘못된 포지션 반환을 방지했습니다.

- 리팩터링
  - 플레이어 초기화를 지연 로딩으로 전환해 시작 안정성과 성능을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->