### PR TITLE
[BE] chore: bump version to 1.2.2 #601

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'com.onair'
-version = '1.2.1'
+version = '1.2.2'
 
 java {
     toolchain {


### PR DESCRIPTION
bump version to 1.2.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * 백엔드 모듈 버전을 1.2.1에서 1.2.2로 상향했습니다. 이번 릴리스는 버전 정렬과 배포 파이프라인 안정화를 위한 관리성 업데이트입니다.
  * 사용자 기능 추가나 UI 변경은 없으며, API 계약, 성능, 보안 정책, 호환성에 가시적 변화는 없습니다. 기존 워크플로우와 설정은 그대로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->