### PR TITLE
[BE] docs: RestDocs 문서화를 모킹으로 변경하여 문서화 환경 독립화 #598

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -38,9 +38,7 @@ dependencies {
     testImplementation 'org.jsoup:jsoup:1.17.2'
 
     // REST Docs & restdocs-api-spec
-    testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-    testImplementation "com.epages:restdocs-api-spec-restassured:0.18.2"
     testImplementation "com.epages:restdocs-api-spec-mockmvc:0.18.2"
     testImplementation testFixtures(project(':core'))
 

--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -39,8 +39,9 @@ dependencies {
 
     // REST Docs & restdocs-api-spec
     testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation "com.epages:restdocs-api-spec-restassured:0.18.2"
-    testImplementation "com.epages:restdocs-api-spec:0.18.2"
+    testImplementation "com.epages:restdocs-api-spec-mockmvc:0.18.2"
     testImplementation testFixtures(project(':core'))
 
     // Swagger UI

--- a/backend/app/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
+++ b/backend/app/src/main/java/com/onair/hearit/auth/presentation/AuthController.java
@@ -1,7 +1,6 @@
 package com.onair.hearit.auth.presentation;
 
 import com.onair.hearit.auth.application.AuthService;
-import com.onair.hearit.domain.OAuthProvider;
 import com.onair.hearit.auth.domain.RequestUser;
 import com.onair.hearit.auth.dto.request.LoginRequest;
 import com.onair.hearit.auth.dto.request.OAuthLoginRequest;
@@ -9,6 +8,7 @@ import com.onair.hearit.auth.dto.request.SignupRequest;
 import com.onair.hearit.auth.dto.request.TokenReissueRequest;
 import com.onair.hearit.auth.dto.response.LoginTokenResponse;
 import com.onair.hearit.auth.dto.response.TokenReissueResponse;
+import com.onair.hearit.domain.OAuthProvider;
 import com.onair.hearit.domain.UserInfo;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/backend/app/src/main/java/com/onair/hearit/playinghistory/dto/RecentlyPlayedHearitResponse.java
+++ b/backend/app/src/main/java/com/onair/hearit/playinghistory/dto/RecentlyPlayedHearitResponse.java
@@ -23,7 +23,7 @@ public record RecentlyPlayedHearitResponse(
         );
     }
 
-    private record CategoryResponse(Long id, String name, String colorCode) {
+    public record CategoryResponse(Long id, String name, String colorCode) {
         public static CategoryResponse from(Category category) {
             return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
         }

--- a/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -17,7 +17,7 @@ import com.onair.hearit.auth.dto.response.LoginTokenResponse;
 import com.onair.hearit.auth.dto.response.TokenReissueResponse;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.auth.infrastructure.repository.RefreshTokenRepository;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.infrastructure.jpa.MemberRepository;

--- a/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthControllerTest.java
@@ -1,343 +1,294 @@
 package com.onair.hearit.auth.presentation;
 
-
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.auth.domain.RefreshToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onair.hearit.auth.application.AuthService;
 import com.onair.hearit.auth.dto.request.LoginRequest;
+import com.onair.hearit.auth.dto.request.OAuthLoginRequest;
 import com.onair.hearit.auth.dto.request.SignupRequest;
 import com.onair.hearit.auth.dto.request.TokenReissueRequest;
 import com.onair.hearit.auth.dto.response.LoginTokenResponse;
 import com.onair.hearit.auth.dto.response.TokenReissueResponse;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
-import com.onair.hearit.auth.infrastructure.repository.RefreshTokenRepository;
+import com.onair.hearit.auth.infrastructure.jwt.TokenStatus;
+import com.onair.hearit.exception.custom.InvalidInputException;
+import com.onair.hearit.exception.custom.UnauthorizedException;
 import com.onair.hearit.fixture.ApiDocSnippets;
-import com.onair.hearit.domain.Member;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.infrastructure.jpa.MemberRepository;
-import com.onair.hearit.fixture.DbHelper;
-import com.onair.hearit.fixture.IntegrationTest;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
-import java.time.LocalDateTime;
-import java.util.UUID;
+import com.onair.hearit.fixture.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class AuthControllerTest extends IntegrationTest {
-
-    @Autowired
-    DbHelper dbHelper;
+@WebMvcTest(controllers = AuthController.class)
+class AuthControllerTest extends ControllerTest {
 
     @Autowired
-    PasswordEncoder passwordEncoder;
+    private ObjectMapper objectMapper;
 
-    @Autowired
-    JwtTokenProvider jwtTokenProvider;
-
-    @Autowired
-    RefreshTokenRepository refreshTokenRepository;
-
-    @Autowired
-    MemberRepository memberRepository;
+    @MockitoBean
+    private AuthService authService;
 
     @Test
-    @DisplayName("로그인 성공 시 200 OK 및 엑세스토큰 + 리프레시토큰을 반환한다.")
-    void login_success() {
+    @DisplayName("로컬 로그인 V1 - 200 OK")
+    void loginV1_OK() throws Exception {
         // given
-        Member member = Member.createLocalUser(
-                UUID.randomUUID().toString(),
-                "test123",
-                "testName",
-                passwordEncoder.encode("pass1234"),
-                "profile.jpg"
+        var request = new LoginRequest("test123", "password1234");
+        var response = new LoginTokenResponse(
+                "access12341234.token12341234.fake-signature",
+                "refresh12341234.token12341234.fake-signature"
         );
-        dbHelper.insertMember(member);
 
-        LoginRequest request = new LoginRequest("test123", "pass1234");
-
-        // when
-        LoginTokenResponse loginTokenResponse = RestAssured.given(this.spec).log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .filter(document("auth-login",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Auth API")
-                                .summary("일반 로그인")
-                                .description("아이디/비밀번호로 로그인하여 토큰을 발급받습니다.")
-                                .requestSchema(Schema.schema("LoginRequest"))
-                                .requestFields(
-                                        fieldWithPath("localId").description("사용자 아이디"),
-                                        fieldWithPath("password").description("비밀번호")
-                                )
-                                .responseSchema(Schema.schema("LoginTokenResponse"))
-                                .responseFields(
-                                        fieldWithPath("accessToken").description("발급된 액세스 토큰"),
-                                        fieldWithPath("refreshToken").description("발급된 리프레시 토큰")
-                                )
-                                .build())
-                ))
-                .when()
-                .post("/api/v1/auth/login")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(LoginTokenResponse.class);
-
-        // then
-        assertAll(() -> {
-            assertThat(loginTokenResponse.accessToken()).isNotNull();
-            assertThat(loginTokenResponse.refreshToken()).isNotNull();
-        });
-    }
-
-    @DisplayName("유효한 리프레시토큰으로 엑세스토큰 재발급 요청 시 새 엑세스토큰을 반환한다.")
-    @Test
-    void reissueToken_requestWithValidRefreshToken() {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        RefreshToken validRefreshToken = createAndSaveRefreshTokenFrom(member);
-
-        TokenReissueRequest tokenReissueRequest = new TokenReissueRequest(validRefreshToken.getToken());
-
-        // when
-        TokenReissueResponse response = RestAssured.given(this.spec).log().all()
-                .contentType(ContentType.JSON)
-                .body(tokenReissueRequest)
-                .filter(document("auth-refresh",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Auth API")
-                                .summary("엑세스토큰 재발급 요청")
-                                .description("리프레시토큰으로 엑세스토큰 재발급 요청해 새 엑세스토큰을 반환받습니다.")
-                                .requestSchema(Schema.schema("TokenReissueResponse"))
-                                .requestFields(
-                                        fieldWithPath("refreshToken").description("리프레시 토큰")
-                                )
-                                .responseSchema(Schema.schema("LoginTokenResponse"))
-                                .responseFields(
-                                        fieldWithPath("accessToken").description("발급된 액세스 토큰")
-                                )
-                                .build())
-                ))
-                .when()
-                .post("/api/v1/auth/token/refresh")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(TokenReissueResponse.class);
-
-        // then
-        assertThat(response.accessToken()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("비밀번호 틀리면 401 Unauthorized 반환한다.")
-    void login_invalidPassword() {
-        Member member = Member.createLocalUser(
-                UUID.randomUUID().toString(),
-                "test123",
-                "testName",
-                passwordEncoder.encode("pass1234"),
-                "profile.jpg"
-        );
-        dbHelper.insertMember(member);
-
-        LoginRequest request = new LoginRequest("test123", "wrong-pass");
-
-        // when
-        // then
-        RestAssured.given(this.spec)
-                .contentType(ContentType.JSON)
-                .body(request)
-                .filter(document("auth-login-unauthorized-wrong-password",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Auth API")
-                                .summary("일반 로그인")
-                                .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
-                                .build())
-                ))
-                .when()
-                .post("/api/v1/auth/login")
-                .then()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 회원이면 401 Unauthorized 반환한다.")
-    void login_nonexistentMember() {
-        // given
-        LoginRequest request = new LoginRequest("ghost123", "pass1234");
-
-        RestAssured.given(this.spec).log().all()
-                .contentType(ContentType.JSON)
-                .body(request)
-                .filter(document("auth-login-unauthorized-nonexistent-member",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Auth API")
-                                .summary("일반 로그인")
-                                .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
-                                .build())
-                ))
-                .when()
-                .post("/api/v1/auth/login")
-                .then().log().all()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
-    }
-
-    @Test
-    @DisplayName("회원가입 성공 시 201 CREATED를 반환한다.")
-    void signup_success() {
-        // given
-        SignupRequest request = new SignupRequest("newUser123", "newNickname", "password1234");
+        given(authService.login(any())).willReturn(response);
 
         // when & then
-        RestAssured.given(this.spec)
-                .contentType(ContentType.JSON)
-                .body(request)
-                .filter(document("auth-signup",
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("v1-post-auth-login-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Auth API")
-                                .summary("회원가입")
-                                .description("새로운 계정을 생성합니다.")
-                                .requestSchema(Schema.schema("SignupRequest"))
+                                .summary("로컬 로그인 V1")
+                                .description("아이디/비밀번호로 로그인하여 `accessToken`과 `refreshToken`을 발급받습니다.")
                                 .requestFields(
-                                        fieldWithPath("localId").description("사용자 아이디"),
+                                        fieldWithPath("localId").description("로컬 아이디"),
+                                        fieldWithPath("password").description("로컬 비밀번호")
+                                )
+                                .responseFields(
+                                        fieldWithPath("accessToken").description("발급된 access token"),
+                                        fieldWithPath("refreshToken").description("발급된 refresh token")
+                                )
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("로컬 로그인 V1 - 401 Unauthorized")
+    void loginV1_Unauthorized() throws Exception {
+        // given
+        var request = new LoginRequest("test123", "wrong-pass");
+
+        given(authService.login(any()))
+                .willThrow(new UnauthorizedException("아이디나 비밀번호가 일치하지 않습니다."));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("v1-post-auth-login-unauthorized",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Auth API")
+                                .summary("로컬 로그인 V1")
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 V1 - 200 OK")
+    void kakaoLoginV1_OK() throws Exception {
+        // given
+        var request = new OAuthLoginRequest("kakao-access-token-12345");
+        var response = new LoginTokenResponse(
+                "access12341234.token12341234.fake-signature",
+                "refresh12341234.token12341234.fake-signature"
+        );
+
+        given(authService.loginOrSignUp(any(), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/kakao-login")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("v1-post-auth-kakao-login-ok",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Auth API")
+                                .summary("카카오 로그인 V1")
+                                .description(
+                                        "카카오 `accessToken`으로 로그인 또는 회원가입을 진행하여 `accessToken`과 `refreshToken`을 발급받습니다.")
+                                .requestFields(
+                                        fieldWithPath("accessToken").description("카카오 access token")
+                                )
+                                .responseFields(
+                                        fieldWithPath("accessToken").description("발급된 access token"),
+                                        fieldWithPath("refreshToken").description("발급된 refresh token")
+                                )
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 V1 - 401 Unauthorized")
+    void kakaoLoginV1_Unauthorized() throws Exception {
+        // given
+        var request = new OAuthLoginRequest("invalid-kakao-access-token");
+
+        given(authService.loginOrSignUp(any(), any()))
+                .willThrow(new UnauthorizedException("this access token is already expired"));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/kakao-login")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("v1-post-auth-kakao-login-unauthorized",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Auth API")
+                                .summary("카카오 로그인 V1")
+                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("로컬 회원가입 V1 - 201 Created")
+    void signupV1_Created() throws Exception {
+        // given
+        var request = new SignupRequest("newUser123", "newNickname", "password1234");
+
+        willDoNothing().given(authService).signup(any());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("v1-post-auth-signup-created",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Auth API")
+                                .summary("로컬 회원가입 V1")
+                                .description("아이디/비밀번호를 통해 새로운 계정을 생성합니다.")
+                                .requestFields(
+                                        fieldWithPath("localId").description("회원 아이디"),
                                         fieldWithPath("nickname").description("닉네임"),
                                         fieldWithPath("password").description("비밀번호")
                                 )
                                 .build())
-                ))
-                .when()
-                .post("/api/v1/auth/signup")
-                .then()
-                .statusCode(HttpStatus.CREATED.value());
+                ));
     }
 
     @Test
-    @DisplayName("이미 존재하는 아이디로 회원가입 시 400 BAD REQUEST를 반환한다.")
-    void signup_fail_with_duplicate_id() {
+    @DisplayName("로컬 회원가입 V1 - 400 Bad Request")
+    void signupV1_BadRequest() throws Exception {
         // given
-        Member existingMember = Member.createLocalUser(
-                UUID.randomUUID().toString(),
-                "existingUser",
-                "existingNickname",
-                passwordEncoder.encode("password1234"),
-                "profile.jpg"
-        );
-        dbHelper.insertMember(existingMember);
+        var request = new SignupRequest("existingUser", "newNickname", "password1234");
 
-        SignupRequest request = new SignupRequest("existingUser", "newNickname", "password1234");
+        willThrow(new InvalidInputException("이미 존재하는 아이디입니다."))
+                .given(authService).signup(any());
 
         // when & then
-        RestAssured.given(this.spec)
-                .contentType(ContentType.JSON)
-                .body(request)
-                .filter(document("auth-signup-bad-request",
+        mockMvc.perform(post("/api/v1/auth/signup")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("v1-post-auth-signup-bad-request",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Auth API")
-                                .summary("회원가입")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("로컬 회원가입 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .post("/api/v1/auth/signup")
-                .then()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                ));
     }
 
+    @DisplayName("access token 재발급 V1 - 200 OK")
     @Test
-    @DisplayName("엑세스토큰 유효성 검증 성공 시 200 OK를 반환한다.")
-    void check_success() {
+    void refresh_tokenV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(
-                Member.createLocalUser(UUID.randomUUID().toString(), "localId", "nickname", "password", "profile.jpg"));
-        String validAccessToken = jwtTokenProvider.createAccessToken(member.getId());
+        var request = new TokenReissueRequest("refresh12341234.token12341234.fake-signature");
+        var response = new TokenReissueResponse("new-access12341234.token12341234.fake-signature");
+
+        given(authService.reissue(any())).willReturn(response.accessToken());
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + validAccessToken)
-                .filter(document("auth-check",
+        mockMvc.perform(post("/api/v1/auth/token/refresh")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("v1-post-auth-token-refresh-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Auth API")
-                                .summary("엑세스토큰 유효성 검증")
-                                .description("엑세스토큰의 유효성을 검증합니다.")
+                                .summary("access token 재발급 V1")
+                                .description("`refreshToken`으로 `accessToken`을 재발급 받습니다.")
+                                .requestFields(
+                                        fieldWithPath("refreshToken").description("refresh token")
+                                )
+                                .responseFields(
+                                        fieldWithPath("accessToken").description("발급된 access token")
+                                )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/auth/check")
-                .then()
-                .statusCode(HttpStatus.OK.value());
+                ));
     }
 
     @Test
-    @DisplayName("엑세스토큰 유효성 검증 실패 시 401 Unauthorized를 반환한다.")
-    void check_unauthorized() {
+    @DisplayName("access token 검증 V1 - 200 OK")
+    void checkV1_OK() throws Exception {
         // given
-        String invalidAccessToken = "invalid-access-token";
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + invalidAccessToken)
-                .filter(document("auth-check-unauthorized",
+        mockMvc.perform(get("/api/v1/auth/check")
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-auth-check-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Auth API")
-                                .summary("엑세스토큰 유효성 검증")
-                                .description("엑세스토큰의 유효성을 검증합니다.")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("access token 검증 V1")
+                                .description("`accessToken`의 유효성을 검증합니다.")
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("access token 검증 V1 - 401 Unauthorized")
+    void checkV1_Unauthorized() throws Exception {
+        // given
+        given(jwtTokenProvider.getTokenStatus("invalid-token")).willReturn(TokenStatus.INVALID);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/auth/check")
+                        .header("Authorization", "Bearer invalid-token"))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("v1-get-auth-check-unauthorized",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Auth API")
+                                .summary("access token 검증 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/auth/check")
-                .then()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                ));
     }
 
     @Test
-    @DisplayName("회원탈퇴 시 해당 회원의 리프레시토큰을 삭제하고 회원탈퇴 시간이 기록된다.")
-    void withdraw() {
+    @DisplayName("회원 탈퇴 V1 - 204 No Content")
+    void withdrawV1_NoContent() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        createAndSaveRefreshTokenFrom(member);
-        assertThat(refreshTokenRepository.findByMemberId(member.getId())).isPresent();
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        willDoNothing().given(authService).withdraw(any());
 
-        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
-
-        // when
-        RestAssured.given(this.spec).log().all()
-                .header("Authorization", "Bearer " + accessToken)
-                .filter(document("auth-withdraw",
+        // when & then
+        mockMvc.perform(delete("/api/v1/auth/withdraw")
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isNoContent())
+                .andDo(document("v1-delete-auth-withdraw-no-content",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Auth API")
-                                .summary("회원탈퇴")
-                                .description("회원탈퇴 시 서버에서 회원을 탈퇴처리합니다.")
+                                .summary("회원 탈퇴 V1")
+                                .description("서버에서 회원을 탈퇴 처리합니다.")
                                 .build())
-                ))
-                .when()
-                .delete("/api/v1/auth/withdraw")
-                .then().log().all()
-                .statusCode(HttpStatus.NO_CONTENT.value());
-
-        // then
-        assertAll(() -> {
-            assertThat(refreshTokenRepository.findByMemberId(member.getId())).isEmpty();
-            assertThat(memberRepository.findById(member.getId()).orElseThrow().getDeletedAt()).isNotNull();
-        });
-    }
-
-    private RefreshToken createAndSaveRefreshTokenFrom(Member member) {
-        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
-        LocalDateTime expiryDate = jwtTokenProvider.extractExpiry(refreshToken);
-        return refreshTokenRepository.save(new RefreshToken(member.getId(), refreshToken, expiryDate));
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthIntegrationTest.java
@@ -1,0 +1,244 @@
+package com.onair.hearit.auth.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.auth.domain.RefreshToken;
+import com.onair.hearit.auth.dto.request.LoginRequest;
+import com.onair.hearit.auth.dto.request.SignupRequest;
+import com.onair.hearit.auth.dto.request.TokenReissueRequest;
+import com.onair.hearit.auth.dto.response.LoginTokenResponse;
+import com.onair.hearit.auth.dto.response.TokenReissueResponse;
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.auth.infrastructure.repository.RefreshTokenRepository;
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.fixture.DbHelper;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.infrastructure.jpa.MemberRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+class AuthIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    DbHelper dbHelper;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("로그인 성공 시 200 OK 및 엑세스토큰 + 리프레시토큰을 반환한다.")
+    void login_success() {
+        // given
+        Member member = Member.createLocalUser(
+                UUID.randomUUID().toString(),
+                "test123",
+                "testName",
+                passwordEncoder.encode("pass1234"),
+                "profile.jpg"
+        );
+        dbHelper.insertMember(member);
+
+        LoginRequest request = new LoginRequest("test123", "pass1234");
+
+        // when
+        LoginTokenResponse loginTokenResponse = RestAssured.given(this.spec).log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/auth/login")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(LoginTokenResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(loginTokenResponse.accessToken()).isNotNull();
+            assertThat(loginTokenResponse.refreshToken()).isNotNull();
+        });
+    }
+
+    @DisplayName("유효한 리프레시토큰으로 엑세스토큰 재발급 요청 시 새 엑세스토큰을 반환한다.")
+    @Test
+    void reissueToken_requestWithValidRefreshToken() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        RefreshToken validRefreshToken = createAndSaveRefreshTokenFrom(member);
+
+        TokenReissueRequest tokenReissueRequest = new TokenReissueRequest(validRefreshToken.getToken());
+
+        // when
+        TokenReissueResponse response = RestAssured.given(this.spec).log().all()
+                .contentType(ContentType.JSON)
+                .body(tokenReissueRequest)
+                .when()
+                .post("/api/v1/auth/token/refresh")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(TokenReissueResponse.class);
+
+        // then
+        assertThat(response.accessToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("비밀번호 틀리면 401 Unauthorized 반환한다.")
+    void login_invalidPassword() {
+        Member member = Member.createLocalUser(
+                UUID.randomUUID().toString(),
+                "test123",
+                "testName",
+                passwordEncoder.encode("pass1234"),
+                "profile.jpg"
+        );
+        dbHelper.insertMember(member);
+
+        LoginRequest request = new LoginRequest("test123", "wrong-pass");
+
+        // when
+        // then
+        RestAssured.given(this.spec)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/auth/login")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이면 401 Unauthorized 반환한다.")
+    void login_nonexistentMember() {
+        // given
+        LoginRequest request = new LoginRequest("ghost123", "pass1234");
+
+        RestAssured.given(this.spec).log().all()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/auth/login")
+                .then().log().all()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 시 201 CREATED를 반환한다.")
+    void signup_success() {
+        // given
+        SignupRequest request = new SignupRequest("newUser123", "newNickname", "password1234");
+
+        // when & then
+        RestAssured.given(this.spec)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 아이디로 회원가입 시 400 BAD REQUEST를 반환한다.")
+    void signup_fail_with_duplicate_id() {
+        // given
+        Member existingMember = Member.createLocalUser(
+                UUID.randomUUID().toString(),
+                "existingUser",
+                "existingNickname",
+                passwordEncoder.encode("password1234"),
+                "profile.jpg"
+        );
+        dbHelper.insertMember(existingMember);
+
+        SignupRequest request = new SignupRequest("existingUser", "newNickname", "password1234");
+
+        // when & then
+        RestAssured.given(this.spec)
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when()
+                .post("/api/v1/auth/signup")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("엑세스토큰 유효성 검증 성공 시 200 OK를 반환한다.")
+    void check_success() {
+        // given
+        Member member = dbHelper.insertMember(
+                Member.createLocalUser(UUID.randomUUID().toString(), "localId", "nickname", "password", "profile.jpg"));
+        String validAccessToken = jwtTokenProvider.createAccessToken(member.getId());
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + validAccessToken)
+                .when()
+                .get("/api/v1/auth/check")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("엑세스토큰 유효성 검증 실패 시 401 Unauthorized를 반환한다.")
+    void check_unauthorized() {
+        // given
+        String invalidAccessToken = "invalid-access-token";
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + invalidAccessToken)
+                .when()
+                .get("/api/v1/auth/check")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 해당 회원의 리프레시토큰을 삭제하고 회원탈퇴 시간이 기록된다.")
+    void withdraw() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        createAndSaveRefreshTokenFrom(member);
+        assertThat(refreshTokenRepository.findByMemberId(member.getId())).isPresent();
+
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+
+        // when
+        RestAssured.given(this.spec).log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .delete("/api/v1/auth/withdraw")
+                .then().log().all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // then
+        assertAll(() -> {
+            assertThat(refreshTokenRepository.findByMemberId(member.getId())).isEmpty();
+            assertThat(memberRepository.findById(member.getId()).orElseThrow().getDeletedAt()).isNotNull();
+        });
+    }
+
+    private RefreshToken createAndSaveRefreshTokenFrom(Member member) {
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        LocalDateTime expiryDate = jwtTokenProvider.extractExpiry(refreshToken);
+        return refreshTokenRepository.save(new RefreshToken(member.getId(), refreshToken, expiryDate));
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthKakaoLoginControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthKakaoLoginControllerTest.java
@@ -16,7 +16,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.onair.hearit.auth.dto.request.OAuthLoginRequest;
 import com.onair.hearit.auth.dto.response.LoginTokenResponse;
 import com.onair.hearit.auth.infrastructure.oauth.kakao.KakaoOAuthService;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.fixture.IntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;

--- a/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthKakaoLoginIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/auth/presentation/AuthKakaoLoginIntegrationTest.java
@@ -1,22 +1,16 @@
 package com.onair.hearit.auth.presentation;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
-import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.onair.hearit.auth.dto.request.OAuthLoginRequest;
 import com.onair.hearit.auth.dto.response.LoginTokenResponse;
 import com.onair.hearit.auth.infrastructure.oauth.kakao.KakaoOAuthService;
-import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.fixture.IntegrationTest;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -30,7 +24,7 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = "kakao.user-info.base-url=http://localhost:8089")
-class AuthKakaoLoginControllerTest extends IntegrationTest {
+class AuthKakaoLoginIntegrationTest extends IntegrationTest {
 
     private static WireMockServer wireMockServer;
 
@@ -68,22 +62,6 @@ class AuthKakaoLoginControllerTest extends IntegrationTest {
         LoginTokenResponse loginTokenResponse = RestAssured.given(this.spec).log().all()
                 .contentType(ContentType.JSON)
                 .body(kakaoLoginRequest)
-                .filter(document("auth-kakao-login",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Auth API")
-                                .summary("카카오 로그인")
-                                .description("카카오 액세스토큰으로 로그인하여 서비스 토큰을 발급받습니다.")
-                                .requestSchema(Schema.schema("OAuthLoginRequest"))
-                                .requestFields(
-                                        fieldWithPath("accessToken").description("카카오에서 발급받은 Access Token")
-                                )
-                                .responseSchema(Schema.schema("TokenResponse"))
-                                .responseFields(
-                                        fieldWithPath("accessToken").description("발급된 서비스 액세스 토큰"),
-                                        fieldWithPath("refreshToken").description("발급된 리프레시 토큰")
-                                )
-                                .build())
-                ))
                 .when()
                 .post("/api/v1/auth/kakao-login")
                 .then().log().all()
@@ -116,18 +94,6 @@ class AuthKakaoLoginControllerTest extends IntegrationTest {
         ProblemDetail problemDetail = given(this.spec)
                 .contentType(ContentType.JSON)
                 .body(kakaoLoginRequest)
-                .filter(document("auth-kakao-login",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Auth API")
-                                .summary("카카오 로그인")
-                                .requestSchema(Schema.schema("OAuthLoginRequest"))
-                                .requestFields(
-                                        fieldWithPath("accessToken").description("카카오에서 발급받은 Access Token")
-                                )
-                                .responseSchema(Schema.schema("ProblemDetail"))
-                                .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
-                                .build())
-                ))
                 .when()
                 .post("/api/v1/auth/kakao-login")
                 .then()

--- a/backend/app/src/test/java/com/onair/hearit/bookmark/presentation/BookmarkControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/bookmark/presentation/BookmarkControllerTest.java
@@ -86,8 +86,7 @@ class BookmarkControllerTest extends ControllerTest {
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].summary").description("히어릿 요약"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
-                                                        fieldWithPath("content[].lastPlayTime").description(
-                                                                "히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].lastPlayTime").description("히어릿 마지막 재생 시간(ms)").optional(),
                                                         fieldWithPath("content[].categoryColor").description("카테고리 색상 코드")
                                                 }), Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields()))
                                         .toArray(FieldDescriptor[]::new)
@@ -139,10 +138,8 @@ class BookmarkControllerTest extends ControllerTest {
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].summary").description("히어릿 요약"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
-                                                        fieldWithPath("content[].lastPlayTime").description(
-                                                                "히어릿 마지막 재생 시간(ms)").optional(),
-                                                        fieldWithPath("content[].isFinished").description(
-                                                                "히어릿 재생 완료 여부").optional(),
+                                                        fieldWithPath("content[].lastPlayTime").description("히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].isFinished").description("히어릿 재생 완료 여부").optional(),
                                                         fieldWithPath("content[].sources").description("출처 정보"),
                                                         fieldWithPath("content[].sources[].sourceName").description("출처 이름"),
                                                         fieldWithPath("content[].sources[].sourceUrl").description("출처 URL"),

--- a/backend/app/src/test/java/com/onair/hearit/bookmark/presentation/BookmarkControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/bookmark/presentation/BookmarkControllerTest.java
@@ -1,69 +1,85 @@
 package com.onair.hearit.bookmark.presentation;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.auth.infrastructure.jwt.TokenStatus;
+import com.onair.hearit.bookmark.application.BookmarkService;
+import com.onair.hearit.bookmark.dto.BookmarkHearitResponseV2;
+import com.onair.hearit.bookmark.dto.BookmarkHearitResponseV2.CategoryResponse;
+import com.onair.hearit.bookmark.dto.BookmarkHearitResponseV2.SourceResponse;
 import com.onair.hearit.bookmark.dto.BookmarkInfoResponse;
-import com.onair.hearit.core.docs.ApiDocSnippets;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.domain.Bookmark;
-import com.onair.hearit.domain.Category;
-import com.onair.hearit.domain.Hearit;
-import com.onair.hearit.domain.Member;
-import com.onair.hearit.fixture.IntegrationTest;
-import io.restassured.RestAssured;
+import com.onair.hearit.exception.custom.AlreadyExistException;
+import com.onair.hearit.exception.custom.ForbiddenException;
+import com.onair.hearit.fixture.ApiDocSnippets;
+import com.onair.hearit.fixture.ControllerTest;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class BookmarkControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = BookmarkController.class)
+class BookmarkControllerTest extends ControllerTest {
 
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    @MockitoBean
+    private BookmarkService bookmarkService;
 
     @Test
-    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
-    void readBookmarkHearitsTest_v1() {
+    @DisplayName("북마크 목록 조회 V1 - 200 OK")
+    void readBookmarkHearitsV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        String token = generateToken(member);
-        int bookmarkCount = 30;
-        for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
-        }
+        var responses = IntStream.range(1, 25).mapToObj(i -> new BookmarkHearitResponseV2(
+                        (long) i,
+                        (long) (1000 + i),
+                        "Title " + i,
+                        "Summary " + i + 1,
+                        100 + i,
+                        (long) 200 + i - 2,
+                        false,
+                        List.of(new SourceResponse("source1", "url1"), new SourceResponse("source2", "url2")),
+                        new CategoryResponse((long) i, "categoryName", "#FFFFFF")
+                ))
+                .toList();
+        var pagedResponses = new PageImpl<>(responses, PageRequest.of(0, 20), responses.size());
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(bookmarkService.getBookmarkHearits(any(), any())).willReturn(pagedResponses);
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .param("page", 0)
-                .param("size", 5)
-                .filter(document("bookmark-read-list-v1",
+        mockMvc.perform(get("/api/v1/bookmarks/hearits")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-bookmarks-hearits-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
                                 .summary("북마크 목록 조회 V1")
-                                .description("사용자가 북마크한 히어릿 목록을 페이지별로 조회합니다.")
+                                .description("로그인한 사용자가 북마크한 히어릿 목록을 `Page` 단위로 조회합니다.")
                                 .queryParameters(
-                                        parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
-                                        parameterWithName("size").description("페이지 당 항목 수 (기본 20)").defaultValue("20")
+                                        parameterWithName("page").description("페이지 번호 (start 0)").defaultValue("0"),
+                                        parameterWithName("size").description("페이지 당 항목 수").defaultValue("20")
                                 )
-                                .responseSchema(Schema.schema("PagedBookmarkHearitResponse"))
-                                .responseFields(
-                                        Stream.concat(
+                                .responseFields(Stream.concat(
                                                 Arrays.stream(new FieldDescriptor[]{
                                                         fieldWithPath("content[].hearitId").description("히어릿 ID"),
                                                         fieldWithPath("content[].bookmarkId").description("북마크 ID"),
@@ -73,49 +89,50 @@ class BookmarkControllerTest extends IntegrationTest {
                                                         fieldWithPath("content[].lastPlayTime").description(
                                                                 "히어릿 마지막 재생 시간(ms)").optional(),
                                                         fieldWithPath("content[].categoryColor").description("카테고리 색상 코드")
-                                                }),
-                                                Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields())
-                                        ).toArray(FieldDescriptor[]::new)
+                                                }), Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields()))
+                                        .toArray(FieldDescriptor[]::new)
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/bookmarks/hearits")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .body("content.size()", equalTo(5));
+                ));
     }
 
     @Test
-    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
-    void readBookmarkHearitsTest_v2() {
+    @DisplayName("북마크 목록 조회 V2 - 200 OK")
+    void readBookmarkHearitsV2_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        String token = generateToken(member);
-        int bookmarkCount = 30;
-        for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
-        }
+        var responses = IntStream.range(1, 25).mapToObj(i -> new BookmarkHearitResponseV2(
+                        (long) i,
+                        (long) (1000 + i),
+                        "Title " + i,
+                        "Summary " + i + 1,
+                        100 + i,
+                        (long) 200 + i - 2,
+                        false,
+                        List.of(new SourceResponse("source1", "url1"), new SourceResponse("source2", "url2")),
+                        new CategoryResponse((long) i, "categoryName", "#FFFFFF")
+                ))
+                .toList();
+        var pagedResponses = new PageImpl<>(responses, PageRequest.of(0, 20), responses.size());
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(bookmarkService.getBookmarkHearits(any(), any())).willReturn(pagedResponses);
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .param("page", 0)
-                .param("size", 5)
-                .filter(document("bookmark-read-list-v2",
+        mockMvc.perform(get("/api/v2/bookmarks/hearits")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andDo(document("v2-get-bookmarks-hearits-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
                                 .summary("북마크 목록 조회 V2")
-                                .description("사용자가 북마크한 히어릿 목록을 페이지별로 조회합니다.")
+                                .description("로그인한 사용자가 북마크한 히어릿 목록을 `Page` 단위로 조회합니다.")
                                 .queryParameters(
-                                        parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
-                                        parameterWithName("size").description("페이지 당 항목 수 (기본 20)").defaultValue("20")
+                                        parameterWithName("page").description("페이지 번호 (start 0)").defaultValue("0"),
+                                        parameterWithName("size").description("페이지 당 항목 수").defaultValue("20")
                                 )
-                                .responseSchema(Schema.schema("PagedBookmarkHearitResponse"))
-                                .responseFields(
-                                        Stream.concat(
+                                .responseFields(Stream.concat(
                                                 Arrays.stream(new FieldDescriptor[]{
                                                         fieldWithPath("content[].hearitId").description("히어릿 ID"),
                                                         fieldWithPath("content[].bookmarkId").description("북마크 ID"),
@@ -126,226 +143,158 @@ class BookmarkControllerTest extends IntegrationTest {
                                                                 "히어릿 마지막 재생 시간(ms)").optional(),
                                                         fieldWithPath("content[].isFinished").description(
                                                                 "히어릿 재생 완료 여부").optional(),
-                                                        fieldWithPath("content[].sources").description("히어릿 소스 리스트"),
-                                                        fieldWithPath("content[].sources[].sourceName").description("소스 이름"),
-                                                        fieldWithPath("content[].sources[].sourceUrl").description("소스 URL"),
+                                                        fieldWithPath("content[].sources").description("출처 정보"),
+                                                        fieldWithPath("content[].sources[].sourceName").description("출처 이름"),
+                                                        fieldWithPath("content[].sources[].sourceUrl").description("출처 URL"),
                                                         fieldWithPath("content[].category").description("카테고리 정보"),
                                                         fieldWithPath("content[].category.id").description("카테고리 ID"),
                                                         fieldWithPath("content[].category.name").description("카테고리 이름"),
-                                                        fieldWithPath("content[].category.colorCode").description("카테고리 색상 코드")
-                                                }),
-                                                Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields())
-                                        ).toArray(FieldDescriptor[]::new)
+                                                        fieldWithPath("content[].category.colorCode").description("카테고리 색상코드")
+                                                }), Arrays.stream(ApiDocSnippets.getCustomPagedResponseFields()))
+                                        .toArray(FieldDescriptor[]::new)
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v2/bookmarks/hearits")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .body("content.size()", equalTo(5));
+                ));
     }
 
     @Test
-    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, page가 0 미만인 경우 400 BADREQUEST가 발생한다.")
-    void readBookmarkHearitsTestWithBadRequestByPage() {
+    @DisplayName("북마크 목록 조회 V2 - 400 BadRequest")
+    void readBookmarkHearitsV2_BadRequest() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .param("page", -1)
-                .filter(document("bookmark-read-list-bad-request",
+        mockMvc.perform(get("/api/v2/bookmarks/hearits")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("page", "-1")
+                        .param("size", "20"))
+                .andExpect(status().isBadRequest())
+                .andDo(document("v2-get-bookmarks-hearits-bad-request",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
-                                .summary("북마크 목록 조회")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("북마크 목록 조회 V2")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/bookmarks/hearits")
-                .then()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {-1, 101})
-    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, size가 0 ~ 100이 아닌 경우 400 BADREQUEST가 발생한다.")
-    void readBookmarkHearitsTestWithBadRequestBySize(int size) {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
-
-        // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .param("size", size)
-                .when()
-                .get("/api/v1/bookmarks/hearits")
-                .then()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                ));
     }
 
     @Test
-    @DisplayName("로그인하지 않은 사용자가 북마크 목록 조회 시, 401 UNAUTHORIZED가 발생한다.")
-    void readBookmarkHearits_error_401_whenNotLogin() {
+    @DisplayName("북마크 목록 조회 V2 - 401 Unauthorized")
+    void readBookmarkHearitsV2_Unauthorized() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        int bookmarkCount = 10;
-        for (int i = 0; i < bookmarkCount; i++) {
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
-        }
+        given(jwtTokenProvider.getTokenStatus(isNull())).willReturn(TokenStatus.NOT_EXIST);
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "")
-                .param("page", 0)
-                .param("size", 20)
-                .filter(document("bookmark-read-list-unauthorized",
+        mockMvc.perform(get("/api/v2/bookmarks/hearits")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("v2-get-bookmarks-hearits-unauthorized",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
-                                .summary("북마크 목록 조회")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("북마크 목록 조회 V2")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/bookmarks/hearits")
-                .then()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                ));
     }
 
     @Test
-    @DisplayName("로그인한 사용자가 북마크 추가 시, 추가 후 201 CREATED를 반환한다.")
-    void createBookmarkTest() {
+    @DisplayName("북마크 추가 V1 - 201 Created")
+    void createBookmarkV1_Created() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        var hearitId = 3L;
+        var response = new BookmarkInfoResponse(hearitId);
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(bookmarkService.addBookmark(any(), any())).willReturn(response);
 
         // when & then
-        BookmarkInfoResponse response = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .filter(document("bookmark-create",
+        mockMvc.perform(post("/api/v1/bookmarks/hearits/{hearitId}", hearitId)
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isCreated())
+                .andDo(document("v1-post-bookmarks-hearits-created",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
-                                .summary("북마크 생성")
-                                .description("로그인한 회원이 히어릿 ID로 북마크를 생성합니다.")
+                                .summary("북마크 생성 V1")
+                                .description("로그인한 사용자가 히어릿에 대한 북마크를 생성합니다.")
                                 .pathParameters(
-                                        parameterWithName("hearitId").description("북마크할 히어릿의 ID")
+                                        parameterWithName("hearitId").description("북마크 대상 히어릿 ID")
                                 )
-                                .responseSchema(Schema.schema("BookmarkInfoResponse"))
                                 .responseFields(
-                                        fieldWithPath("id").description("생성된 북마크의 ID")
+                                        fieldWithPath("id").description("생성된 북마크 ID")
                                 )
                                 .build())
-                ))
-                .when()
-                .post("/api/v1/bookmarks/hearits/{hearitId}", hearit.getId())
-                .then()
-                .statusCode(HttpStatus.CREATED.value())
-                .extract().as(BookmarkInfoResponse.class);
-
-        assertThat(response.id()).isNotNull();
+                ));
     }
 
     @Test
-    @DisplayName("로그인한 사용자가 이미 추가된 북마크 추가 시, 추가 후 409 CONFLICT를 반환한다.")
-    void createBookmarkTestWithConflict() {
+    @DisplayName("북마크 추가 V1 - 409 Conflict")
+    void createBookmarkV1_Conflict() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        var hearitId = 3L;
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(bookmarkService.addBookmark(any(), any()))
+                .willThrow(new AlreadyExistException("이미 북마크된 히어릿입니다."));
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .filter(document("bookmark-create-conflict",
+        mockMvc.perform(post("/api/v1/bookmarks/hearits/{hearitId}", hearitId)
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isConflict())
+                .andDo(document("v1-post-bookmarks-hearits-conflict",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
-                                .summary("북마크 생성")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("북마크 생성 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .post("/api/v1/bookmarks/hearits/{hearitId}", hearit.getId())
-                .then()
-                .statusCode(HttpStatus.CONFLICT.value());
+                ));
     }
 
     @Test
-    @DisplayName("로그인한 사용자가 북마크 삭제 시, 삭제 후 204 NOCONTENT를 반환한다.")
-    void deleteBookmark() {
+    @DisplayName("북마크 삭제 V1 - 204 No Content")
+    void deleteBookmarkV1_NoContent() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        var bookmarkId = 1L;
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        willDoNothing().given(bookmarkService).deleteBookmark(any(), any());
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .filter(document("bookmark-delete",
+        mockMvc.perform(delete("/api/v1/bookmarks/{bookmarkId}", bookmarkId)
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isNoContent())
+                .andDo(document("v1-delete-bookmarks-no-content",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
-                                .summary("북마크 삭제")
-                                .description("로그인한 히어릿 ID와 북마크 ID로 북마크를 삭제합니다.")
+                                .summary("북마크 삭제 V1")
+                                .description("로그인한 사용자가 히어릿에 대한 북마크를 삭제합니다.")
                                 .pathParameters(
-                                        parameterWithName("bookmarkId").description("삭제할 북마크의 ID")
+                                        parameterWithName("bookmarkId").description("삭제 대상 북마크 ID")
                                 )
                                 .build())
-                ))
-                .when()
-                .delete("/api/v1/bookmarks/{bookmarkId}", bookmark.getId())
-                .then()
-                .statusCode(HttpStatus.NO_CONTENT.value());
+                ));
     }
 
     @Test
-    @DisplayName("자신의 북마크가 아닌 북마크 삭제 시, 403 FORBIDDEN을 반환한다.")
-    void notFoundHearitId() {
+    @DisplayName("북마크 삭제 V1 - 403 Forbidden")
+    void deleteBookmarkV1_Forbidden() throws Exception {
         // given
-        Member bookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
-        Member notBookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(notBookmarkMember);
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(bookmarkMember, hearit));
+        var bookmarkId = 1L;
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        willThrow(new ForbiddenException("북마크를 삭제할 권한이 없습니다."))
+                .given(bookmarkService).deleteBookmark(any(), any());
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .filter(document("bookmark-delete-unauthorized",
+        mockMvc.perform(delete("/api/v1/bookmarks/{bookmarkId}", bookmarkId)
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isForbidden())
+                .andDo(document("v1-delete-bookmarks-forbidden",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
-                                .summary("북마크 삭제")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("북마크 삭제 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .delete("/api/v1/bookmarks/{bookmarkId}", bookmark.getId())
-                .then()
-                .statusCode(HttpStatus.FORBIDDEN.value());
-    }
-
-    private String generateToken(Member member) {
-        return jwtTokenProvider.createAccessToken(member.getId());
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/bookmark/presentation/BookmarkIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/bookmark/presentation/BookmarkIntegrationTest.java
@@ -1,0 +1,223 @@
+package com.onair.hearit.bookmark.presentation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.bookmark.dto.BookmarkInfoResponse;
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Bookmark;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.fixture.IntegrationTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+class BookmarkIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
+    void readBookmarkHearitsTest_v1() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        String token = generateToken(member);
+        int bookmarkCount = 30;
+        for (int i = 0; i < bookmarkCount; i++) {
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        }
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .param("page", 0)
+                .param("size", 5)
+                .when()
+                .get("/api/v1/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("content.size()", equalTo(5));
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, 200 OK 및 페이지에 따른 북마크 목록을 반환한다.")
+    void readBookmarkHearitsTest_v2() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        String token = generateToken(member);
+        int bookmarkCount = 30;
+        for (int i = 0; i < bookmarkCount; i++) {
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        }
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .param("page", 0)
+                .param("size", 5)
+                .when()
+                .get("/api/v2/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("content.size()", equalTo(5));
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, page가 0 미만인 경우 400 BADREQUEST가 발생한다.")
+    void readBookmarkHearitsTestWithBadRequestByPage() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+
+        // when & then
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .param("page", -1)
+                .when()
+                .get("/api/v2/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 101})
+    @DisplayName("로그인한 사용자가 북마크 목록 조회 시, size가 0 ~ 100이 아닌 경우 400 BADREQUEST가 발생한다.")
+    void readBookmarkHearitsTestWithBadRequestBySize(int size) {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .param("size", size)
+                .when()
+                .get("/api/v1/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 북마크 목록 조회 시, 401 UNAUTHORIZED가 발생한다.")
+    void readBookmarkHearits_error_401_whenNotLogin() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        int bookmarkCount = 10;
+        for (int i = 0; i < bookmarkCount; i++) {
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+        }
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "")
+                .param("page", 0)
+                .param("size", 20)
+                .when()
+                .get("/api/v1/bookmarks/hearits")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크 추가 시, 추가 후 201 CREATED를 반환한다.")
+    void createBookmarkTest() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        // when & then
+        BookmarkInfoResponse response = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .post("/api/v1/bookmarks/hearits/{hearitId}", hearit.getId())
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().as(BookmarkInfoResponse.class);
+
+        assertThat(response.id()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 이미 추가된 북마크 추가 시, 추가 후 409 CONFLICT를 반환한다.")
+    void createBookmarkTestWithConflict() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .post("/api/v1/bookmarks/hearits/{hearitId}", hearit.getId())
+                .then()
+                .statusCode(HttpStatus.CONFLICT.value());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 북마크 삭제 시, 삭제 후 204 NOCONTENT를 반환한다.")
+    void deleteBookmark() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .delete("/api/v1/bookmarks/{bookmarkId}", bookmark.getId())
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    @DisplayName("자신의 북마크가 아닌 북마크 삭제 시, 403 FORBIDDEN을 반환한다.")
+    void notFoundHearitId() {
+        // given
+        Member bookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
+        Member notBookmarkMember = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(notBookmarkMember);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(bookmarkMember, hearit));
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .delete("/api/v1/bookmarks/{bookmarkId}", bookmark.getId())
+                .then()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    private String generateToken(Member member) {
+        return jwtTokenProvider.createAccessToken(member.getId());
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/category/presentation/CategoryControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/category/presentation/CategoryControllerTest.java
@@ -2,55 +2,65 @@ package com.onair.hearit.category.presentation;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
+import com.onair.hearit.category.application.CategoryService;
 import com.onair.hearit.category.dto.CategoryResponse;
 import com.onair.hearit.common.dto.response.PagedResponse;
 import com.onair.hearit.fixture.ApiDocSnippets;
-import com.onair.hearit.domain.Category;
-import com.onair.hearit.fixture.IntegrationTest;
-import io.restassured.RestAssured;
-import io.restassured.common.mapper.TypeRef;
+import com.onair.hearit.fixture.ControllerTest;
 import java.util.Arrays;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class CategoryControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = CategoryController.class)
+class CategoryControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private CategoryService categoryService;
 
     @Test
-    @DisplayName("전체 카테고리를 조회 시 200 OK 및 페이징이 적용된 카테고리 목록을 반환한다.")
-    void readAllCategories() {
+    @DisplayName("카테고리 목록 조회 V1 - 200 OK")
+    void readCategoriesV1_OK() throws Exception {
         // given
-        Category category1 = dbHelper.insertCategory(new Category("category1", "#111111"));
-        Category category2 = dbHelper.insertCategory(new Category("category2", "#222222"));
-        Category category3 = dbHelper.insertCategory(new Category("category3", "#333333"));
-        Category category4 = dbHelper.insertCategory(new Category("category4", "#444444"));
-        Category category5 = dbHelper.insertCategory(new Category("category5", "#555555"));
+        var responses = IntStream.range(1, 25).mapToObj(i -> new CategoryResponse(
+                        (long) i,
+                        "category" + i,
+                        "#" + i * 111111
+                ))
+                .toList();
+        var pagedResponses = PagedResponse.from(new PageImpl<>(responses, PageRequest.of(0, 20), responses.size()));
 
-        // when
-        PagedResponse<CategoryResponse> result = RestAssured.given(this.spec)
-                .param("page", 1)
-                .param("size", 2)
-                .filter(document("category-read-list",
+        given(categoryService.getCategories(any())).willReturn(pagedResponses);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/categories")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-categories-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Category API")
-                                .summary("전체 카테고리 목록 조회")
-                                .description("전체 카테고리 목록을 페이지별로 조회합니다.")
+                                .summary("카테고리 목록 조회 V1")
+                                .description("전체 카테고리 목록을 `Page` 단위로 조회합니다.")
                                 .queryParameters(
-                                        parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
-                                        parameterWithName("size").description("페이지 당 항목 수 (기본 20)").defaultValue("20")
+                                        parameterWithName("page").description("페이지 번호 (start 0)").defaultValue("0"),
+                                        parameterWithName("size").description("페이지 당 항목 수").defaultValue("20")
                                 )
-                                .responseSchema(Schema.schema("PagedResponse"))
-                                .responseFields(
-                                        Stream.concat(
+                                .responseFields(Stream.concat(
                                                 Arrays.stream(new FieldDescriptor[]{
                                                         fieldWithPath("content[].id").description("카테고리 ID"),
                                                         fieldWithPath("content[].name").description("카테고리 이름"),
@@ -60,42 +70,23 @@ class CategoryControllerTest extends IntegrationTest {
                                         ).toArray(FieldDescriptor[]::new)
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/categories")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(new TypeRef<>() {
-                });
-
-        // then
-        assertAll(
-                () -> assertThat(result.content()).hasSize(2),
-                () -> assertThat(result.content()).extracting(CategoryResponse::id)
-                        .containsExactly(category3.getId(), category4.getId()),
-                () -> assertThat(result.content()).extracting(CategoryResponse::colorCode)
-                        .containsExactly("#333333", "#444444")
-        );
+                ));
     }
 
     @Test
-    @DisplayName("전체 카테고리 조회 시 유효하지 않은 페이지 번호를 보내면 400 BAD_REQUEST를 반환한다.")
-    void readAllCategoriesWithInvalidPage() {
-        RestAssured.given(this.spec)
-                .param("page", -1)
-                .param("size", 10)
-                .filter(document("category-read-list-bad-request",
+    @DisplayName("카테고리 목록 조회 V1 - 400 Bad Request")
+    void readCategoriesV1_BadRequest() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/categories")
+                        .param("page", "-1")
+                        .param("size", "20"))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-categories-bad-request",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Category API")
-                                .summary("전체 카테고리 목록 조회")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("카테고리 목록 조회 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/categories")
-                .then()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/category/presentation/CategoryControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/category/presentation/CategoryControllerTest.java
@@ -11,7 +11,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.onair.hearit.category.dto.CategoryResponse;
 import com.onair.hearit.common.dto.response.PagedResponse;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.fixture.IntegrationTest;
 import io.restassured.RestAssured;

--- a/backend/app/src/test/java/com/onair/hearit/category/presentation/CategoryIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/category/presentation/CategoryIntegrationTest.java
@@ -1,0 +1,60 @@
+package com.onair.hearit.category.presentation;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.category.dto.CategoryResponse;
+import com.onair.hearit.common.dto.response.PagedResponse;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.fixture.IntegrationTest;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class CategoryIntegrationTest extends IntegrationTest {
+
+    @Test
+    @DisplayName("전체 카테고리를 조회 시 200 OK 및 페이징이 적용된 카테고리 목록을 반환한다.")
+    void readAllCategories() {
+        // given
+        Category category1 = dbHelper.insertCategory(new Category("category1", "#111111"));
+        Category category2 = dbHelper.insertCategory(new Category("category2", "#222222"));
+        Category category3 = dbHelper.insertCategory(new Category("category3", "#333333"));
+        Category category4 = dbHelper.insertCategory(new Category("category4", "#444444"));
+        Category category5 = dbHelper.insertCategory(new Category("category5", "#555555"));
+
+        // when
+        PagedResponse<CategoryResponse> result = RestAssured.given(this.spec)
+                .param("page", 1)
+                .param("size", 2)
+                .when()
+                .get("/api/v1/categories")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<>() {});
+
+        // then
+        assertAll(
+                () -> assertThat(result.content()).hasSize(2),
+                () -> assertThat(result.content()).extracting(CategoryResponse::id)
+                        .containsExactly(category3.getId(), category4.getId()),
+                () -> assertThat(result.content()).extracting(CategoryResponse::colorCode)
+                        .containsExactly("#333333", "#444444")
+        );
+    }
+
+    @Test
+    @DisplayName("전체 카테고리 조회 시 유효하지 않은 페이지 번호를 보내면 400 BAD_REQUEST를 반환한다.")
+    void readAllCategoriesWithInvalidPage() {
+        RestAssured.given(this.spec)
+                .param("page", -1)
+                .param("size", 10)
+                .when()
+                .get("/api/v1/categories")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/explore/presentation/ExploreControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/explore/presentation/ExploreControllerTest.java
@@ -12,7 +12,7 @@ import com.epages.restdocs.apispec.Schema;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.dto.response.CursorResponseV1;
 import com.onair.hearit.common.dto.response.CursorResponseV2;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;

--- a/backend/app/src/test/java/com/onair/hearit/explore/presentation/ExploreControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/explore/presentation/ExploreControllerTest.java
@@ -2,182 +2,140 @@ package com.onair.hearit.explore.presentation;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
-import com.onair.hearit.common.dto.response.CursorResponseV1;
+import com.onair.hearit.auth.infrastructure.jwt.TokenStatus;
 import com.onair.hearit.common.dto.response.CursorResponseV2;
-import com.onair.hearit.fixture.ApiDocSnippets;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.domain.Category;
-import com.onair.hearit.domain.Hearit;
-import com.onair.hearit.domain.HearitKeyword;
-import com.onair.hearit.domain.Keyword;
-import com.onair.hearit.domain.Member;
+import com.onair.hearit.explore.application.HearitExploreService;
 import com.onair.hearit.explore.dto.ExploredHearitResponse;
-import com.onair.hearit.fixture.IntegrationTest;
-import io.restassured.RestAssured;
-import io.restassured.common.mapper.TypeRef;
+import com.onair.hearit.explore.dto.ExploredHearitResponse.KeywordResponse;
+import com.onair.hearit.fixture.ApiDocSnippets;
+import com.onair.hearit.fixture.ControllerTest;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class ExploreControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = ExploreController.class)
+class ExploreControllerTest extends ControllerTest {
 
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
-
-    @Test
-    @DisplayName("탐색 히어릿을 조회 시, 200 OK 및 최대 10개 히어릿 정보 목록을 제공한다.")
-    void readExploredHearits_byMember_v2() {
-        // given
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Keyword keyword = dbHelper.insertKeyword(new Keyword("Keyword"));
-
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit1, keyword));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit2, keyword));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit3, keyword));
-
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-
-        // when
-        CursorResponseV2<ExploredHearitResponse> responses = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .queryParam("cursorId", 0)
-                .queryParam("size", 10)
-                .filter(document("hearit-read-explore-member-v2",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Hearit API")
-                                .summary("탐색 히어릿 목록 조회 V2")
-                                .description("사용자 별 최대 10개의 히어릿 목록을 조회합니다.")
-                                .queryParameters(
-                                        parameterWithName("cursorId").description("시작 Cursor ID").defaultValue("0"),
-                                        parameterWithName("size").description("필요한 히어릿 항목 수").defaultValue("10")
-                                )
-                                .responseSchema(Schema.schema("CursorExploredHearitResponse"))
-                                .responseFields(
-                                        Stream.concat(
-                                                Arrays.stream(new FieldDescriptor[]{
-                                                        fieldWithPath("content[].id").description("히어릿 ID"),
-                                                        fieldWithPath("content[].title").description("히어릿 제목"),
-                                                        fieldWithPath("content[].categoryColorCode").description(
-                                                                "카테고리 색상"),
-                                                        fieldWithPath("content[].isBookmarked").description("북마크 여부"),
-                                                        fieldWithPath("content[].bookmarkId").description(
-                                                                "북마크 ID (북마크된 경우)").optional(),
-                                                        fieldWithPath("content[].keywords").description(
-                                                                "히어릿에 포함된 키워드 목록"),
-                                                        fieldWithPath("content[].keywords[].id").description("키워드 ID"),
-                                                        fieldWithPath("content[].keywords[].name").description(
-                                                                "키워드 이름"),
-                                                        fieldWithPath("content[].cursorId").description("커서 ID"),
-                                                }),
-                                                Arrays.stream(ApiDocSnippets.getCustomCursorResponseFields())
-                                        ).toArray(FieldDescriptor[]::new)
-                                )
-                                .build())
-                ))
-                .when()
-                .get("/api/v2/hearits/explore")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(new TypeRef<>() {
-                });
-
-        // then
-        assertAll(() -> {
-            assertThat(responses.content()).hasSize(3);
-            assertThat(responses.content()).extracting(ExploredHearitResponse::cursorId)
-                    .containsExactly(1L, 2L, 3L);
-            assertThat(responses.isEmpty()).isFalse();
-        });
-    }
+    @MockitoBean
+    private HearitExploreService hearitExploreService;
 
     @Test
-    @DisplayName("탐색 히어릿을 조회 시, 200 OK 및 최대 10개 히어릿 정보 목록을 제공한다.")
-    void readExploredHearits_byMember_v1() {
+    @DisplayName("탐색 히어릿 목록 조회 V1 - 200 OK")
+    void readExploredHearitsV1_OK() throws Exception {
         // given
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Keyword keyword = dbHelper.insertKeyword(new Keyword("Keyword"));
+        var responses = IntStream.range(1, 12).mapToObj(i -> new ExploredHearitResponse(
+                        (long) i,
+                        "Title " + i,
+                        "#FFFFFF",
+                        false,
+                        null,
+                        List.of(new KeywordResponse((long) i, "keyword1"), new KeywordResponse((long) i, "keyword2")),
+                        (long) i - 1)
+                )
+                .toList();
+        var pagedResponses = CursorResponseV2.from(responses);
 
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit1, keyword));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit2, keyword));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit3, keyword));
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(hearitExploreService.getExploredHearits(any(), any())).willReturn(pagedResponses);
 
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-
-        // when
-        CursorResponseV1<ExploredHearitResponse> responses = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .queryParam("cursorId", 0)
-                .queryParam("size", 10)
-                .filter(document("hearit-read-explore-member-v1",
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/explore")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("cursorId", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-explore-ok",
                         resource(ResourceSnippetParameters.builder()
-                                .tag("Hearit API")
+                                .tag("Explore API")
                                 .summary("탐색 히어릿 목록 조회 V1")
-                                .description("사용자 별 최대 10개의 히어릿 목록을 조회합니다.")
+                                .description("로그인한 사용자가 탐색된 히어릿 목록을 `cursorId` 기준으로 조회합니다.")
                                 .queryParameters(
                                         parameterWithName("cursorId").description("시작 Cursor ID").defaultValue("0"),
                                         parameterWithName("size").description("필요한 히어릿 항목 수").defaultValue("10")
                                 )
-                                .responseSchema(Schema.schema("CursorExploredHearitResponse"))
-                                .responseFields(
-                                        Stream.concat(
+                                .responseFields(Stream.concat(
                                                 Arrays.stream(new FieldDescriptor[]{
                                                         fieldWithPath("content[].id").description("히어릿 ID"),
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
-                                                        fieldWithPath("content[].categoryColorCode").description(
-                                                                "카테고리 색상"),
+                                                        fieldWithPath("content[].categoryColorCode").description("카테고리 색상"),
                                                         fieldWithPath("content[].isBookmarked").description("북마크 여부"),
-                                                        fieldWithPath("content[].bookmarkId").description(
-                                                                "북마크 ID (북마크된 경우)").optional(),
-                                                        fieldWithPath("content[].keywords").description(
-                                                                "히어릿에 포함된 키워드 목록"),
+                                                        fieldWithPath("content[].bookmarkId").description("북마크 ID (북마크된 경우)").optional(),
+                                                        fieldWithPath("content[].keywords").description("히어릿에 포함된 키워드 목록"),
                                                         fieldWithPath("content[].keywords[].id").description("키워드 ID"),
-                                                        fieldWithPath("content[].keywords[].name").description(
-                                                                "키워드 이름"),
+                                                        fieldWithPath("content[].keywords[].name").description("키워드 이름"),
                                                         fieldWithPath("content[].cursorId").description("커서 ID"),
                                                 }),
                                                 Arrays.stream(ApiDocSnippets.getCustomCursorResponseV1Fields())
                                         ).toArray(FieldDescriptor[]::new)
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/explore")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(new TypeRef<>() {
-                });
-
-        // then
-        assertAll(() -> {
-            assertThat(responses.content()).hasSize(3);
-            assertThat(responses.cursorId()).isEqualTo(3L);
-            assertThat(responses.isEmpty()).isFalse();
-        });
+                ));
     }
 
-    private String generateToken(Member member) {
-        return jwtTokenProvider.createAccessToken(member.getId());
+    @Test
+    @DisplayName("탐색 히어릿 목록 조회 V2 - 200 OK")
+    void readExploredHearitsV2_OK() throws Exception {
+        // given
+        var responses = IntStream.range(1, 12).mapToObj(i -> new ExploredHearitResponse(
+                        (long) i,
+                        "Title " + i,
+                        "#FFFFFF",
+                        false,
+                        null,
+                        List.of(new KeywordResponse((long) i, "keyword1"), new KeywordResponse((long) i, "keyword2")),
+                        (long) i - 1)
+                )
+                .toList();
+        var pagedResponses = CursorResponseV2.from(responses);
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(hearitExploreService.getExploredHearits(any(), any())).willReturn(pagedResponses);
+
+        // when & then
+        mockMvc.perform(get("/api/v2/hearits/explore")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("cursorId", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v2-get-hearits-explore-ok",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Explore API")
+                                .summary("탐색 히어릿 목록 조회 V2")
+                                .description("로그인한 사용자가 탐색된 히어릿 목록을 `cursorId` 기준으로 조회합니다.")
+                                .queryParameters(
+                                        parameterWithName("cursorId").description("시작 Cursor ID").defaultValue("0"),
+                                        parameterWithName("size").description("필요한 히어릿 항목 수").defaultValue("10")
+                                )
+                                .responseFields(Stream.concat(
+                                                Arrays.stream(new FieldDescriptor[]{
+                                                        fieldWithPath("content[].id").description("히어릿 ID"),
+                                                        fieldWithPath("content[].title").description("히어릿 제목"),
+                                                        fieldWithPath("content[].categoryColorCode").description("카테고리 색상"),
+                                                        fieldWithPath("content[].isBookmarked").description("북마크 여부"),
+                                                        fieldWithPath("content[].bookmarkId").description("북마크 ID (북마크된 경우)").optional(),
+                                                        fieldWithPath("content[].keywords").description("히어릿에 포함된 키워드 목록"),
+                                                        fieldWithPath("content[].keywords[].id").description("키워드 ID"),
+                                                        fieldWithPath("content[].keywords[].name").description("키워드 이름"),
+                                                        fieldWithPath("content[].cursorId").description("커서 ID"),
+                                                }),
+                                                Arrays.stream(ApiDocSnippets.getCustomCursorResponseFields())
+                                        ).toArray(FieldDescriptor[]::new)
+                                )
+                                .build())
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/explore/presentation/ExploreIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/explore/presentation/ExploreIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.onair.hearit.explore.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.common.dto.response.CursorResponseV1;
+import com.onair.hearit.common.dto.response.CursorResponseV2;
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.HearitKeyword;
+import com.onair.hearit.domain.Keyword;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.explore.dto.ExploredHearitResponse;
+import com.onair.hearit.fixture.IntegrationTest;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+class ExploreIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("탐색 히어릿을 조회 시, 200 OK 및 최대 10개 히어릿 정보 목록을 제공한다.")
+    void readExploredHearits_byMember_v2() {
+        // given
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Keyword keyword = dbHelper.insertKeyword(new Keyword("Keyword"));
+
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit1, keyword));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit2, keyword));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit3, keyword));
+
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+
+        // when
+        CursorResponseV2<ExploredHearitResponse> responses = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .queryParam("cursorId", 0)
+                .queryParam("size", 10)
+                .when()
+                .get("/api/v2/hearits/explore")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<>() {});
+
+        // then
+        assertAll(() -> {
+            assertThat(responses.content()).hasSize(3);
+            assertThat(responses.content()).extracting(ExploredHearitResponse::cursorId)
+                    .containsExactly(1L, 2L, 3L);
+            assertThat(responses.isEmpty()).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("탐색 히어릿을 조회 시, 200 OK 및 최대 10개 히어릿 정보 목록을 제공한다.")
+    void readExploredHearits_byMember_v1() {
+        // given
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Keyword keyword = dbHelper.insertKeyword(new Keyword("Keyword"));
+
+        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit1, keyword));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit2, keyword));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit3, keyword));
+
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+
+        // when
+        CursorResponseV1<ExploredHearitResponse> responses = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .queryParam("cursorId", 0)
+                .queryParam("size", 10)
+                .when()
+                .get("/api/v1/hearits/explore")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<>() {});
+
+        // then
+        assertAll(() -> {
+            assertThat(responses.content()).hasSize(3);
+            assertThat(responses.cursorId()).isEqualTo(3L);
+            assertThat(responses.isEmpty()).isFalse();
+        });
+    }
+
+    private String generateToken(Member member) {
+        return jwtTokenProvider.createAccessToken(member.getId());
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/fixture/ApiDocSnippets.java
+++ b/backend/app/src/test/java/com/onair/hearit/fixture/ApiDocSnippets.java
@@ -1,4 +1,4 @@
-package com.onair.hearit.core.docs;
+package com.onair.hearit.fixture;
 
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
@@ -40,10 +40,8 @@ public class ApiDocSnippets {
                 fieldWithPath("title").type(JsonFieldType.STRING).description("문제 유형에 대한 요약 (에러 코드 제목)"),
                 fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                 fieldWithPath("detail").type(JsonFieldType.STRING).description("문제 발생에 대한 상세 설명"),
-                fieldWithPath("instance").type(JsonFieldType.STRING)
-                        .description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
-                fieldWithPath("properties").type(JsonFieldType.OBJECT)
-                        .description("문제 유형에 대한 추가 세부 정보 (현재는 사용되지 않아 null)").optional()
+                fieldWithPath("instance").type(JsonFieldType.STRING).description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
+                fieldWithPath("properties").type(JsonFieldType.OBJECT).description("문제 유형에 대한 추가 세부 정보 (현재는 사용되지 않아 null)").optional()
         };
     }
 
@@ -53,14 +51,9 @@ public class ApiDocSnippets {
                 fieldWithPath("title").type(JsonFieldType.STRING).description("문제 유형에 대한 요약 (에러 코드 제목)"),
                 fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                 fieldWithPath("detail").type(JsonFieldType.STRING).description("문제 발생에 대한 상세 설명"),
-                fieldWithPath("instance").type(JsonFieldType.STRING)
-                        .description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
-                fieldWithPath("properties").type(JsonFieldType.OBJECT)
-                        .description("문제 유형에 대한 추가 세부 정보").optional(),
-                fieldWithPath("properties.code").type(JsonFieldType.STRING)
-                        .description("에러 코드 (예: UNAUTHENTICATED)"),
-                fieldWithPath("properties.reissuable").type(JsonFieldType.BOOLEAN)
-                        .description("토큰 재발급 가능 여부")
+                fieldWithPath("instance").type(JsonFieldType.STRING).description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
+                fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드 (예: UNAUTHENTICATED)"),
+                fieldWithPath("reissuable").type(JsonFieldType.BOOLEAN).description("토큰 재발급 가능 여부")
         };
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/fixture/ControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/fixture/ControllerTest.java
@@ -1,0 +1,48 @@
+package com.onair.hearit.fixture;
+
+import com.onair.hearit.auth.config.ApiSecurityConfig;
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.log.exception.FilterExceptionLogger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@Import(ApiSecurityConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+@AutoConfigureRestDocs(outputDir = "build/generated-snippets")
+public abstract class ControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private RestDocumentationContextProvider restDocumentationContextProvider;
+
+    @MockitoBean
+    protected JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    protected FilterExceptionLogger filterExceptionLogger;
+
+    @BeforeEach
+    public void setUpMockMvc() {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(SecurityMockMvcConfigurers.springSecurity())
+                .apply(MockMvcRestDocumentation.documentationConfiguration(restDocumentationContextProvider))
+                .build();
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/FileSourceControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/FileSourceControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/FileSourceControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/FileSourceControllerTest.java
@@ -2,148 +2,134 @@ package com.onair.hearit.hearit.presentation;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
+import com.onair.hearit.exception.custom.NotFoundException;
 import com.onair.hearit.fixture.ApiDocSnippets;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.domain.Category;
-import com.onair.hearit.domain.Hearit;
-import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.fixture.ControllerTest;
+import com.onair.hearit.hearit.application.FileSourceService;
 import com.onair.hearit.hearit.dto.OriginalAudioResponse;
 import com.onair.hearit.hearit.dto.ScriptResponse;
 import com.onair.hearit.hearit.dto.ShortAudioResponse;
-import io.restassured.RestAssured;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class FileSourceControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = FileSourceController.class)
+class FileSourceControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private FileSourceService fileSourceService;
 
     @Test
-    @DisplayName("원본 오디오 url 요청 시, 200 OK 및 id와 url을 반환한다.")
-    void readOriginalAudioUrlWithSuccess() {
+    @DisplayName("원본 오디오 조회 - 200 OK")
+    void readOriginalAudioUrlV1_OK() throws Exception {
         // given
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        var hearitId = 3L;
+        var response = new OriginalAudioResponse(1L, "http://hearit.com/original-audio-url");
 
-        // when
-        OriginalAudioResponse response = RestAssured.given(this.spec)
-                .filter(document("filesource-read-original-audio",
+        given(fileSourceService.getOriginalAudio(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/{hearitId}/original-audio-url", hearitId))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-original-audio-url-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("FileSource API")
-                                .summary("원본 오디오 URL 조회")
-                                .description("히어릿 ID를 통해 원본 오디오 파일의 URL을 조회합니다.")
+                                .summary("원본 오디오 조회 V1")
+                                .description("히어릿에 대한 원본 오디오 파일 URL을 조회합니다.")
                                 .pathParameters(
-                                        parameterWithName("hearitId").description("히어릿 ID")
+                                        parameterWithName("hearitId").description("대상 히어릿 ID")
                                 )
-                                .responseSchema(Schema.schema("OriginalAudioResponse"))
                                 .responseFields(
                                         fieldWithPath("id").description("히어릿 ID"),
                                         fieldWithPath("url").description("원본 오디오 파일 URL")
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/{hearitId}/original-audio-url", hearit.getId())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(OriginalAudioResponse.class);
-
-        // then
-        assertThat(response.url()).contains(hearit.getOriginalAudioUrl());
+                ));
     }
 
     @Test
-    @DisplayName("1분 오디오 url 요청 시, 200 OK 및 id와 url을 반환한다.")
-    void readShortAudioUrlWithSuccess() {
+    @DisplayName("1분 오디오 조회 - 200 OK")
+    void readShortAudioUrlV1_OK() throws Exception {
         // given
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        var hearitId = 3L;
+        var response = new ShortAudioResponse(1L, "http://hearit.com/short-audio-url");
 
-        // when
-        ShortAudioResponse response = RestAssured.given(this.spec)
-                .filter(document("filesource-read-short-audio",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("FileSource API")
-                                .summary("1분 미리듣기 오디오 URL 조회")
-                                .description("히어릿 ID를 통해 1분 미리듣기 오디오 파일의 URL을 조회합니다.")
-                                .pathParameters(
-                                        parameterWithName("hearitId").description("히어릿 ID")
-                                )
-                                .responseSchema(Schema.schema("ShortAudioResponse"))
-                                .responseFields(
-                                        fieldWithPath("id").description("히어릿 ID"),
-                                        fieldWithPath("url").description("1분 미리듣기 오디오 파일 URL")
-                                )
-                                .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/{hearitId}/short-audio-url", hearit.getId())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(ShortAudioResponse.class);
-
-        // then
-        assertThat(response.url()).contains(hearit.getShortAudioUrl());
-    }
-
-    @Test
-    @DisplayName("대본 url 요청 시 200 OK 및 id와 url을 반환한다.")
-    void readScriptUrlWithSuccess() {
-        // given
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-
-        // when
-        ScriptResponse response = RestAssured.given(this.spec)
-                .filter(document("filesource-read-script",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("FileSource API")
-                                .summary("스크립트 URL 조회")
-                                .description("히어릿 ID를 통해 스크립트 파일의 URL을 조회합니다.")
-                                .pathParameters(
-                                        parameterWithName("hearitId").description("히어릿 ID")
-                                )
-                                .responseSchema(Schema.schema("ScriptResponse"))
-                                .responseFields(
-                                        fieldWithPath("id").description("히어릿 ID"),
-                                        fieldWithPath("url").description("스크립트 파일 URL")
-                                )
-                                .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/{hearitId}/script-url", hearit.getId())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(ScriptResponse.class);
-
-        // then
-        assertThat(response.url()).contains(hearit.getScriptUrl());
-    }
-
-    @Test
-    @DisplayName("존재하지 않은 hearit id로 url 요청 시, 404 NOT_FOUND를 반환한다.")
-    void notFoundHearitId() {
-        // given
-        Long notSavedHearitId = 9999L;
+        given(fileSourceService.getShortAudio(any())).willReturn(response);
 
         // when & then
-        RestAssured.given(this.spec)
-                .filter(document("filesource-read-not-found",
+        mockMvc.perform(get("/api/v1/hearits/{hearitId}/short-audio-url", hearitId))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-short-audio-url-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("FileSource API")
-                                .summary("원본/미리듣기/스크립트 URL 조회")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("1분 오디오 조회 V1")
+                                .description("히어릿에 대한 1분 오디오 파일 URL을 조회합니다.")
+                                .pathParameters(
+                                        parameterWithName("hearitId").description("대상 히어릿 ID")
+                                )
+                                .responseFields(
+                                        fieldWithPath("id").description("히어릿 ID"),
+                                        fieldWithPath("url").description("1분 오디오 파일 URL")
+                                )
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("대본 조회 - 200 OK")
+    void readScriptUrlV1_OK() throws Exception {
+        // given
+        var hearitId = 3L;
+        var response = new ScriptResponse(1L, "http://hearit.com/script-url");
+
+        given(fileSourceService.getScript(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/{hearitId}/script-url", hearitId))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-script-url-ok",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("FileSource API")
+                                .summary("대본 조회 V1")
+                                .description("히어릿에 대한 대본 파일 URL을 조회합니다.")
+                                .pathParameters(
+                                        parameterWithName("hearitId").description("대상 히어릿 ID")
+                                )
+                                .responseFields(
+                                        fieldWithPath("id").description("히어릿 ID"),
+                                        fieldWithPath("url").description("대본 파일 URL")
+                                )
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("대본 조회 - 404 Not Found")
+    void readScriptUrlV1_NotFound() throws Exception {
+        // given
+        var notSavedHearitId = 9999L;
+
+        given(fileSourceService.getScript(any()))
+                .willThrow(new NotFoundException("hearitId", "9999"));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/{hearitId}/script-url", notSavedHearitId))
+                .andExpect(status().isNotFound())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-script-url-not-found",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("FileSource API")
+                                .summary("대본 조회 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/{hearitId}/script-url", notSavedHearitId)
-                .then()
-                .statusCode(HttpStatus.NOT_FOUND.value());
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/FileSourceIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/FileSourceIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.onair.hearit.hearit.presentation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.hearit.dto.OriginalAudioResponse;
+import com.onair.hearit.hearit.dto.ScriptResponse;
+import com.onair.hearit.hearit.dto.ShortAudioResponse;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class FileSourceIntegrationTest extends IntegrationTest {
+
+    @Test
+    @DisplayName("원본 오디오 url 요청 시, 200 OK 및 id와 url을 반환한다.")
+    void readOriginalAudioUrlWithSuccess() {
+        // given
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        // when
+        OriginalAudioResponse response = RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/hearits/{hearitId}/original-audio-url", hearit.getId())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(OriginalAudioResponse.class);
+
+        // then
+        assertThat(response.url()).contains(hearit.getOriginalAudioUrl());
+    }
+
+    @Test
+    @DisplayName("1분 오디오 url 요청 시, 200 OK 및 id와 url을 반환한다.")
+    void readShortAudioUrlWithSuccess() {
+        // given
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        // when
+        ShortAudioResponse response = RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/hearits/{hearitId}/short-audio-url", hearit.getId())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(ShortAudioResponse.class);
+
+        // then
+        assertThat(response.url()).contains(hearit.getShortAudioUrl());
+    }
+
+    @Test
+    @DisplayName("대본 url 요청 시 200 OK 및 id와 url을 반환한다.")
+    void readScriptUrlWithSuccess() {
+        // given
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+        // when
+        ScriptResponse response = RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/hearits/{hearitId}/script-url", hearit.getId())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(ScriptResponse.class);
+
+        // then
+        assertThat(response.url()).contains(hearit.getScriptUrl());
+    }
+
+    @Test
+    @DisplayName("존재하지 않은 hearit id로 url 요청 시, 404 NOT_FOUND를 반환한다.")
+    void notFoundHearitId() {
+        // given
+        Long notSavedHearitId = 9999L;
+
+        // when & then
+        RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/hearits/{hearitId}/script-url", notSavedHearitId)
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitControllerTest.java
@@ -2,173 +2,154 @@ package com.onair.hearit.hearit.presentation;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.auth.infrastructure.jwt.TokenStatus;
 import com.onair.hearit.common.dto.response.PagedResponse;
+import com.onair.hearit.exception.custom.NotFoundException;
 import com.onair.hearit.fixture.ApiDocSnippets;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.domain.Category;
-import com.onair.hearit.domain.Hearit;
-import com.onair.hearit.domain.HearitKeyword;
-import com.onair.hearit.domain.Keyword;
-import com.onair.hearit.domain.Member;
-import com.onair.hearit.domain.PlayingHistory;
-import com.onair.hearit.domain.Source;
-import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.fixture.ControllerTest;
+import com.onair.hearit.hearit.application.HearitService;
 import com.onair.hearit.hearit.dto.HearitDetailResponse;
+import com.onair.hearit.hearit.dto.HearitDetailResponse.CategoryResponse;
+import com.onair.hearit.hearit.dto.HearitDetailResponse.SourceResponse;
 import com.onair.hearit.hearit.dto.HearitOfCategoryResponse;
 import com.onair.hearit.hearit.dto.HearitsWithRecommendCategoryResponse;
-import io.restassured.RestAssured;
-import io.restassured.common.mapper.TypeRef;
+import com.onair.hearit.hearit.dto.HearitsWithRecommendCategoryResponse.HearitResponse;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class HearitControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = HearitController.class)
+class HearitControllerTest extends ControllerTest {
 
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    @MockitoBean
+    private HearitService hearitService;
 
     @Test
-    @DisplayName("로그인한 사용자가 히어릿 단일 조회 시, 200 OK 및 히어릿 정보를 제공한다.")
-    void readHearitWithSuccessWithMember() {
+    @DisplayName("단일 히어릿 조회 - 200 OK")
+    void readHearitV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), hearit, 1_000));
-        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("Java"));
-        Keyword keyword2 = dbHelper.insertKeyword(new Keyword("Spring"));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword1));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword2));
+        var hearitId = 3L;
+        var response = new HearitDetailResponse(
+                1L,
+                "Title",
+                "summary",
+                List.of(new SourceResponse("source1", "url1"), new SourceResponse("source2", "url2")),
+                300,
+                (long) 1_000,
+                LocalDateTime.of(2025, 9, 30, 10, 0),
+                false,
+                null,
+                new CategoryResponse(2L, "categoryName", "#FFFFFF"),
+                List.of(new HearitDetailResponse.KeywordResponse(1L, "keyword1"),
+                        new HearitDetailResponse.KeywordResponse(2L, "keyword2"))
+        );
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(hearitService.getHearitDetail(any(), any())).willReturn(response);
+
         // when & then
-        HearitDetailResponse response = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .filter(document("hearit-read-detail",
+        mockMvc.perform(get("/api/v1/hearits/{hearitId}", hearitId)
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearit-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
-                                .summary("히어릿 상세 조회")
+                                .summary("단일 히어릿 조회 V1")
                                 .description("히어릿의 상세 정보를 조회합니다. \n\n"
-                                             + "로그인한 사용자의 경우, `isBookmarked`와 `bookmarkId` 필드가 사용자의 북마크 상태를 반영하여 반환됩니다. \n\n"
-                                             + "비로그인 사용자의 경우, `isBookmarked`는 항상 `false`이며 `bookmarkId`는 `null` 입니다.")
+                                        + "로그인한 사용자의 경우, `isBookmarked`와 `bookmarkId` 필드가 사용자의 북마크 상태를 반영하여 반환됩니다. \n\n"
+                                        + "비로그인 사용자의 경우, `isBookmarked`는 항상 `false`이며 `bookmarkId`는 `null` 입니다.")
                                 .pathParameters(
                                         parameterWithName("hearitId").description("조회할 히어릿의 ID")
                                 )
-                                .responseSchema(Schema.schema("HearitDetailResponse"))
                                 .responseFields(getHearitDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/{hearitId}", hearit.getId())
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(HearitDetailResponse.class);
-
-        assertThat(response.id()).isEqualTo(hearit.getId());
+                ));
     }
 
     @Test
-    @DisplayName("로그인 하지 않은 사용자가 히어릿 단일 조회 시, 200 OK 및 히어릿 정보를 제공한다.")
-    void readHearitWithSuccessWithNotMember() {
+    @DisplayName("단일 히어릿 조회 - 404 Not Found")
+    void readHearitV1_NotFound() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("Java"));
-        dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword1));
-
-        // when & then
-        HearitDetailResponse response = RestAssured.given(this.spec)
-                .when()
-                .get("/api/v1/hearits/{hearitId}", hearit.getId())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(HearitDetailResponse.class);
-
-        assertAll(
-                () -> assertThat(response.id()).isEqualTo(hearit.getId()),
-                () -> assertThat(response.isBookmarked()).isFalse()
-        );
-    }
-
-    @Test
-    @DisplayName("히어릿 단일 조회 시, 존재하지 않는 아이디인 경우 404 NOT_FOUND를 반환한다.")
-    void readHearitWithNotFound() {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
         Long notFoundHearitId = 9999L;
 
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(hearitService.getHearitDetail(any(), any())).willThrow(new NotFoundException("hearitId", "9999"));
+
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .filter(document("hearit-read-detail-not-found",
+        mockMvc.perform(get("/api/v1/hearits/{hearitId}", notFoundHearitId)
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isNotFound())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearit-not-found",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
-                                .summary("히어릿 상세 조회")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("단일 히어릿 조회 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/{hearitId}", notFoundHearitId)
-                .then()
-                .statusCode(HttpStatus.NOT_FOUND.value());
+                ));
     }
 
     @Test
-    @DisplayName("카테고리별로 그룹화된 히어릿들을 조회 시, 추천하는 3개의 카테고리와 히어릿들을 반환한다.")
-    void readHomeCategoriesHearit() {
+    @DisplayName("추천 카테고리별 히어릿 조회 V1 - 200 OK")
+    void readHearitsWithRecommendCategoryV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
+        var category1 = new HearitsWithRecommendCategoryResponse(1L, "Category A", "#FF0000",
+                List.of(
+                        new HearitResponse(101L, "Hearit 101", LocalDateTime.now()),
+                        new HearitResponse(102L, "Hearit 102", LocalDateTime.now()),
+                        new HearitResponse(103L, "Hearit 103", LocalDateTime.now()),
+                        new HearitResponse(104L, "Hearit 104", LocalDateTime.now()),
+                        new HearitResponse(105L, "Hearit 105", LocalDateTime.now())
+                )
+        );
+        var category2 = new HearitsWithRecommendCategoryResponse(2L, "Category B", "#00FF00",
+                List.of(
+                        new HearitResponse(201L, "Hearit 201", LocalDateTime.now()),
+                        new HearitResponse(202L, "Hearit 202", LocalDateTime.now()),
+                        new HearitResponse(203L, "Hearit 203", LocalDateTime.now()),
+                        new HearitResponse(204L, "Hearit 204", LocalDateTime.now()),
+                        new HearitResponse(205L, "Hearit 205", LocalDateTime.now())
+                )
+        );
+        var category3 = new HearitsWithRecommendCategoryResponse(3L, "Category C", "#0000FF",
+                List.of(
+                        new HearitResponse(301L, "Hearit 301", LocalDateTime.now()),
+                        new HearitResponse(302L, "Hearit 302", LocalDateTime.now()),
+                        new HearitResponse(303L, "Hearit 303", LocalDateTime.now()),
+                        new HearitResponse(304L, "Hearit 304", LocalDateTime.now()),
+                        new HearitResponse(305L, "Hearit 305", LocalDateTime.now())
+                )
+        );
+        var mockedResponse = List.of(category1, category2, category3);
 
-        Category category1 = dbHelper.insertCategory(new Category("Java", "#FF0000"));
-        Category category2 = dbHelper.insertCategory(new Category("Spring", "#00FF00"));
-        Category category3 = dbHelper.insertCategory(new Category("React1", "#0000FF"));
-        Category category4 = dbHelper.insertCategory(new Category("React2", "#0000FF"));
-        Category category5 = dbHelper.insertCategory(new Category("React3", "#0000FF"));
-        Category category6 = dbHelper.insertCategory(new Category("React4", "#0000FF"));
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(hearitService.getHearitsWithRecommendCategory(any())).willReturn(mockedResponse);
 
-        Hearit hearit11 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
-        Hearit hearit12 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
-        Hearit hearit13 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
-        Hearit hearit21 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category2));
-        Hearit hearit22 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category2));
-        Hearit hearit31 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category3));
-
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit11));
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit12));
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit13));
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit21));
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit22));
-        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit31));
-
-        // when
-        List<HearitsWithRecommendCategoryResponse> responses = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .filter(document("hearit-recommend-category",
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/recommend-category")
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-recommend-category-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
-                                .summary("추천 카테고리별 그룹화된 히어릿 조회")
-                                .description(
-                                        "추천하는 3개 카테고리와 카테고리별로 그룹화된 히어릿 5개 목록을 조회합니다. (현재 추천 기준 : 북마크 많은 카테고리 순, 북마크가 없는 경우 하루마다 랜덤 카테고리 추천)")
-                                .responseSchema(Schema.schema("HearitsWithRecommendCategoryResponse"))
+                                .summary("추천 카테고리별 히어릿 조회 V1")
+                                .description("추천하는 3개 카테고리와 카테고리별로 그룹화된 히어릿 5개 목록을 조회합니다.")
                                 .responseFields(
                                         fieldWithPath("[].categoryId").description("카테고리 ID"),
                                         fieldWithPath("[].categoryName").description("카테고리 이름"),
@@ -178,67 +159,49 @@ class HearitControllerTest extends IntegrationTest {
                                         fieldWithPath("[].hearits[].title").description("히어릿 제목"),
                                         fieldWithPath("[].hearits[].createdAt").description("히어릿 생성 일시")
                                 )
-                                .build()))
-                )
-                .when()
-                .get("/api/v1/hearits/recommend-category")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .jsonPath()
-                .getList(".", HearitsWithRecommendCategoryResponse.class);
-
-        // then
-        assertAll(() -> {
-            assertThat(responses).hasSize(3);
-            assertThat(responses.get(0).hearits()).hasSize(3);
-            assertThat(responses.get(1).hearits()).hasSize(2);
-            assertThat(responses.get(2).hearits()).hasSize(1);
-            assertThat(responses.get(0).categoryId()).isEqualTo(category1.getId());
-            assertThat(responses.get(1).categoryId()).isEqualTo(category2.getId());
-            assertThat(responses.get(2).categoryId()).isEqualTo(category3.getId());
-        });
+                                .build())
+                ));
     }
 
     @Test
-    @DisplayName("카테고리로 히어릿 검색 시 200 OK 및 해당 카테고리의 히어릿들을 최신순으로 반환한다.")
-    void getHearitsByCategoryWithPagination() {
+    @DisplayName("카테고리별 히어릿 조회 V1 - 200 OK")
+    void getHearitsByCategoryWithPagination() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category1 = dbHelper.insertCategory(new Category("Spring", "#000001"));
-        Category category2 = dbHelper.insertCategory(new Category("Java", "#000002"));
+        var categoryId = 1L;
+        var responses = List.of(new HearitOfCategoryResponse(101L, "Spring Boot Guide", 300, null,
+                        List.of(new HearitOfCategoryResponse.KeywordResponse(1L, "spring"),
+                                new HearitOfCategoryResponse.KeywordResponse(2L, "boot"))),
+                new HearitOfCategoryResponse(102L, "JPA Tips", 200, null,
+                        List.of(new HearitOfCategoryResponse.KeywordResponse(3L, "jpa"),
+                                new HearitOfCategoryResponse.KeywordResponse(4L, "hibernate"))));
+        var pagedResponses = PagedResponse.from(new PageImpl<>(responses, PageRequest.of(0, 20), responses.size()));
 
-        Keyword keyword = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
-        Hearit hearit1 = saveHearitWithCategoryAndKeyword(category1, keyword);
-        Hearit hearit2 = saveHearitWithCategoryAndKeyword(category1, keyword);
-        Hearit hearit3 = saveHearitWithCategoryAndKeyword(category2, keyword); // 카테고리 2의 히어릿
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(hearitService.getHearitsByCategory(any(), any(), any())).willReturn(pagedResponses);
 
-        // when
-        PagedResponse<HearitOfCategoryResponse> pagedResponse = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .queryParam("categoryId", category1.getId())
-                .queryParam("page", 0)
-                .queryParam("size", 10)
-                .filter(document("category-search-hearits",
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("categoryId", String.valueOf(categoryId))
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-by-category-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
-                                .summary("카테고리별 히어릿 목록 조회")
-                                .description("특정 카테고리에 속한 히어릿 목록을 페이지별로 조회합니다.")
+                                .summary("카테고리별 히어릿 목록 조회 V1")
+                                .description("특정 카테고리에 속한 히어릿 목록을 `Page` 단위로 조회합니다.")
                                 .queryParameters(
                                         parameterWithName("categoryId").description("조회할 카테고리의 ID"),
                                         parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
                                         parameterWithName("size").description("페이지 당 항목 수 (기본 20)").defaultValue("20")
                                 )
-                                .responseSchema(Schema.schema("PagedHearitSearchResponse"))
-                                .responseFields(
-                                        Stream.concat(
+                                .responseFields(Stream.concat(
                                                 Arrays.stream(new FieldDescriptor[]{
                                                         fieldWithPath("content[].id").description("히어릿 ID"),
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
-                                                        fieldWithPath("content[].lastPlayTime").description(
-                                                                "히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].lastPlayTime").description("히어릿 마지막 재생 시간(ms)").optional(),
                                                         fieldWithPath("content[].keywords[].id").description("키워드 ID"),
                                                         fieldWithPath("content[].keywords[].name").description("키워드 이름")
                                                 }),
@@ -246,41 +209,7 @@ class HearitControllerTest extends IntegrationTest {
                                         ).toArray(FieldDescriptor[]::new)
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(new TypeRef<>() {
-                });
-        List<HearitOfCategoryResponse> responses = pagedResponse.content();
-
-        // then
-        assertAll(
-                () -> assertThat(responses).hasSize(2),
-                () -> assertThat(responses.get(0).id()).isEqualTo(hearit2.getId()), // 최신 hearit 먼저
-                () -> assertThat(responses.get(1).id()).isEqualTo(hearit1.getId())
-        );
-    }
-
-    private String generateToken(Member member) {
-        return jwtTokenProvider.createAccessToken(member.getId());
-    }
-
-    private Hearit saveHearitWithCategoryAndKeyword(Category category, Keyword keyword) {
-        Hearit hearit = new Hearit(
-                "title",
-                "summary",
-                100,
-                "/hearit/audio/original/ORG_test.mp3",
-                "/hearit/audio/short/SHR_test.mp3",
-                "/hearit/script/SCR_test.json",
-                List.of(new Source("출처", "url")),
-                category);
-        Hearit savedHearit = dbHelper.insertHearit(hearit);
-        dbHelper.insertHearitKeyword(new HearitKeyword(savedHearit, keyword));
-        return savedHearit;
+                ));
     }
 
     private FieldDescriptor[] getHearitDetailResponseFields() {

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitControllerTest.java
@@ -11,7 +11,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.dto.response.PagedResponse;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitIntegrationTest.java
@@ -1,0 +1,208 @@
+package com.onair.hearit.hearit.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.common.dto.response.PagedResponse;
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.HearitKeyword;
+import com.onair.hearit.domain.Keyword;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.domain.PlayingHistory;
+import com.onair.hearit.domain.Source;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.hearit.dto.HearitDetailResponse;
+import com.onair.hearit.hearit.dto.HearitOfCategoryResponse;
+import com.onair.hearit.hearit.dto.HearitsWithRecommendCategoryResponse;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+class HearitIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("로그인한 사용자가 히어릿 단일 조회 시, 200 OK 및 히어릿 정보를 제공한다.")
+    void readHearitWithSuccessWithMember() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getId(), hearit, 1_000));
+        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("Java"));
+        Keyword keyword2 = dbHelper.insertKeyword(new Keyword("Spring"));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword1));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword2));
+
+        // when & then
+        HearitDetailResponse response = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/hearits/{hearitId}", hearit.getId())
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(HearitDetailResponse.class);
+
+        assertThat(response.id()).isEqualTo(hearit.getId());
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않은 사용자가 히어릿 단일 조회 시, 200 OK 및 히어릿 정보를 제공한다.")
+    void readHearitWithSuccessWithNotMember() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("Java"));
+        dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword1));
+
+        // when & then
+        HearitDetailResponse response = RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/hearits/{hearitId}", hearit.getId())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(HearitDetailResponse.class);
+
+        assertAll(
+                () -> assertThat(response.id()).isEqualTo(hearit.getId()),
+                () -> assertThat(response.isBookmarked()).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("히어릿 단일 조회 시, 존재하지 않는 아이디인 경우 404 NOT_FOUND를 반환한다.")
+    void readHearitWithNotFound() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Long notFoundHearitId = 9999L;
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/hearits/{hearitId}", notFoundHearitId)
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("카테고리별로 그룹화된 히어릿들을 조회 시, 추천하는 3개의 카테고리와 히어릿들을 반환한다.")
+    void readHomeCategoriesHearit() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+
+        Category category1 = dbHelper.insertCategory(new Category("Java", "#FF0000"));
+        Category category2 = dbHelper.insertCategory(new Category("Spring", "#00FF00"));
+        Category category3 = dbHelper.insertCategory(new Category("React1", "#0000FF"));
+        Category category4 = dbHelper.insertCategory(new Category("React2", "#0000FF"));
+        Category category5 = dbHelper.insertCategory(new Category("React3", "#0000FF"));
+        Category category6 = dbHelper.insertCategory(new Category("React4", "#0000FF"));
+
+        Hearit hearit11 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
+        Hearit hearit12 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
+        Hearit hearit13 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
+        Hearit hearit21 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category2));
+        Hearit hearit22 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category2));
+        Hearit hearit31 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category3));
+
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit11));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit12));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit13));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit21));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit22));
+        dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit31));
+
+        // when
+        List<HearitsWithRecommendCategoryResponse> responses = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/hearits/recommend-category")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList(".", HearitsWithRecommendCategoryResponse.class);
+
+        // then
+        assertAll(() -> {
+            assertThat(responses).hasSize(3);
+            assertThat(responses.get(0).hearits()).hasSize(3);
+            assertThat(responses.get(1).hearits()).hasSize(2);
+            assertThat(responses.get(2).hearits()).hasSize(1);
+            assertThat(responses.get(0).categoryId()).isEqualTo(category1.getId());
+            assertThat(responses.get(1).categoryId()).isEqualTo(category2.getId());
+            assertThat(responses.get(2).categoryId()).isEqualTo(category3.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("카테고리로 히어릿 검색 시 200 OK 및 해당 카테고리의 히어릿들을 최신순으로 반환한다.")
+    void getHearitsByCategoryWithPagination() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category1 = dbHelper.insertCategory(new Category("Spring", "#000001"));
+        Category category2 = dbHelper.insertCategory(new Category("Java", "#000002"));
+
+        Keyword keyword = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Hearit hearit1 = saveHearitWithCategoryAndKeyword(category1, keyword);
+        Hearit hearit2 = saveHearitWithCategoryAndKeyword(category1, keyword);
+        Hearit hearit3 = saveHearitWithCategoryAndKeyword(category2, keyword); // 카테고리 2의 히어릿
+
+        // when
+        PagedResponse<HearitOfCategoryResponse> pagedResponse = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .queryParam("categoryId", category1.getId())
+                .queryParam("page", 0)
+                .queryParam("size", 10)
+                .when()
+                .get("/api/v1/hearits")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<>() {
+                });
+        List<HearitOfCategoryResponse> responses = pagedResponse.content();
+
+        // then
+        assertAll(
+                () -> assertThat(responses).hasSize(2),
+                () -> assertThat(responses.get(0).id()).isEqualTo(hearit2.getId()), // 최신 hearit 먼저
+                () -> assertThat(responses.get(1).id()).isEqualTo(hearit1.getId())
+        );
+    }
+
+    private String generateToken(Member member) {
+        return jwtTokenProvider.createAccessToken(member.getId());
+    }
+
+    private Hearit saveHearitWithCategoryAndKeyword(Category category, Keyword keyword) {
+        Hearit hearit = new Hearit(
+                "title",
+                "summary",
+                100,
+                "/hearit/audio/original/ORG_test.mp3",
+                "/hearit/audio/short/SHR_test.mp3",
+                "/hearit/script/SCR_test.json",
+                List.of(new Source("출처", "url")),
+                category);
+        Hearit savedHearit = dbHelper.insertHearit(hearit);
+        dbHelper.insertHearitKeyword(new HearitKeyword(savedHearit, keyword));
+        return savedHearit;
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchControllerTest.java
@@ -1,85 +1,81 @@
 package com.onair.hearit.hearit.presentation;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.auth.infrastructure.jwt.TokenStatus;
 import com.onair.hearit.common.dto.response.PagedResponse;
 import com.onair.hearit.fixture.ApiDocSnippets;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.domain.Category;
-import com.onair.hearit.domain.Hearit;
-import com.onair.hearit.domain.HearitKeyword;
-import com.onair.hearit.domain.Keyword;
-import com.onair.hearit.domain.Member;
-import com.onair.hearit.domain.Source;
-import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.fixture.ControllerTest;
+import com.onair.hearit.hearit.application.HearitSearchService;
 import com.onair.hearit.hearit.dto.HearitSearchResponse;
-import io.restassured.RestAssured;
-import io.restassured.common.mapper.TypeRef;
+import com.onair.hearit.hearit.dto.HearitSearchResponse.KeywordResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-public class HearitSearchControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = HearitSearchController.class)
+public class HearitSearchControllerTest extends ControllerTest {
 
-    @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    @MockitoBean
+    private HearitSearchService hearitSearchService;
 
     @Test
-    @DisplayName("히어릿 검색 요청 시 200 OK 및 제목 또는 키워드에 검색어가 포함된 히어릿을 최신순으로 반환한다.")
-    void readHearitsByCategoryWithPagination() {
+    @DisplayName("히어릿 검색 V1 - 200 OK")
+    void readSearchedHearitsV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Keyword keyword = dbHelper.insertKeyword(new Keyword("Spring"));
-        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("noKeyword"));
+        var responses = List.of(
+                new HearitSearchResponse(1L, "examplespring1", 300, null, false,
+                        List.of(new KeywordResponse(1L, "spring"), new KeywordResponse(2L, "boot"))),
+                new HearitSearchResponse(2L, "SPRING1example", 200, null, false,
+                        List.of(new KeywordResponse(2L, "noKeyword"))),
+                new HearitSearchResponse(3L, "notitle", 400, null, false,
+                        List.of(new KeywordResponse(1L, "Spring"))));
+        var pagedResponses = PagedResponse.from(new PageImpl<>(responses, PageRequest.of(0, 20), responses.size()));
 
-        Hearit hearit = saveHearitWithTitleAndKeyword("examplespring1", keyword);
-        Hearit hearit1 = saveHearitWithTitleAndKeyword("SPRING1example", keyword1);
-        Hearit hearit2 = saveHearitWithTitleAndKeyword("notitle", keyword);
-        saveHearitWithTitleAndKeyword("notitle", keyword1);
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(hearitSearchService.search(any(), any(), any())).willReturn(pagedResponses);
 
-        // when
-        PagedResponse<HearitSearchResponse> pagedResponse = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .queryParam("searchTerm", "spring")
-                .queryParam("page", 0)
-                .queryParam("size", 10)
-                .filter(document("hearit-search",
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/search")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("searchTerm", "spring")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-hearits-search-ok",
                         resource(ResourceSnippetParameters.builder()
-                                .tag("Hearit API")
-                                .summary("히어릿 검색")
-                                .description("제목 또는 키워드에 검색어가 포함된 히어릿 목록을 페이지별로 조회합니다.")
+                                .tag("Search API")
+                                .summary("히어릿 검색 V1")
+                                .description("제목 또는 키워드에 검색어가 포함된 히어릿 목록을 페이지네이션 방식으로 조회합니다.")
                                 .queryParameters(
                                         parameterWithName("searchTerm").description("검색어"),
                                         parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
-                                        parameterWithName("size").description("페이지 당 항목 수").defaultValue("20")
+                                        parameterWithName("size").description("페이지 당 항목 수 (기본 20)").defaultValue("20")
                                 )
-                                .responseSchema(Schema.schema("PagedHearitSearchResponse"))
                                 .responseFields(
                                         Stream.concat(
                                                 Arrays.stream(new FieldDescriptor[]{
                                                         fieldWithPath("content[].id").description("히어릿 ID"),
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
-                                                        fieldWithPath("content[].lastPlayTime").description(
-                                                                "히어릿 마지막 재생 시간(ms)").optional(),
-                                                        fieldWithPath("content[].isFinished").description(
-                                                                "히어릿을 끝까지 시청했는지 여부").optional(),
-                                                        fieldWithPath("content[].keywords").description(
-                                                                "히어릿에 포함된 키워드 목록"),
+                                                        fieldWithPath("content[].lastPlayTime").description("히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].isFinished").description("히어릿을 끝까지 시청했는지 여부").optional(),
+                                                        fieldWithPath("content[].keywords").description("히어릿에 포함된 키워드 목록"),
                                                         fieldWithPath("content[].keywords[].id").description("키워드 ID"),
                                                         fieldWithPath("content[].keywords[].name").description("키워드 이름")
                                                 }),
@@ -87,80 +83,28 @@ public class HearitSearchControllerTest extends IntegrationTest {
                                         ).toArray(FieldDescriptor[]::new)
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/search")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(new TypeRef<>() {
-                });
-
-        List<HearitSearchResponse> responses = pagedResponse.content();
-
-        // then
-        assertAll(
-                () -> assertThat(responses).hasSize(3),
-                () -> assertThat(responses).extracting(HearitSearchResponse::id)
-                        .containsExactlyInAnyOrder(
-                                hearit.getId(),
-                                hearit1.getId(),
-                                hearit2.getId())
-        );
+                ));
     }
 
     @Test
-    @DisplayName("검색 파라미터가 유효하지 않을 때 400 에러를 반환한다. ")
-    void readHearitsByCategoryWithInvalidParams() {
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
+    @DisplayName("히어릿 검색 V1 - 400 Bad Request")
+    void readHearitsByCategoryWithInvalidParams() throws Exception {
+        // given
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .queryParam("searchTerm", "spring")
-                .queryParam("page", -1)
-                .queryParam("size", 10)
-                .filter(document("hearit-search-bad-request",
+        mockMvc.perform(get("/api/v1/hearits/search")
+                        .header("Authorization", "Bearer valid-token")
+                        .param("searchTerm", "spring")
+                        .param("page", "-1")
+                        .param("size", "10"))
+                .andExpect(status().isBadRequest())
+                .andDo(document("v1-get-hearits-search-bad-request",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
-                                .summary("히어릿 검색")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("히어릿 검색 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/search")
-                .then()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
-
-        RestAssured.given()
-                .header("Authorization", "Bearer " + token)
-                .queryParam("searchTerm", "spring")
-                .queryParam("page", 0)
-                .queryParam("size", -1)
-                .when()
-                .get("/api/v1/hearits/search")
-                .then()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
-    }
-
-    private String generateToken(Member member) {
-        return jwtTokenProvider.createAccessToken(member.getId());
-    }
-
-    private Hearit saveHearitWithTitleAndKeyword(String title, Keyword keyword) {
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit = new Hearit(
-                title,
-                "summary",
-                100,
-                "/hearit/audio/original/ORG_test.mp3",
-                "/hearit/audio/short/SHR_test.mp3",
-                "/hearit/script/SCR_test.json",
-                List.of(new Source("출처", "url")),
-                category);
-        Hearit savedHearit = dbHelper.insertHearit(hearit);
-        dbHelper.insertHearitKeyword(new HearitKeyword(savedHearit, keyword));
-        return savedHearit;
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchControllerTest.java
@@ -101,7 +101,7 @@ public class HearitSearchControllerTest extends ControllerTest {
                 .andExpect(status().isBadRequest())
                 .andDo(document("v1-get-hearits-search-bad-request",
                         resource(ResourceSnippetParameters.builder()
-                                .tag("Hearit API")
+                                .tag("Search API")
                                 .summary("히어릿 검색 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchControllerTest.java
@@ -88,7 +88,7 @@ public class HearitSearchControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("히어릿 검색 V1 - 400 Bad Request")
-    void readHearitsByCategoryWithInvalidParams() throws Exception {
+    void readSearchedHearitsV1_BadRequest() throws Exception {
         // given
         given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
 

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchControllerTest.java
@@ -11,7 +11,7 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.common.dto.response.PagedResponse;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.domain.Category;
 import com.onair.hearit.domain.Hearit;

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchIntegrationTest.java
@@ -1,0 +1,117 @@
+package com.onair.hearit.hearit.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.common.dto.response.PagedResponse;
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.HearitKeyword;
+import com.onair.hearit.domain.Keyword;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.domain.Source;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.hearit.dto.HearitSearchResponse;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+public class HearitSearchIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("히어릿 검색 요청 시 200 OK 및 제목 또는 키워드에 검색어가 포함된 히어릿을 최신순으로 반환한다.")
+    void readHearitsByCategoryWithPagination() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Keyword keyword = dbHelper.insertKeyword(new Keyword("Spring"));
+        Keyword keyword1 = dbHelper.insertKeyword(new Keyword("noKeyword"));
+
+        Hearit hearit = saveHearitWithTitleAndKeyword("examplespring1", keyword);
+        Hearit hearit1 = saveHearitWithTitleAndKeyword("SPRING1example", keyword1);
+        Hearit hearit2 = saveHearitWithTitleAndKeyword("notitle", keyword);
+        saveHearitWithTitleAndKeyword("notitle", keyword1);
+
+        // when
+        PagedResponse<HearitSearchResponse> pagedResponse = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .queryParam("searchTerm", "spring")
+                .queryParam("page", 0)
+                .queryParam("size", 10)
+                .when()
+                .get("/api/v1/hearits/search")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<>() {
+                });
+
+        List<HearitSearchResponse> responses = pagedResponse.content();
+
+        // then
+        assertAll(
+                () -> assertThat(responses).hasSize(3),
+                () -> assertThat(responses).extracting(HearitSearchResponse::id)
+                        .containsExactlyInAnyOrder(
+                                hearit.getId(),
+                                hearit1.getId(),
+                                hearit2.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("검색 파라미터가 유효하지 않을 때 400 에러를 반환한다. ")
+    void readHearitsByCategoryWithInvalidParams() {
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .queryParam("searchTerm", "spring")
+                .queryParam("page", -1)
+                .queryParam("size", 10)
+                .when()
+                .get("/api/v1/hearits/search")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+
+        RestAssured.given()
+                .header("Authorization", "Bearer " + token)
+                .queryParam("searchTerm", "spring")
+                .queryParam("page", 0)
+                .queryParam("size", -1)
+                .when()
+                .get("/api/v1/hearits/search")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    private String generateToken(Member member) {
+        return jwtTokenProvider.createAccessToken(member.getId());
+    }
+
+    private Hearit saveHearitWithTitleAndKeyword(String title, Keyword keyword) {
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        Hearit hearit = new Hearit(
+                title,
+                "summary",
+                100,
+                "/hearit/audio/original/ORG_test.mp3",
+                "/hearit/audio/short/SHR_test.mp3",
+                "/hearit/script/SCR_test.json",
+                List.of(new Source("출처", "url")),
+                category);
+        Hearit savedHearit = dbHelper.insertHearit(hearit);
+        dbHelper.insertHearitKeyword(new HearitKeyword(savedHearit, keyword));
+        return savedHearit;
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/hearit/presentation/HearitSearchIntegrationTest.java
@@ -84,7 +84,7 @@ public class HearitSearchIntegrationTest extends IntegrationTest {
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
 
-        RestAssured.given()
+        RestAssured.given(this.spec)
                 .header("Authorization", "Bearer " + token)
                 .queryParam("searchTerm", "spring")
                 .queryParam("page", 0)

--- a/backend/app/src/test/java/com/onair/hearit/keyword/presentation/KeywordControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/keyword/presentation/KeywordControllerTest.java
@@ -1,128 +1,109 @@
 package com.onair.hearit.keyword.presentation;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
+import com.onair.hearit.exception.custom.NotFoundException;
 import com.onair.hearit.fixture.ApiDocSnippets;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.domain.Keyword;
-import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.fixture.ControllerTest;
+import com.onair.hearit.keyword.application.KeywordService;
 import com.onair.hearit.keyword.dto.KeywordResponse;
-import io.restassured.RestAssured;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class KeywordControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = KeywordController.class)
+class KeywordControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private KeywordService keywordService;
 
     @Test
-    @DisplayName("전체 키워드를 조회 시 200 OK 및 페이징이 적용된 키워드 목록을 반환한다.")
-    void readAllKeywords() {
+    @DisplayName("키워드 조회 V1 - 200 OK")
+    void readKeywordsV1_OK() throws Exception {
         // given
-        Keyword keyword1 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
-        Keyword keyword2 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
-        Keyword keyword3 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
-        Keyword keyword4 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
-        Keyword keyword5 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        var responses = List.of(
+                new KeywordResponse(1L, "Spring"),
+                new KeywordResponse(2L, "Java")
+        );
 
-        // when
-        List<KeywordResponse> result = RestAssured.given(this.spec)
-                .param("page", 1)
-                .param("size", 2)
-                .filter(document("keyword-read-all",
+        given(keywordService.getKeywords(any())).willReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/keywords")
+                        .param("page", "0")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-keywords-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Keyword API")
-                                .summary("전체 키워드 목록 조회")
-                                .description("전체 키워드 목록을 페이지별로 조회합니다.")
+                                .summary("전체 키워드 목록 조회 V1")
+                                .description("전체 키워드 목록을 `Page` 단위로 조회합니다.")
                                 .queryParameters(
                                         parameterWithName("page").description("페이지 번호 (0부터 시작)").defaultValue("0"),
                                         parameterWithName("size").description("페이지 당 항목 수 (기본 20)").defaultValue("20")
                                 )
-                                .responseSchema(Schema.schema("KeywordResponseList"))
                                 .responseFields(
                                         fieldWithPath("[].id").description("키워드 ID"),
                                         fieldWithPath("[].name").description("키워드 이름")
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/keywords")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .jsonPath()
-                .getList(".", KeywordResponse.class);
-
-        // then
-        assertAll(
-                () -> assertThat(result).hasSize(2),
-                () -> assertThat(result).extracting(KeywordResponse::id)
-                        .containsExactly(keyword3.getId(), keyword4.getId())
-        );
+                ));
     }
 
-
     @Test
-    @DisplayName("단일 키워드 조회 시 200 OK 및 해당 키워드 정보를 반환한다.")
-    void readSingleKeyword() {
+    @DisplayName("단일 키워드 조회 V1 - 200 OK")
+    void readKeywordV1_OK() throws Exception {
         // given
-        Keyword keyword = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        var response = new KeywordResponse(1L, "Spring");
 
-        // when
-        KeywordResponse result = RestAssured.given(this.spec)
-                .filter(document("keyword-read-single",
+        given(keywordService.getKeyword(any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/keywords/{keywordId}", response.id()))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-keyword-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Keyword API")
-                                .summary("단일 키워드 조회")
-                                .description("ID로 특정 키워드의 정보를 조회합니다.")
+                                .summary("단일 키워드 조회 V1")
+                                .description("단일 키워드의 정보를 조회합니다.")
                                 .pathParameters(
                                         parameterWithName("keywordId").description("조회할 키워드의 ID")
                                 )
-                                .responseSchema(Schema.schema("KeywordResponse"))
                                 .responseFields(
                                         fieldWithPath("id").description("키워드 ID"),
                                         fieldWithPath("name").description("키워드 이름")
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/keywords/{keywordId}", keyword.getId())
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .as(KeywordResponse.class);
-
-        // then
-        assertAll(
-                () -> assertThat(result.id()).isEqualTo(keyword.getId()),
-                () -> assertThat(result.name()).isEqualTo(keyword.getName())
-        );
-
+                ));
     }
 
     @Test
-    @DisplayName("존재하지 않는 키워드를 조회 시 404 NOT_FOUND를 반환한다.")
-    void readNotFoundKeyword() {
+    @DisplayName("단일 키워드 조회 V1 - 404 Not Found")
+    void readNotFoundKeyword() throws Exception {
+        // given
+        var notFoundKeywordId = 9999L;
+
+        given(keywordService.getKeyword(any())).willThrow(new NotFoundException("keywordId", "9999"));
+
         // when & then
-        RestAssured.given(this.spec)
-                .filter(document("keyword-read-single-not-found",
+        mockMvc.perform(get("/api/v1/keywords/{keywordId}", notFoundKeywordId))
+                .andExpect(status().isNotFound())
+                .andDo(document("v1-get-keywords-not-found",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Keyword API")
-                                .summary("단일 키워드 조회")
-                                .responseSchema(Schema.schema("ProblemDetail"))
+                                .summary("단일 키워드 조회 V1")
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/keywords/{keywordId}", 9999L)
-                .then()
-                .statusCode(HttpStatus.NOT_FOUND.value());
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/keyword/presentation/KeywordControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/keyword/presentation/KeywordControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.domain.Keyword;
 import com.onair.hearit.fixture.IntegrationTest;

--- a/backend/app/src/test/java/com/onair/hearit/keyword/presentation/KeywordIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/keyword/presentation/KeywordIntegrationTest.java
@@ -1,0 +1,82 @@
+package com.onair.hearit.keyword.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Keyword;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.keyword.dto.KeywordResponse;
+import io.restassured.RestAssured;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class KeywordIntegrationTest extends IntegrationTest {
+
+    @Test
+    @DisplayName("전체 키워드를 조회 시 200 OK 및 페이징이 적용된 키워드 목록을 반환한다.")
+    void readAllKeywords() {
+        // given
+        Keyword keyword1 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword2 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword3 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword4 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+        Keyword keyword5 = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+
+        // when
+        List<KeywordResponse> result = RestAssured.given(this.spec)
+                .param("page", 1)
+                .param("size", 2)
+                .when()
+                .get("/api/v1/keywords")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList(".", KeywordResponse.class);
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(2),
+                () -> assertThat(result).extracting(KeywordResponse::id)
+                        .containsExactly(keyword3.getId(), keyword4.getId())
+        );
+    }
+
+
+    @Test
+    @DisplayName("단일 키워드 조회 시 200 OK 및 해당 키워드 정보를 반환한다.")
+    void readSingleKeyword() {
+        // given
+        Keyword keyword = dbHelper.insertKeyword(TestFixture.createFixedKeyword());
+
+        // when
+        KeywordResponse result = RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/keywords/{keywordId}", keyword.getId())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(KeywordResponse.class);
+
+        // then
+        assertAll(
+                () -> assertThat(result.id()).isEqualTo(keyword.getId()),
+                () -> assertThat(result.name()).isEqualTo(keyword.getName())
+        );
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 키워드를 조회 시 404 NOT_FOUND를 반환한다.")
+    void readNotFoundKeyword() {
+        // when & then
+        RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/keywords/{keywordId}", 9999L)
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/member/presentation/MemberControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/member/presentation/MemberControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
-import com.onair.hearit.core.docs.ApiDocSnippets;
+import com.onair.hearit.fixture.ApiDocSnippets;
 import com.onair.hearit.domain.Member;
 import com.onair.hearit.domain.OAuthProvider;
 import com.onair.hearit.fixture.IntegrationTest;

--- a/backend/app/src/test/java/com/onair/hearit/member/presentation/MemberControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/member/presentation/MemberControllerTest.java
@@ -1,93 +1,76 @@
 package com.onair.hearit.member.presentation;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.auth.infrastructure.jwt.TokenStatus;
 import com.onair.hearit.fixture.ApiDocSnippets;
-import com.onair.hearit.domain.Member;
-import com.onair.hearit.domain.OAuthProvider;
-import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.fixture.ControllerTest;
+import com.onair.hearit.member.application.MemberService;
 import com.onair.hearit.member.dto.MemberInfoResponse;
-import io.restassured.RestAssured;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class MemberControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest extends ControllerTest {
 
-    @Autowired
-    JwtTokenProvider jwtTokenProvider;
+    @MockitoBean
+    private MemberService memberService;
 
     @Test
-    @DisplayName("로그인한 사용자가 사용자 정보 조회 시, 200 OK 및 사용지 정보를 제공한다.")
-    void getMemberInfo_success() {
+    @DisplayName("사용자 정보 조회 V1 - 200 OK")
+    void getMemberInfoV1_OK() throws Exception {
         // given
-        String socialId = "12345678";
-        String nickname = "nickname";
-        String profileImage = "profile-image.jpg";
-        Member member = dbHelper.insertMember(
-                Member.createSocialUser(UUID.randomUUID().toString(), socialId, nickname, profileImage,
-                        OAuthProvider.KAKAO));
+        var response = new MemberInfoResponse(
+                1L,
+                "nickname",
+                "profile-image.jpg"
+        );
 
-        String token = generateToken(member);
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(memberService.getMember(any())).willReturn(response);
 
         // when & then
-        MemberInfoResponse response = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .filter(document("member-read-me",
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-members-me-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Member API")
-                                .summary("내 정보 조회")
+                                .summary("사용자 정보 조회 V1")
                                 .description("현재 로그인한 사용자의 정보를 조회합니다.")
-                                .responseSchema(Schema.schema("MemberInfoResponse"))
                                 .responseFields(
                                         fieldWithPath("id").description("사용자 ID"),
                                         fieldWithPath("nickname").description("닉네임"),
                                         fieldWithPath("profileImage").description("프로필 이미지 URL")
                                 )
-                                .build()))
-                )
-                .when()
-                .get("/api/v1/members/me")
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(MemberInfoResponse.class);
-
-        assertAll(() -> {
-            assertThat(response.id()).isEqualTo(member.getId());
-            assertThat(response.nickname()).isEqualTo(member.getNickname());
-            assertThat(response.profileImage()).isEqualTo(member.getProfileImage());
-        });
+                                .build())
+                ));
     }
 
     @Test
-    @DisplayName("로그인하지 않은 사용자가 사용자 정보 조회 시, 401 Unauthorized 예외를 반환한다.")
-    void getMemberInfo_error_when_isNotLoginedMember() {
-        RestAssured.given(this.spec)
-                .filter(document("member-read-me-unauthorized",
+    @DisplayName("사용자 정보 조회 V1 - 401 Unauthorized")
+    void getMemberInfoV1_Unauthorized() throws Exception {
+        // given
+        given(jwtTokenProvider.getTokenStatus(isNull())).willReturn(TokenStatus.NOT_EXIST);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/members/me"))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("v1-get-members-me-unauthorized",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Member API")
-                                .summary("내 정보 조회")
-                                .description("현재 로그인한 사용자의 정보를 조회합니다.")
-                                .responseSchema(Schema.schema("ProblemDetail"))
                                 .responseFields(ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
-                                .build()))
-                )
-                .when()
-                .get("/api/v1/members/me")
-                .then()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
-    }
-
-    private String generateToken(Member member) {
-        return jwtTokenProvider.createAccessToken(member.getId());
+                                .build())
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/member/presentation/MemberIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/member/presentation/MemberIntegrationTest.java
@@ -21,7 +21,7 @@ class MemberIntegrationTest extends IntegrationTest {
     JwtTokenProvider jwtTokenProvider;
 
     @Test
-    @DisplayName("로그인한 사용자가 사용자 정보 조회 시, 200 OK 및 사용지 정보를 제공한다.")
+    @DisplayName("로그인한 사용자가 사용자 정보 조회 시, 200 OK 및 사용자 정보를 제공한다.")
     void getMemberInfo_success() {
         // given
         String socialId = "12345678";

--- a/backend/app/src/test/java/com/onair/hearit/member/presentation/MemberIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/member/presentation/MemberIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.onair.hearit.member.presentation;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.domain.OAuthProvider;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.member.dto.MemberInfoResponse;
+import io.restassured.RestAssured;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+class MemberIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("로그인한 사용자가 사용자 정보 조회 시, 200 OK 및 사용지 정보를 제공한다.")
+    void getMemberInfo_success() {
+        // given
+        String socialId = "12345678";
+        String nickname = "nickname";
+        String profileImage = "profile-image.jpg";
+        Member member = dbHelper.insertMember(
+                Member.createSocialUser(UUID.randomUUID().toString(), socialId, nickname, profileImage,
+                        OAuthProvider.KAKAO));
+
+        String token = generateToken(member);
+
+        // when & then
+        MemberInfoResponse response = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get("/api/v1/members/me")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(MemberInfoResponse.class);
+
+        assertAll(() -> {
+            assertThat(response.id()).isEqualTo(member.getId());
+            assertThat(response.nickname()).isEqualTo(member.getNickname());
+            assertThat(response.profileImage()).isEqualTo(member.getProfileImage());
+        });
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 사용자 정보 조회 시, 401 Unauthorized 예외를 반환한다.")
+    void getMemberInfo_error_when_isNotLoginedMember() {
+        RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/members/me")
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    private String generateToken(Member member) {
+        return jwtTokenProvider.createAccessToken(member.getId());
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/playinghistory/presentation/PlayingHistoryControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/playinghistory/presentation/PlayingHistoryControllerTest.java
@@ -1,223 +1,149 @@
 package com.onair.hearit.playinghistory.presentation;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.domain.Category;
-import com.onair.hearit.domain.Hearit;
-import com.onair.hearit.domain.Member;
-import com.onair.hearit.domain.PlayingHistory;
-import com.onair.hearit.domain.Source;
-import com.onair.hearit.fixture.IntegrationTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onair.hearit.auth.infrastructure.jwt.TokenStatus;
+import com.onair.hearit.fixture.ControllerTest;
+import com.onair.hearit.playinghistory.application.PlayingHistoryService;
 import com.onair.hearit.playinghistory.dto.PlayingHistoryRequest;
 import com.onair.hearit.playinghistory.dto.RecentlyPlayedHearitResponse;
-import io.restassured.RestAssured;
-import io.restassured.common.mapper.TypeRef;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class PlayingHistoryControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = PlayingHistoryController.class)
+class PlayingHistoryControllerTest extends ControllerTest {
 
     @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PlayingHistoryService playingHistoryService;
 
     @Test
-    @DisplayName("로그인한 사용자는 최근 재생 기록 최대 10개와 200 OK를 반환한다.")
-    void getRecentPlayingHistories_whenMember() {
+    @DisplayName("최근 재생 기록 조회 V1 - 로그인 사용자 200 OK")
+    void getRecentPlayingHistoriesWhenMemberV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        var responses = List.of(
+                new RecentlyPlayedHearitResponse(1L, "title1", 120, 30L, null,
+                        new RecentlyPlayedHearitResponse.CategoryResponse(1L, "카테고리1", "#000000")),
+                new RecentlyPlayedHearitResponse(2L, "title2", 150, 60L, null,
+                        new RecentlyPlayedHearitResponse.CategoryResponse(2L, "카테고리2", "#111111"))
+        );
 
-        for (int i = 0; i < 12; i++) {
-            Hearit hearit = dbHelper.insertHearit(createHearitWith(100 + i, category));
-            dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L * i));
-        }
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(playingHistoryService.getRecentPlayingHistory(any())).willReturn(responses);
 
         // when & then
-        List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .contentType("application/json")
-                .filter(document("playing-history-read-member",
+        mockMvc.perform(get("/api/v1/playing-histories/hearits")
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-playing-histories-member-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
-                                .summary("최근 재생 기록 조회")
-                                .description("로그인한 사용자는 최근 재생 기록을 최대 10개까지 조회할 수 있습니다.\n\n"
-                                             + "로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
+                                .summary("최근 재생 기록 조회 V1")
+                                .description("로그인한 사용자는 최근 재생 기록을 최대 10개까지 조회합니다.")
                                 .responseFields(
                                         fieldWithPath("[].id").description("히어릿 ID"),
                                         fieldWithPath("[].title").description("히어릿 제목"),
                                         fieldWithPath("[].playTime").description("히어릿 전체 재생 시간(s)"),
                                         fieldWithPath("[].lastPlayTime").description("사용자가 마지막으로 재생한 시간(ms)"),
-                                        fieldWithPath("[].createdAt").description("히어릿 생성일"),
+                                        fieldWithPath("[].createdAt").description("히어릿 생성일").optional(),
                                         fieldWithPath("[].category.id").description("카테고리 ID"),
                                         fieldWithPath("[].category.name").description("카테고리 이름"),
                                         fieldWithPath("[].category.colorCode").description("카테고리 색상 코드")
-                                ).build())
-                ))
-                .when()
-                .get("/api/v1/playing-histories/hearits")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(new TypeRef<>() {
-                });
-
-        assertThat(response).hasSize(10);
+                                )
+                                .build())
+                ));
     }
 
     @Test
-    @DisplayName("로그인하지 않은 사용자는 최근 재생 기록 조회 시 빈 리스트와 200 OK를 반환한다.")
-    void getRecentPlayingHistories_whenGuest() {
+    @DisplayName("최근 재생 기록 조회 V1 - 게스트 사용자 200 OK 빈 리스트")
+    void getRecentPlayingHistoriesWhenGuestV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        for (int i = 0; i < 2; i++) {
-            Hearit hearit = dbHelper.insertHearit(createHearitWith(100 + i, category));
-            dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L * i));
-        }
+        given(playingHistoryService.getRecentPlayingHistory(any())).willReturn(List.of());
 
         // when & then
-        List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
-                .contentType("application/json")
-                .filter(document("playing-history-read-guest",
+        mockMvc.perform(get("/api/v1/playing-histories/hearits"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-playing-histories-guest-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
-                                .summary("최근 재생 기록 조회")
-                                .description("로그인한 사용자는 최근 재생 기록을 최대 10개까지 조회할 수 있습니다.\n\n"
-                                             + "로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
+                                .summary("최근 재생 기록 조회 V1")
+                                .description("로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
                                 .responseFields(
                                         fieldWithPath("[]").description("빈 리스트")
-                                ).build())
-                ))
-                .when()
-                .get("/api/v1/playing-histories/hearits")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(new TypeRef<>() {
-                });
-
-        assertThat(response).hasSize(0);
+                                )
+                                .build())
+                ));
     }
 
     @Test
-    @DisplayName("로그인한 사용자가 처음 재생기록 저장 시, 200 OK를 반환한다.")
-    void createPlayingHistory() {
+    @DisplayName("재생기록 생성/수정 V1 - 사용자 200 OK")
+    void createPlayingHistoryWhenMemberV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+        var request = new PlayingHistoryRequest(1L, 100L);
 
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        willDoNothing().given(playingHistoryService).addPlayingHistory(any(), any());
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .contentType("application/json")
-                .body(request)
-                .filter(document("playing-history-createad",
+        mockMvc.perform(post("/api/v1/playing-histories")
+                        .header("Authorization", "Bearer valid-token")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("v1-post-playing-history-member-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
-                                .summary("재생기록 생성 또는 수정")
+                                .summary("재생기록 생성/수정 V1")
                                 .description("사용자의 재생 기록을 생성하거나 업데이트합니다.")
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
                                 )
                                 .build())
-                ))
-                .when()
-                .post("/api/v1/playing-histories")
-                .then()
-                .statusCode(HttpStatus.OK.value());
+                ));
     }
 
     @Test
-    @DisplayName("로그인한 사용자가 다시 재생기록 저장 시, 200 OK를 반환한다.")
-    void updatePlayingHistory() {
+    @DisplayName("재생기록 생성/수정 V1 - 게스트 200 OK")
+    void createPlayingHistoryWhenGuestV1_OK() throws Exception {
         // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), hearit, 20_000));
+        var request = new PlayingHistoryRequest(1L, 100L);
 
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
+        given(jwtTokenProvider.getTokenStatus(isNull())).willReturn(TokenStatus.NOT_EXIST);
+        willDoNothing().given(playingHistoryService).addPlayingHistory(any(), any());
 
         // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .contentType("application/json")
-                .body(request)
-                .filter(document("playing-history-ok",
+        mockMvc.perform(post("/api/v1/playing-histories")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("v1-post-playing-history-guest-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
-                                .summary("재생기록 생성 또는 저장")
-                                .description("사용자의 재생 기록을 생성하거나 업데이트합니다.")
+                                .summary("재생기록 생성/수정 V1")
+                                .description("로그인하지 않은 사용자는 재생 기록을 저장하지 않습니다.")
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
                                 )
                                 .build())
-                ))
-                .when()
-                .post("/api/v1/playing-histories")
-                .then()
-                .statusCode(HttpStatus.OK.value());
-    }
-
-    @Test
-    @DisplayName("로그인하지 않은 사용자는 재생기록 저장를 저장하지 않고, 200 OK를 반환한다.")
-    void createBookmarkTestWithConflict() {
-        // given
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
-
-        // when & then
-        RestAssured.given(this.spec)
-                .contentType("application/json")
-                .body(request)
-                .filter(document("playing-history-unauthorized",
-                        resource(ResourceSnippetParameters.builder()
-                                .tag("Playing History API")
-                                .summary("재생기록 생성 또는 저장")
-                                .description("사용자의 재생 기록을 생성하거나 업데이트합니다.")
-                                .requestFields(
-                                        fieldWithPath("hearitId").description("히어릿 ID"),
-                                        fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")
-                                )
-                                .build())
-                ))
-                .when()
-                .post("/api/v1/playing-histories")
-                .then()
-                .statusCode(HttpStatus.OK.value());
-    }
-
-    private Hearit createHearitWith(int playTime, Category category) {
-        return new Hearit("title",
-                "summary",
-                playTime,
-                "/hearit/audio/original/ORG_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
-                "/hearit/audio/short/SHR_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
-                "/hearit/script/SCR_bf7c513e-579e-4224-8505-3824bb22ed01.json",
-                List.of(new Source("원본은 CC BY 4.0 라이선스를 따릅니다.", "https://example.com/2")),
-                category
-        );
-    }
-
-    private String generateToken(Member member) {
-        return jwtTokenProvider.createAccessToken(member.getId());
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/playinghistory/presentation/PlayingHistoryControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/playinghistory/presentation/PlayingHistoryControllerTest.java
@@ -75,6 +75,7 @@ class PlayingHistoryControllerTest extends ControllerTest {
     @DisplayName("최근 재생 기록 조회 V1 - 게스트 사용자 200 OK 빈 리스트")
     void getRecentPlayingHistoriesWhenGuestV1_OK() throws Exception {
         // given
+        given(jwtTokenProvider.getTokenStatus(isNull())).willReturn(TokenStatus.NOT_EXIST);
         given(playingHistoryService.getRecentPlayingHistory(any())).willReturn(List.of());
 
         // when & then

--- a/backend/app/src/test/java/com/onair/hearit/playinghistory/presentation/PlayingHistoryIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/playinghistory/presentation/PlayingHistoryIntegrationTest.java
@@ -1,0 +1,159 @@
+package com.onair.hearit.playinghistory.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.onair.hearit.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.Member;
+import com.onair.hearit.domain.PlayingHistory;
+import com.onair.hearit.domain.Source;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.playinghistory.dto.PlayingHistoryRequest;
+import com.onair.hearit.playinghistory.dto.RecentlyPlayedHearitResponse;
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+class PlayingHistoryIntegrationTest extends IntegrationTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    @DisplayName("로그인한 사용자는 최근 재생 기록 최대 10개와 200 OK를 반환한다.")
+    void getRecentPlayingHistories_whenMember() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+
+        for (int i = 0; i < 12; i++) {
+            Hearit hearit = dbHelper.insertHearit(createHearitWith(100 + i, category));
+            dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L * i));
+        }
+
+        // when & then
+        List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .when()
+                .get("/api/v1/playing-histories/hearits")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(new TypeRef<>() {
+                });
+
+        assertThat(response).hasSize(10);
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 최근 재생 기록 조회 시 빈 리스트와 200 OK를 반환한다.")
+    void getRecentPlayingHistories_whenGuest() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        for (int i = 0; i < 2; i++) {
+            Hearit hearit = dbHelper.insertHearit(createHearitWith(100 + i, category));
+            dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L * i));
+        }
+
+        // when & then
+        List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
+                .contentType("application/json")
+                .when()
+                .get("/api/v1/playing-histories/hearits")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract().as(new TypeRef<>() {
+                });
+
+        assertThat(response).hasSize(0);
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 처음 재생기록 저장 시, 200 OK를 반환한다.")
+    void createPlayingHistory() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("로그인한 사용자가 다시 재생기록 저장 시, 200 OK를 반환한다.")
+    void updatePlayingHistory() {
+        // given
+        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+        String token = generateToken(member);
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getId(), hearit, 20_000));
+
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
+
+        // when & then
+        RestAssured.given(this.spec)
+                .header("Authorization", "Bearer " + token)
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자는 재생기록 저장를 저장하지 않고, 200 OK를 반환한다.")
+    void createBookmarkTestWithConflict() {
+        // given
+        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+
+        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+
+        // when & then
+        RestAssured.given(this.spec)
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/v1/playing-histories")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    private Hearit createHearitWith(int playTime, Category category) {
+        return new Hearit("title",
+                "summary",
+                playTime,
+                "/hearit/audio/original/ORG_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/audio/short/SHR_bf7c513e-579e-4224-8505-3824bb22ed01.mp3",
+                "/hearit/script/SCR_bf7c513e-579e-4224-8505-3824bb22ed01.json",
+                List.of(new Source("원본은 CC BY 4.0 라이선스를 따릅니다.", "https://example.com/2")),
+                category
+        );
+    }
+
+    private String generateToken(Member member) {
+        return jwtTokenProvider.createAccessToken(member.getId());
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/recommendhearit/presentation/RecommendHearitControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/recommendhearit/presentation/RecommendHearitControllerTest.java
@@ -1,47 +1,51 @@
 package com.onair.hearit.recommendhearit.presentation;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
-import com.epages.restdocs.apispec.Schema;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.domain.Category;
-import com.onair.hearit.domain.Hearit;
-import com.onair.hearit.domain.RecommendHearit;
-import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.fixture.ControllerTest;
+import com.onair.hearit.recommendhearit.application.RecommendHearitService;
 import com.onair.hearit.recommendhearit.dto.RecommendHearitResponse;
-import io.restassured.RestAssured;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class RecommendHearitControllerTest extends IntegrationTest {
+@WebMvcTest(controllers = RecommendHearitController.class)
+class RecommendHearitControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private RecommendHearitService recommendHearitService;
 
     @Test
-    @DisplayName("오늘의 추천 히어릿을 조회 시, 200 OK 및 5개 히어릿 정보 목록을 제공한다.")
-    void readRecommendedHearits() {
+    @DisplayName("오늘의 추천 히어릿 목록 조회 V1 - 200 OK")
+    void readRecommendedHearitsV1_OK() throws Exception {
         // given
-        LocalDate today = LocalDate.now();
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        for (int i = 0; i < 5; i++) {
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-            dbHelper.insertRecommendHearit(new RecommendHearit(hearit, today));
-        }
+        var responses = List.of(
+                new RecommendHearitResponse(1L, "히어릿1", 120, LocalDateTime.now(), "카테고리1", "#000001"),
+                new RecommendHearitResponse(2L, "히어릿2", 150, LocalDateTime.now(), "카테고리2", "#000002"),
+                new RecommendHearitResponse(3L, "히어릿3", 200, LocalDateTime.now(), "카테고리3", "#000003"),
+                new RecommendHearitResponse(4L, "히어릿4", 180, LocalDateTime.now(), "카테고리4", "#000004"),
+                new RecommendHearitResponse(5L, "히어릿5", 210, LocalDateTime.now(), "카테고리5", "#000005")
+        );
 
-        // when
-        List<RecommendHearitResponse> responses = RestAssured.given(this.spec)
-                .filter(document("hearit-read-recommend",
+        given(recommendHearitService.getRecommendedHearits()).willReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/recommend"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-hearits-recommend-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
-                                .summary("추천 히어릿 목록 조회")
+                                .summary("오늘의 추천 히어릿 목록 조회 V1")
                                 .description("추천 히어릿 목록을 최대 5개까지 조회합니다.")
-                                .responseSchema(Schema.schema("RecommendHearitResponseList"))
                                 .responseFields(
                                         fieldWithPath("[].id").description("히어릿 ID"),
                                         fieldWithPath("[].title").description("히어릿 제목"),
@@ -51,16 +55,6 @@ class RecommendHearitControllerTest extends IntegrationTest {
                                         fieldWithPath("[].categoryColor").description("카테고리 색상 코드")
                                 )
                                 .build())
-                ))
-                .when()
-                .get("/api/v1/hearits/recommend")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract()
-                .jsonPath()
-                .getList(".", RecommendHearitResponse.class);
-
-        // then
-        assertThat(responses).hasSize(5);
+                ));
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/recommendhearit/presentation/RecommendHearitControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/recommendhearit/presentation/RecommendHearitControllerTest.java
@@ -28,12 +28,13 @@ class RecommendHearitControllerTest extends ControllerTest {
     @DisplayName("오늘의 추천 히어릿 목록 조회 V1 - 200 OK")
     void readRecommendedHearitsV1_OK() throws Exception {
         // given
+        var now = LocalDateTime.of(2025, 9, 30, 10, 0);
         var responses = List.of(
-                new RecommendHearitResponse(1L, "히어릿1", 120, LocalDateTime.now(), "카테고리1", "#000001"),
-                new RecommendHearitResponse(2L, "히어릿2", 150, LocalDateTime.now(), "카테고리2", "#000002"),
-                new RecommendHearitResponse(3L, "히어릿3", 200, LocalDateTime.now(), "카테고리3", "#000003"),
-                new RecommendHearitResponse(4L, "히어릿4", 180, LocalDateTime.now(), "카테고리4", "#000004"),
-                new RecommendHearitResponse(5L, "히어릿5", 210, LocalDateTime.now(), "카테고리5", "#000005")
+                new RecommendHearitResponse(1L, "히어릿1", 120, now, "카테고리1", "#000001"),
+                new RecommendHearitResponse(2L, "히어릿2", 150, now, "카테고리2", "#000002"),
+                new RecommendHearitResponse(3L, "히어릿3", 200, now, "카테고리3", "#000003"),
+                new RecommendHearitResponse(4L, "히어릿4", 180, now, "카테고리4", "#000004"),
+                new RecommendHearitResponse(5L, "히어릿5", 210, now, "카테고리5", "#000005")
         );
 
         given(recommendHearitService.getRecommendedHearits()).willReturn(responses);

--- a/backend/app/src/test/java/com/onair/hearit/recommendhearit/presentation/RecommendHearitIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/recommendhearit/presentation/RecommendHearitIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.onair.hearit.recommendhearit.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.domain.Category;
+import com.onair.hearit.domain.Hearit;
+import com.onair.hearit.domain.RecommendHearit;
+import com.onair.hearit.fixture.IntegrationTest;
+import com.onair.hearit.recommendhearit.dto.RecommendHearitResponse;
+import io.restassured.RestAssured;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+class RecommendHearitIntegrationTest extends IntegrationTest {
+
+    @Test
+    @DisplayName("오늘의 추천 히어릿을 조회 시, 200 OK 및 5개 히어릿 정보 목록을 제공한다.")
+    void readRecommendedHearits() {
+        // given
+        LocalDate today = LocalDate.now();
+        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+        for (int i = 0; i < 5; i++) {
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            dbHelper.insertRecommendHearit(new RecommendHearit(hearit, today));
+        }
+
+        // when
+        List<RecommendHearitResponse> responses = RestAssured.given(this.spec)
+                .when()
+                .get("/api/v1/hearits/recommend")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .jsonPath()
+                .getList(".", RecommendHearitResponse.class);
+
+        // then
+        assertThat(responses).hasSize(5);
+    }
+}

--- a/backend/core/src/testFixtures/java/com/onair/hearit/core/fixture/ApiTest.java
+++ b/backend/core/src/testFixtures/java/com/onair/hearit/core/fixture/ApiTest.java
@@ -1,18 +1,12 @@
 package com.onair.hearit.core.fixture;
 
-import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
-
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.RestDocumentationExtension;
 
-@ExtendWith(RestDocumentationExtension.class)
 public abstract class ApiTest {
 
     @LocalServerPort
@@ -21,11 +15,10 @@ public abstract class ApiTest {
     protected RequestSpecification spec;
 
     @BeforeEach
-    void setUp(RestDocumentationContextProvider provider) {
+    void setUp() {
         RestAssured.port = port;
         this.spec = new RequestSpecBuilder()
                 .addHeader("X-Device-UUID", UUID.randomUUID().toString())
-                .addFilter(documentationConfiguration(provider))
                 .build();
     }
 }


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

문서화 할 api가 많아지고 예외 상황이 많아지면서 테스트 코드가 많아짐에 따라,
테스트를 작성하기 불편하다는 의견이 빈번하게 나왔습니다.
따라서 이번 테스트 리팩터링을 통해 `presentation` 계층 테스트가 다음과 같이 나뉩니다.

1. XXXIntegrationTest: 실제 테스트 하고자 하는 E2E 테스트
2. XXXControllerTest: First API Design을 위한 Service 계층을 모킹한 Controller 단위 테스트

## 📸 스크린샷 (선택)

<img width="1443" height="663" alt="스크린샷 2025-09-30 02 09 51" src="https://github.com/user-attachments/assets/4144a386-8619-4890-8078-ed70ff16a216" />

## 🧪 테스트 방법 (선택)

app 모듈의 presentation 계층 테스트가 모두 2개로 분리된 것을 확인할 수 있습니다. 
또한 다음 명령어로 실제 API 문서를 볼 수 있습니다.

```
./gradlew :boot:clean :boot:build
 java -jar boot/build/libs/boot-1.2.2.jar
```
확인 URL: http://localhost:8080/swagger-ui/index.html

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #598 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 문서화
  - REST Docs 설정 및 응답 필드 정리(ProblemDetail, code, reissuable 등) 업데이트
- 테스트
  - 다수 컨트롤러 테스트를 MockMvc(@WebMvcTest) 기반으로 전환 및 공통 ControllerTest 도입
  - 여러 통합 테스트 클래스 추가/보강(인증, 북마크, 카테고리, 탐색, 히어릿, 검색, 재생기록, 추천 등)
- 잡무(Chores)
  - 테스트용 REST Docs 의존성 MockMvc 기반으로 변경
  - 일부 DTO/내부 타입 접근성(public) 조정으로 테스트·문서 호환성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->