### PR TITLE
[BE] refactor: 북마크된 히어릿 조회 API 반환값에서 Source와 isFinished 여부 필드 추가 #590

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/BookmarkService.java
@@ -11,7 +11,7 @@ import com.onair.hearit.common.exception.custom.AlreadyExistException;
 import com.onair.hearit.common.exception.custom.ForbiddenException;
 import com.onair.hearit.common.exception.custom.NotFoundException;
 import com.onair.hearit.common.exception.custom.UnauthenticatedException;
-import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlaytimeProjection;
+import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlayingHistoryProjection;
 import com.onair.hearit.common.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.common.infrastructure.jpa.MemberRepository;
@@ -35,17 +35,17 @@ public class BookmarkService {
             PagingRequest pagingRequest) {
         Member member = getMemberByUserInfo(userInfo);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
-        Page<BookmarkWithPlaytimeProjection> projections = bookmarkRepository.findAllByMemberOrderByRecent(
+        Page<BookmarkWithPlayingHistoryProjection> projections = bookmarkRepository.findAllByMemberOrderByRecent(
                 member.getId(),
                 pageable);
         return toBookmarkHearitResponse(projections);
     }
 
-    private Page<BookmarkHearitResponseV2> toBookmarkHearitResponse(Page<BookmarkWithPlaytimeProjection> projections) {
+    private Page<BookmarkHearitResponseV2> toBookmarkHearitResponse(Page<BookmarkWithPlayingHistoryProjection> projections) {
         return projections.map(p -> BookmarkHearitResponseV2.of(
                 p.getBookmark(),
                 p.getBookmark().getHearit(),
-                p.getLastPlayTime()
+                p.getPlayingHistory()
         ));
     }
 

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV2.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/BookmarkHearitResponseV2.java
@@ -3,6 +3,9 @@ package com.onair.hearit.app.dto.response;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.domain.Source;
+import java.util.List;
 
 public record BookmarkHearitResponseV2(
         Long hearitId,
@@ -11,22 +14,43 @@ public record BookmarkHearitResponseV2(
         String summary,
         Integer playTime,
         Long lastPlayTime,
+        Boolean isFinished,
+        List<SourceResponse> sources,
         CategoryResponse category
 ) {
-    public static BookmarkHearitResponseV2 of(Bookmark bookmark, Hearit hearit, Long lastPlayTime) {
+    public static BookmarkHearitResponseV2 of(Bookmark bookmark, Hearit hearit, PlayingHistory playingHistory) {
+        List<SourceResponse> sources = getSources(hearit.getSources());
         return new BookmarkHearitResponseV2(
                 hearit.getId(),
                 bookmark.getId(),
                 hearit.getTitle(),
                 hearit.getSummary(),
                 hearit.getPlayTime(),
-                lastPlayTime,
+                playingHistory != null ? playingHistory.getLastPlayTime() : null,
+                playingHistory != null ? playingHistory.isFinished() : null,
+                sources,
                 CategoryResponse.from(hearit.getCategory()));
+    }
+
+    private static List<SourceResponse> getSources(List<Source> sources) {
+        return sources.stream().map(SourceResponse::from).toList();
     }
 
     public record CategoryResponse(Long id, String name, String colorCode) {
         public static CategoryResponse from(Category category) {
             return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
+        }
+    }
+
+    public record SourceResponse(
+            String sourceName,
+            String sourceUrl
+    ) {
+        private static SourceResponse from(Source source) {
+            return new SourceResponse(
+                    source.getSourceName(),
+                    source.getSourceUrl()
+            );
         }
     }
 }

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/dto/BookmarkWithPlayingHistoryProjection.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/dto/BookmarkWithPlayingHistoryProjection.java
@@ -1,0 +1,10 @@
+package com.onair.hearit.common.infrastructure.dto;
+
+import com.onair.hearit.common.domain.Bookmark;
+import com.onair.hearit.common.domain.PlayingHistory;
+
+public interface BookmarkWithPlayingHistoryProjection {
+    Bookmark getBookmark();
+
+    PlayingHistory getPlayingHistory();
+}

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/dto/BookmarkWithPlaytimeProjection.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/dto/BookmarkWithPlaytimeProjection.java
@@ -1,9 +1,0 @@
-package com.onair.hearit.common.infrastructure.dto;
-
-import com.onair.hearit.common.domain.Bookmark;
-
-public interface BookmarkWithPlaytimeProjection {
-    Bookmark getBookmark();
-
-    Long getLastPlayTime();
-}

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/BookmarkRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/BookmarkRepository.java
@@ -3,7 +3,7 @@ package com.onair.hearit.common.infrastructure.jpa;
 import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
-import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlaytimeProjection;
+import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlayingHistoryProjection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -17,7 +17,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     @Query("""
                 SELECT
                     b AS bookmark,
-                    ph.lastPlayTime AS lastPlayTime
+                    ph AS playingHistory
                 FROM Bookmark b
                 JOIN FETCH b.hearit h
                 JOIN FETCH h.category c
@@ -26,8 +26,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
                 WHERE b.member.id = :memberId
                 ORDER BY b.createdAt DESC
             """)
-    Page<BookmarkWithPlaytimeProjection> findAllByMemberOrderByRecent(@Param("memberId") Long memberId,
-                                                                      Pageable pageable);
+    Page<BookmarkWithPlayingHistoryProjection> findAllByMemberOrderByRecent(@Param("memberId") Long memberId,
+                                                                            Pageable pageable);
 
     Optional<Bookmark> findByHearitAndMember(Hearit hearit, Member member);
 

--- a/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/BookmarkControllerTest.java
@@ -124,6 +124,12 @@ class BookmarkControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
                                                         fieldWithPath("content[].lastPlayTime").description(
                                                                 "히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].isFinished").description(
+                                                                "히어릿 재생 완료 여부").optional(),
+                                                        fieldWithPath("content[].sources").description("히어릿 소스 리스트"),
+                                                        fieldWithPath("content[].sources[].sourceName").description("소스 이름"),
+                                                        fieldWithPath("content[].sources[].sourceUrl").description("소스 URL"),
+                                                        fieldWithPath("content[].category").description("카테고리 정보"),
                                                         fieldWithPath("content[].category.id").description("카테고리 ID"),
                                                         fieldWithPath("content[].category.name").description("카테고리 이름"),
                                                         fieldWithPath("content[].category.colorCode").description("카테고리 색상 코드")

--- a/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/BookmarkRepositoryTest.java
+++ b/backend/src/test/java/com/onair/hearit/common/infrastructure/jpa/BookmarkRepositoryTest.java
@@ -7,7 +7,8 @@ import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
-import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlaytimeProjection;
+import com.onair.hearit.common.domain.PlayingHistory;
+import com.onair.hearit.common.infrastructure.dto.BookmarkWithPlayingHistoryProjection;
 import com.onair.hearit.fixture.DbHelper;
 import com.onair.hearit.fixture.TestFixture;
 import java.util.List;
@@ -46,7 +47,7 @@ class BookmarkRepositoryTest {
         Bookmark newestBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit3));
 
         // when
-        Page<BookmarkWithPlaytimeProjection> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(
+        Page<BookmarkWithPlayingHistoryProjection> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(
                 member.getId(),
                 PageRequest.of(0, 5));
 
@@ -55,6 +56,36 @@ class BookmarkRepositoryTest {
             assertThat(bookmarks.getContent().get(0).getBookmark().getId()).isEqualTo(newestBookmark.getId());
             assertThat(bookmarks.getContent().get(1).getBookmark().getId()).isEqualTo(mideumBookmark.getId());
             assertThat(bookmarks.getContent().get(2).getBookmark().getId()).isEqualTo(oldestBookmark.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("멤버의 북마크와 함께 재생 시간을 가져온다.")
+    void findAllByMemberOrderByRecentWithPlayingTimeTest() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(
+                member.getId(),
+                hearit,
+                (hearit.getPlayTime() - 10) * 1000L));
+
+        // when
+        Page<BookmarkWithPlayingHistoryProjection> bookmarks = bookmarkRepository.findAllByMemberOrderByRecent(
+                member.getId(),
+                PageRequest.of(0, 5)
+        );
+
+        // then
+        BookmarkWithPlayingHistoryProjection projection = bookmarks.getContent().get(0);
+
+        assertAll(() -> {
+            assertThat(bookmarks.getContent()).hasSize(1);
+            assertThat(projection.getBookmark().getId()).isEqualTo(bookmark.getId());
+            assertThat(projection.getPlayingHistory().getLastPlayTime()).isEqualTo(playingHistory.getLastPlayTime());
+            assertThat(projection.getPlayingHistory().isFinished()).isTrue();
         });
     }
 


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 북마크 재생 목록에 완료 여부 및 source 응답 필드 추가

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #590 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 북마크 목록 V2 응답에 재생 완료 여부(isFinished)와 소스 목록(sources: sourceName, sourceUrl) 추가
- 문서
  - 북마크 목록 V2 API 응답 필드에 isFinished, sources, category 정보 반영
- 리팩터
  - 내부 북마크 조회 프로젝션을 재생 이력 기반으로 통합하여 응답 매핑 개선
- 테스트
  - 새로운 프로젝션과 응답 필드(isFinished, sources)를 검증하는 테스트 추가 및 기존 테스트 갱신

<!-- end of auto-generated comment: release notes by coderabbit.ai -->