### PR TITLE
[BE] fix: SecurityFilterChain Order 고정되도록 조정 추가 #611

### DIFF
--- a/backend/admin/src/main/java/com/onair/hearit/auth/config/AdminSecurityConfig.java
+++ b/backend/admin/src/main/java/com/onair/hearit/auth/config/AdminSecurityConfig.java
@@ -4,6 +4,7 @@ import com.onair.hearit.auth.application.AdminUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -14,6 +15,7 @@ public class AdminSecurityConfig {
     private final AdminUserDetailsService adminUserDetailsService;
 
     @Bean
+    @Order(1)
     public SecurityFilterChain adminFilterChain(HttpSecurity http) throws Exception {
         return http
                 .securityMatcher("/admin/**", "/api/v1/admin/**")

--- a/backend/app/src/main/java/com/onair/hearit/auth/config/ApiSecurityConfig.java
+++ b/backend/app/src/main/java/com/onair/hearit/auth/config/ApiSecurityConfig.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -41,6 +42,7 @@ public class ApiSecurityConfig {
     private final FilterExceptionLogger filterExceptionLogger;
 
     @Bean
+    @Order(2)
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

각 SecurityFilterChain 빈 메서드에 @Order 적용
- `@Bean @Order(1) adminFilterChain : /admin/**, /api/v1/admin/** `요청 → 세션 로그인 방식 적용
- `@Bean @Order(2) apiFilterChain : /api/**` 요청 → JWT 인증 필터 적용
- Spring Security 권장 방식(SecurityFilterChain Bean-level Order)으로 수정하여 체인 우선순위 적용이 제대로 되도록 함

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #611 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 보안 필터 체인의 적용 순서를 정교화해 관리 콘솔과 공개 API의 인증/인가가 예측 가능하게 동작합니다.
  * 특정 시나리오에서 로그인 리다이렉트 및 세션 충돌이 간헐적으로 발생하던 문제를 완화했습니다.
  * 경로별 보안 규칙 우선순위를 명확히 해 접근 제어 오류를 줄였습니다.
  * 인증 흐름의 안정성과 일관성을 높여 불필요한 재인증 시도를 감소시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->