### PR TITLE
[BE] bug: is_finished가 true 로 설정되었음에도 업데이트되는 버그 수정

### DIFF
--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jdbc/PlayingHistoryCommandRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jdbc/PlayingHistoryCommandRepository.java
@@ -22,7 +22,7 @@ public class PlayingHistoryCommandRepository {
                 VALUES (?, ?, ?, ?, ?)
                 ON DUPLICATE KEY UPDATE
                     last_play_time = VALUES(last_play_time),
-                    is_finished = VALUES(is_finished),
+                    is_finished = playing_history.is_finished OR VALUES(is_finished),
                     updated_at = VALUES(updated_at)
                 """;
 

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -3,12 +3,16 @@ package com.onair.hearit.app.presentation;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
+import com.onair.hearit.app.dto.response.BookmarkHearitResponseV2;
+import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.app.dto.response.RecentlyPlayedHearitResponse;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
@@ -203,6 +207,54 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                 .post("/api/v1/playing-histories")
                 .then()
                 .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("isFinished가 true인 상태에서 lastPlayTime이 줄어들면 isFinished는 유지되고 lastPlayTime만 업데이트된다.")
+    void updatePlayingHistory_keepFinishedTrueWhenTimeDec2reases() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+        Bookmark bookmark = dbHelper.insertBookmark(new Bookmark(member, hearit));
+
+        // 처음에 거의 끝까지 들은 상태 저장 → isFinished = true
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getId(), hearit, 99_500L) // 100초 기준, 끝까지 다 들음
+        );
+        assertThat(playingHistory.isFinished()).isTrue();
+
+        // lastPlayTime을 줄여서 다시 요청
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 20_000L);
+
+        // when
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        PagedResponse<BookmarkHearitResponseV2> response = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .param("page", 0)
+                .param("size", 5)
+                .when()
+                .get("/api/v2/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<>() {
+                });
+
+        // then
+        assertAll(
+                () -> assertThat(response.content().getFirst().lastPlayTime()).isEqualTo(20_000L),
+                () -> assertThat(response.content().getFirst().isFinished()).isTrue()
+        );
     }
 
     private Hearit createHearitWith(int playTime, Category category) {

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -3,16 +3,12 @@ package com.onair.hearit.app.presentation;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.onair.hearit.app.dto.request.PlayingHistoryRequest;
-import com.onair.hearit.app.dto.response.BookmarkHearitResponseV2;
-import com.onair.hearit.app.dto.response.PagedResponse;
 import com.onair.hearit.app.dto.response.RecentlyPlayedHearitResponse;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
-import com.onair.hearit.common.domain.Bookmark;
 import com.onair.hearit.common.domain.Category;
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Member;
@@ -207,54 +203,6 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                 .post("/api/v1/playing-histories")
                 .then()
                 .statusCode(HttpStatus.OK.value());
-    }
-
-    @Test
-    @DisplayName("isFinished가 true인 상태에서 lastPlayTime이 줄어들면 isFinished는 유지되고 lastPlayTime만 업데이트된다.")
-    void updatePlayingHistory_keepFinishedTrueWhenTimeDecreases() {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        Bookmark bookmark = dbHelper.insertBookmark(new Bookmark(member, hearit));
-
-        // 처음에 거의 끝까지 들은 상태 저장 → isFinished = true
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), hearit, 99_500L) // 100초 기준, 끝까지 다 들음
-        );
-        assertThat(playingHistory.isFinished()).isTrue();
-
-        // lastPlayTime을 줄여서 다시 요청
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 20_000L);
-
-        // when
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .contentType("application/json")
-                .body(request)
-                .when()
-                .post("/api/v1/playing-histories")
-                .then()
-                .statusCode(HttpStatus.OK.value());
-
-        PagedResponse<BookmarkHearitResponseV2> response = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .param("page", 0)
-                .param("size", 5)
-                .when()
-                .get("/api/v2/bookmarks/hearits")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(new TypeRef<>() {
-                });
-
-        // then
-        assertAll(
-                () -> assertThat(response.content().getFirst().lastPlayTime()).isEqualTo(20_000L),
-                () -> assertThat(response.content().getFirst().isFinished()).isTrue()
-        );
     }
 
     private Hearit createHearitWith(int playTime, Category category) {

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -211,7 +211,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
 
     @Test
     @DisplayName("isFinished가 true인 상태에서 lastPlayTime이 줄어들면 isFinished는 유지되고 lastPlayTime만 업데이트된다.")
-    void updatePlayingHistory_keepFinishedTrueWhenTimeDec2reases() {
+    void updatePlayingHistory_keepFinishedTrueWhenTimeDecreases() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         String token = generateToken(member);


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 재생 기록 업데이트 시 재생 완료로 기록했음에도 재생 여부 지속적으로 업데이트됨.
- is_finished를 true 로 저장한 뒤 더 이상 is_finished 를 업데이트하지 않아야한다.
- 쿼리문에서 or 문을 활용해 is_finished가 true일 경우 업데이트하지 않도록 변경
## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

- PlayingHistoryController의 updatePlayingHistory_keepFinishedTrueWhenTimeDecreases 

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#593 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 재생 기록 업데이트 시 완료(isFinished)가 한 번 true가 되면, 이후 더 작은 재생 위치(lastPlayTime)로 업데이트해도 완료 상태가 유지되도록 수정했습니다.
  * lastPlayTime은 요청한 값으로 갱신되며, 북마크/콘텐츠 목록 조회 결과에도 즉시 반영됩니다.

* 테스트
  * 위 시나리오를 검증하는 단위 테스트를 추가해 회귀를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->