### PR TITLE
[BE] feat: 히어릿 상세조회 lastPlayTime 초기화 규칙 적용 및 검색 응답에 정보 추가

### DIFF
--- a/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitSearchService.java
@@ -66,12 +66,12 @@ public class HearitSearchService {
     private Page<HearitSearchResponse> toHearitSearchResponseForMember(Page<Hearit> hearits, Member member) {
         List<Long> hearitIds = hearits.getContent().stream().map(Hearit::getId).toList();
         Map<Long, List<Keyword>> hearitKeywords = getHearitKeywords(hearitIds);
-        Map<Long, Long> playingHistories =
+        Map<Long, PlayingHistory> playingHistories =
                 playingHistoryRepository.findByMemberIdAndHearitIdIn(member.getId(), hearitIds)
                         .stream()
                         .collect(Collectors.toMap(
                                 PlayingHistory::getHearitId,
-                                PlayingHistory::getLastPlayTime));
+                                playingHistory -> playingHistory));
         return hearits.map(hearit -> HearitSearchResponse.of(
                 hearit,
                 hearitKeywords.get(hearit.getId()),

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -76,14 +76,15 @@ public class HearitService {
     }
 
     private Long calculateLastPlayTime(Hearit hearit, Member member) {
-        Optional<Long> optionalLastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
+        Optional<Long> optionalLastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(),
+                        member.getId())
                 .map(PlayingHistory::getLastPlayTime);
-        if(optionalLastPlayTime.isEmpty()) {
+        if (optionalLastPlayTime.isEmpty()) {
             return null;
         }
         Long lastPlayTime = optionalLastPlayTime.get();
-        Long remainingTime = hearit.getPlayTime() - lastPlayTime;
-        if(remainingTime <= 5) {
+        Long remainingMillis = hearit.getPlayTime() * 1000 - lastPlayTime; // playTime(s), lastPlayTime(ms)
+        if (remainingMillis <= 5000) {
             return 0L;
         }
         return lastPlayTime;

--- a/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/HearitService.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -65,15 +66,27 @@ public class HearitService {
         Long bookmarkId = bookmarkRepository.findByHearitAndMember(hearit, member)
                 .map(Bookmark::getId)
                 .orElse(null);
-        Long lastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
-                .map(PlayingHistory::getLastPlayTime)
-                .orElse(null);
+        Long lastPlayTime = calculateLastPlayTime(hearit, member);
         return HearitDetailResponse.of(hearit, keywords, lastPlayTime, bookmarkId);
     }
 
     private Hearit getHearitById(Long hearitId) {
         return hearitRepository.findWithCategoryById(hearitId)
                 .orElseThrow(() -> new NotFoundException("hearitId", hearitId.toString()));
+    }
+
+    private Long calculateLastPlayTime(Hearit hearit, Member member) {
+        Optional<Long> optionalLastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(), member.getId())
+                .map(PlayingHistory::getLastPlayTime);
+        if(optionalLastPlayTime.isEmpty()) {
+            return null;
+        }
+        Long lastPlayTime = optionalLastPlayTime.get();
+        Long remainingTime = hearit.getPlayTime() - lastPlayTime;
+        if(remainingTime <= 5) {
+            return 0L;
+        }
+        return lastPlayTime;
     }
 
     public List<RecommendHearitResponse> getRecommendedHearits() {

--- a/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
+++ b/backend/src/main/java/com/onair/hearit/app/application/PlayingHistoryService.java
@@ -28,7 +28,7 @@ public class PlayingHistoryService {
     private final PlayingHistoryRepository playingHistoryRepository;
     private final PlayingHistoryBuffer playingHistoryBuffer;
 
-    public List<RecentlyPlayedHearitResponse> getRecentPlayingHistoryOfMember(UserInfo userInfo) {
+    public List<RecentlyPlayedHearitResponse> getRecentPlayingHistory(UserInfo userInfo) {
         if (userInfo == null || userInfo.isGuest()) {
             return Collections.emptyList();
         }

--- a/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
+++ b/backend/src/main/java/com/onair/hearit/app/dto/response/HearitSearchResponse.java
@@ -2,6 +2,7 @@ package com.onair.hearit.app.dto.response;
 
 import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.Keyword;
+import com.onair.hearit.common.domain.PlayingHistory;
 import java.util.List;
 
 public record HearitSearchResponse(
@@ -9,17 +10,19 @@ public record HearitSearchResponse(
         String title,
         Integer playTime,
         Long lastPlayTime,
+        Boolean isFinished,
         List<KeywordResponse> keywords
 ) {
     private static final int KEYWORD_PER_HEARIT = 3;
 
-    public static HearitSearchResponse of(Hearit hearit, List<Keyword> keywords, Long lastPlayTime) {
+    public static HearitSearchResponse of(Hearit hearit, List<Keyword> keywords, PlayingHistory playingHistory) {
         List<KeywordResponse> keywordResponses = getKeywordNames(keywords);
         return new HearitSearchResponse(
                 hearit.getId(),
                 hearit.getTitle(),
                 hearit.getPlayTime(),
-                lastPlayTime,
+                playingHistory != null ? playingHistory.getLastPlayTime() : null,
+                playingHistory != null ? playingHistory.isFinished() : null,
                 keywordResponses
         );
     }

--- a/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
+++ b/backend/src/main/java/com/onair/hearit/app/presentation/PlayingHistoryController.java
@@ -23,10 +23,10 @@ public class PlayingHistoryController {
     private final PlayingHistoryService playingHistoryService;
 
     @GetMapping("/hearits")
-    public ResponseEntity<List<RecentlyPlayedHearitResponse>> readPlayingHistoriesOfMember(
+    public ResponseEntity<List<RecentlyPlayedHearitResponse>> readPlayingHistories(
             @AuthenticationPrincipal RequestUser requestUser) {
         List<RecentlyPlayedHearitResponse> responses =
-                playingHistoryService.getRecentPlayingHistoryOfMember(requestUser.getUserInfo());
+                playingHistoryService.getRecentPlayingHistory(requestUser.getUserInfo());
         return ResponseEntity.ok(responses);
     }
 

--- a/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
+++ b/backend/src/main/java/com/onair/hearit/common/infrastructure/jpa/HearitRepository.java
@@ -69,6 +69,7 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
             """)
     Page<Hearit> findAll(Pageable pageable);
 
+    @Query("SELECT h FROM Hearit h JOIN FETCH h.category WHERE h.id IN :hearitIds")
     List<Hearit> findAllByIdIn(List<Long> hearitIds);
 
     @Query("""

--- a/backend/src/test/java/com/onair/hearit/admin/presentation/AdminHearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/admin/presentation/AdminHearitControllerTest.java
@@ -238,7 +238,7 @@ class AdminHearitControllerTest extends IntegrationTest {
 
         Hearit updatedHearit = hearitRepository.findById(hearit.getId()).orElseThrow();
 
-            assertThat(updatedHearit.getShortAudioUrl()).isEqualTo(shortPath);
+        assertThat(updatedHearit.getShortAudioUrl()).isEqualTo(shortPath);
 
     }
 

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitSearchServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitSearchServiceTest.java
@@ -11,6 +11,7 @@ import com.onair.hearit.common.domain.Hearit;
 import com.onair.hearit.common.domain.HearitKeyword;
 import com.onair.hearit.common.domain.Keyword;
 import com.onair.hearit.common.domain.Member;
+import com.onair.hearit.common.domain.PlayingHistory;
 import com.onair.hearit.common.domain.Source;
 import com.onair.hearit.common.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.common.infrastructure.jpa.HearitRepository;
@@ -212,19 +213,47 @@ class HearitSearchServiceTest {
         Hearit hearit1 = saveHearitWithTitleAndKeyword("spring1", saveKeyword("keyword"));
         Hearit hearit2 = saveHearitWithTitleAndKeyword("spring2", saveKeyword("springKeyword"));
         Hearit hearit3 = saveHearitWithTitleAndKeyword("otherTitle", saveKeyword("Spring"));
-
-        // when
         TestTransaction.flagForCommit();
         TestTransaction.end();
+
+        // when
         TestTransaction.start();
 
-        PagedResponse<HearitSearchResponse> result = hearitSearchService.search("spring", request,
-                TestFixture.createFixedMemberUserInfo(member));
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search(
+                "spring", request, TestFixture.createFixedMemberUserInfo(member));
 
         // then
         assertAll(
                 () -> assertThat(result.content()).hasSize(1),
                 () -> assertThat(result.content().get(0).id()).isEqualTo(hearit1.getId())
+        );
+    }
+
+    @DisplayName("검색 시 시청기록 정보(마지막 재생시간, 끝까지 시청했는지 여부)도 함께 제공한다.")
+    @Test
+    void searchHearit_withPlayingHistory() {
+        // given
+        PagingRequest pagingRequest = new PagingRequest(0, 10);
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Hearit hearit = saveHearitWithTitleAndKeyword("spring test title", saveKeyword("keyword"));
+
+        PlayingHistory playingHistory = playingHistoryRepository.save(
+                new PlayingHistory(member.getId(), hearit, 10L));
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // when
+        TestTransaction.start();
+        PagedResponse<HearitSearchResponse> result = hearitSearchService.search(
+                "spring", pagingRequest, TestFixture.createFixedMemberUserInfo(member));
+
+        // then
+        HearitSearchResponse hearitSearchResponse = result.content().get(0);
+        assertAll(
+                () -> assertThat(hearitSearchResponse.id()).isEqualTo(hearit.getId()),
+                () -> assertThat(hearitSearchResponse.lastPlayTime()).isEqualTo(playingHistory.getLastPlayTime()),
+                () -> assertThat(hearitSearchResponse.isFinished()).isEqualTo(playingHistory.isFinished())
         );
     }
 

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
@@ -37,7 +37,10 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -115,6 +118,61 @@ class HearitServiceTest {
             assertThat(response.category().name()).isEqualTo(hearit.getCategory().getName());
             assertThat(response.keywords()).hasSize(1);
         });
+    }
+
+    @Nested
+    @DisplayName("히어릿 단일조회 시 lastPlayTime 초기화 규칙")
+    class LastPlayTimeResetTest {
+
+        @ParameterizedTest
+        @ValueSource(longs = {5L, 1L, 0L})
+        @DisplayName("lastPlayTime이 5초 이내로 저장된 경우 lastPlayTime은 0으로 초기화된다.")
+        void resetLastPlayTimeToZero_whenWithin5Seconds(long remainingSeconds) {
+            // given
+            Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+            Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+            long lastPlayTime = hearit.getPlayTime() - remainingSeconds;
+            playingHistoryRepository.save(new PlayingHistory(member.getId(), hearit, lastPlayTime));
+
+            // when
+            HearitDetailResponse response = hearitService.getHearitDetail(
+                    hearit.getId(),
+                    TestFixture.createFixedMemberUserInfo(member)
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(response.id()).isEqualTo(hearit.getId()),
+                    () -> assertThat(response.lastPlayTime()).isEqualTo(0L)
+            );
+        }
+
+        @Test
+        @DisplayName("lastPlayTime이 5초 초과로 저장된 경우 lastPlayTime은 그대로 유지된다.")
+        void keepLastPlayTime_whenExceeds5Seconds() {
+            // given
+            Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+            Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+            long remainingSeconds = 6L;
+            Long lastPlayTime = hearit.getPlayTime() - remainingSeconds;
+            playingHistoryRepository.save(new PlayingHistory(member.getId(), hearit, lastPlayTime));
+
+            // when
+            HearitDetailResponse response = hearitService.getHearitDetail(
+                    hearit.getId(),
+                    TestFixture.createFixedMemberUserInfo(member)
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(response.id()).isEqualTo(hearit.getId()),
+                    () -> assertThat(response.lastPlayTime()).isEqualTo(lastPlayTime)
+            );
+        }
     }
 
     @Test

--- a/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/HearitServiceTest.java
@@ -125,15 +125,15 @@ class HearitServiceTest {
     class LastPlayTimeResetTest {
 
         @ParameterizedTest
-        @ValueSource(longs = {5L, 1L, 0L})
-        @DisplayName("lastPlayTime이 5초 이내로 저장된 경우 lastPlayTime은 0으로 초기화된다.")
+        @ValueSource(longs = {5000L, 1000L, 0L})
+        @DisplayName("lastPlayTime이 5000ms 이내로 저장된 경우 lastPlayTime은 0ms으로 초기화된다.")
         void resetLastPlayTimeToZero_whenWithin5Seconds(long remainingSeconds) {
             // given
             Member member = dbHelper.insertMember(TestFixture.createFixedMember());
             Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
             Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-            long lastPlayTime = hearit.getPlayTime() - remainingSeconds;
+            long lastPlayTime = hearit.getPlayTime() * 1000 - remainingSeconds;
             playingHistoryRepository.save(new PlayingHistory(member.getId(), hearit, lastPlayTime));
 
             // when
@@ -150,15 +150,15 @@ class HearitServiceTest {
         }
 
         @Test
-        @DisplayName("lastPlayTime이 5초 초과로 저장된 경우 lastPlayTime은 그대로 유지된다.")
+        @DisplayName("lastPlayTime이 5000ms 초과로 저장된 경우 lastPlayTime은 그대로 유지된다.")
         void keepLastPlayTime_whenExceeds5Seconds() {
             // given
             Member member = dbHelper.insertMember(TestFixture.createFixedMember());
             Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category)); //히어릿 playTime 500초
 
-            long remainingSeconds = 6L;
-            Long lastPlayTime = hearit.getPlayTime() - remainingSeconds;
+            long remainingSeconds = 5001L;
+            Long lastPlayTime = hearit.getPlayTime() * 1000 - remainingSeconds;
             playingHistoryRepository.save(new PlayingHistory(member.getId(), hearit, lastPlayTime));
 
             // when

--- a/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/application/PlayingHistoryServiceTest.java
@@ -79,7 +79,7 @@ class PlayingHistoryServiceTest {
         dbHelper.insertPlayingHistory(new PlayingHistory(memberInfo.getMemberId(), hearit2, 20));
 
         // when
-        List<RecentlyPlayedHearitResponse> result = playingHistoryService.getRecentPlayingHistoryOfMember(memberInfo);
+        List<RecentlyPlayedHearitResponse> result = playingHistoryService.getRecentPlayingHistory(memberInfo);
 
         // then
         assertAll(
@@ -96,7 +96,7 @@ class PlayingHistoryServiceTest {
         UserInfo guestInfo = RequestUser.guest(UUID.randomUUID().toString()).getUserInfo();
 
         // when
-        List<RecentlyPlayedHearitResponse> guestResult = playingHistoryService.getRecentPlayingHistoryOfMember(guestInfo);
+        List<RecentlyPlayedHearitResponse> guestResult = playingHistoryService.getRecentPlayingHistory(guestInfo);
 
         // then
         assertThat(guestResult).isEmpty();

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -70,8 +70,8 @@ class HearitControllerTest extends IntegrationTest {
                                 .tag("Hearit API")
                                 .summary("히어릿 상세 조회")
                                 .description("히어릿의 상세 정보를 조회합니다. \n\n"
-                                        + "로그인한 사용자의 경우, `isBookmarked`와 `bookmarkId` 필드가 사용자의 북마크 상태를 반영하여 반환됩니다. \n\n"
-                                        + "비로그인 사용자의 경우, `isBookmarked`는 항상 `false`이며 `bookmarkId`는 `null` 입니다.")
+                                             + "로그인한 사용자의 경우, `isBookmarked`와 `bookmarkId` 필드가 사용자의 북마크 상태를 반영하여 반환됩니다. \n\n"
+                                             + "비로그인 사용자의 경우, `isBookmarked`는 항상 `false`이며 `bookmarkId`는 `null` 입니다.")
                                 .pathParameters(
                                         parameterWithName("hearitId").description("조회할 히어릿의 ID")
                                 )

--- a/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/HearitControllerTest.java
@@ -359,6 +359,8 @@ class HearitControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
                                                         fieldWithPath("content[].lastPlayTime").description(
                                                                 "히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].isFinished").description(
+                                                                "히어릿을 끝까지 시청했는지 여부").optional(),
                                                         fieldWithPath("content[].keywords").description(
                                                                 "히어릿에 포함된 키워드 목록"),
                                                         fieldWithPath("content[].keywords[].id").description("키워드 ID"),

--- a/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
+++ b/backend/src/test/java/com/onair/hearit/app/presentation/PlayingHistoryControllerTest.java
@@ -51,7 +51,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 .tag("Playing History API")
                                 .summary("최근 재생 기록 조회")
                                 .description("로그인한 사용자는 최근 재생 기록을 최대 10개까지 조회할 수 있습니다.\n\n"
-                                        + "로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
+                                             + "로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
                                 .responseFields(
                                         fieldWithPath("[].id").description("히어릿 ID"),
                                         fieldWithPath("[].title").description("히어릿 제목"),
@@ -92,7 +92,7 @@ class PlayingHistoryControllerTest extends IntegrationTest {
                                 .tag("Playing History API")
                                 .summary("최근 재생 기록 조회")
                                 .description("로그인한 사용자는 최근 재생 기록을 최대 10개까지 조회할 수 있습니다.\n\n"
-                                        + "로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
+                                             + "로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
                                 .responseFields(
                                         fieldWithPath("[]").description("빈 리스트")
                                 ).build())


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

- lastPlayTime 초기화 규칙 추가
  - 히어릿 단일 조회 시, lastPlayTime이 5초 이내로 저장된 경우 0으로 초기화하도록 변경
  - 사용자 경험 개선: 거의 끝까지 본 경우, 다음 재생 시 처음부터 시작하도록 유도
- 테스트 코드 추가 및 구조 개선
  - @ParameterizedTest로 0초, 1초, 5초 → 0 초기화 케이스 검증
  - 6초 이상 → 기존 값 유지 케이스 검증
  - @Nested 적용으로 테스트 그룹화 (가독성 향상)
- HearitSearchResponse.of 파라미터 변경
  - 기존: Long lastPlayTime → 변경: PlayingHistory playingHistory
  - 호출부 리팩터링: Map<Long, Long> → Map<Long, PlayingHistory> 로 수정


## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

- HearitServiceTest 내 LastPlayTimeResetTest 실행
    - resetLastPlayTimeToZero_whenWithin5Seconds → 0, 1, 5초 케이스 검증
    - keepLastPlayTime_whenExceeds5Seconds → 6, 10, 100초 케이스 검증

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #595 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 검색 결과에 콘텐츠의 재생 완료 여부(isFinished)와 최근 재생 위치(lastPlayTime)가 포함되어 사용자에게 현재 재생 상태가 더 명확하게 제공됩니다.

* **Bug Fixes**
  * 남은 재생 시간이 5초 이하인 경우 최근 재생 위치를 0으로 초기화해 사실상 끝난 콘텐츠가 처음부터 재생되도록 동작을 개선했습니다.

* **Documentation**
  * 검색 응답 스펙에 isFinished 필드를 추가해 API 문서를 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->