### PR TITLE
[AN] bug: 라이브러리 -> 단일 재생 시에 미디어 알림에 팟캐스트가 안붙는 오류 해결

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
@@ -229,18 +229,17 @@ class PlayerDetailActivity :
 
         if (previousScreen == LIBRARY_SCREEN_ID) {
             // 재생목록 모드: 서비스가 큐 세팅을 담당
-            if (isDifferentHearit || controller.mediaItemCount == 0) {
+            if (isDifferentHearit || controller.mediaItemCount == 1) {
                 startLibraryPlayback(
                     seedHearitId = hearit.id,
                     seedBookmarkId = viewModel.bookmarkId.value,
                     startPositionMs = startPosition,
                 )
-            } else {
-                if (!controller.isPlaying) controller.play()
+                return
             }
         } else {
             // 단일 재생 모드
-            if (isDifferentHearit) {
+            if (isDifferentHearit || controller.mediaItemCount != 1) {
                 playSingleWithController(hearit, previousScreen, startPosition)
             } else {
                 if (!controller.isPlaying) controller.play()

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackSessionCallback.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackSessionCallback.kt
@@ -23,10 +23,6 @@ class PlaybackSessionCallback(
     private val playbackPositionListener: PlaybackPositionListener,
     private val stateSaver: PlaybackStateSaver,
 ) : MediaSession.Callback {
-    // setMediaItems가 중복으로 실행되면서, Library에서의 플래그를 무시해서 처음에 라이브러리에서 눌렀을 때 단일 재생으로 이루어지는 경우가 있었음
-    @Volatile
-    private var ignoreNextSetFromController = false
-
     // 컨트롤러가 세션에 연결될 때 호출됨
     // 기본 세션 명령어 + 커스텀 명령어(PRELOAD, START_LIBRARY_PLAY, PREFETCH_NEXT)를 등록
     override fun onConnect(
@@ -61,17 +57,6 @@ class PlaybackSessionCallback(
         startPositionMs: Long,
     ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> =
         executeAsync(serviceScope, "onSetMediaItems") {
-            // 만약에 이미 라이브러리 트리거로 진행이 된 상태이면 현재의 큐를 그대로 돌려주도록 하는 코드
-            if (ignoreNextSetFromController) {
-                ignoreNextSetFromController = false
-                val player = mediaSession.player
-                val current = List(player.mediaItemCount) { i -> player.getMediaItemAt(i) }
-                return@executeAsync MediaSession.MediaItemsWithStartPosition(
-                    current,
-                    player.currentMediaItemIndex.coerceAtLeast(0),
-                    player.currentPosition.coerceAtLeast(0L),
-                )
-            }
             // 다음으로 바꿀 타켓 아이템 id 파악
             val targetIndex =
                 if (mediaItems.isNotEmpty()) startIndex.coerceIn(0, mediaItems.size - 1) else 0
@@ -167,7 +152,6 @@ class PlaybackSessionCallback(
         val itemsWithStart = libraryPlaybackHandler.loadLibraryItemsWithStartPosition(playParams)
 
         withContext(Dispatchers.Main) {
-            ignoreNextSetFromController = true
             session.player.setMediaItems(
                 itemsWithStart.mediaItems,
                 itemsWithStart.startIndex,


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 라이브러리 화면에서 재생 후에 단일 재생을 하는 경우에 미디어 알림에 해당하는 히어릿이 붙지 않는 오류를 해결

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

https://github.com/user-attachments/assets/5804a7ef-394e-4f03-a46b-a8b10ccbc949


## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
- 라이브러리에서 듣다가, 단일로 듣는 경우에 미디어 알림에 잘 붙는 지 확인하기
- 라이브러리에서 동일한 히어릿을 듣다가 단일로 동일한 히어릿을 듣는 경우 연속 재생이 아닌 단일 재생으로 변경되는 것 확인하기

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#606 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 라이브러리 재생 진입 시 재생 큐가 특정 조건에서 정상적으로 시작되지 않던 문제를 수정하여, 단일 항목일 때도 안정적으로 재생이 시작되도록 개선했습니다.
  * 단일 재생 동작을 보완하여, 다른 항목으로 전환하거나 재생 큐 상태가 달라진 경우 즉시 재생이 시작되도록 했습니다.
  * 이전 위치에서 재개 시 점프(Seek)가 간헐적으로 누락되던 문제를 개선해, 유의미한 위치 차이가 있을 때 확실히 해당 지점으로 이동하도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->