### PR TITLE
[BE] docs: 추천 카테고리별 히어릿에 IT트랜드와 랜덤 카테고리 추가

### DIFF
--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/presentation/HearitControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/presentation/HearitControllerTest.java
@@ -144,7 +144,7 @@ class HearitControllerTest extends ControllerTest {
                         new HearitResponse(405L, "Hearit 405", LocalDateTime.now())
                 )
         );
-        var category4 = new HearitsWithRecommendCategoryResponse(5L, "Category D", "#0000FF",
+        var randomCategory = new HearitsWithRecommendCategoryResponse(5L, "Random Category", "#0000FF",
                 List.of(
                         new HearitResponse(501L, "Hearit 501", LocalDateTime.now()),
                         new HearitResponse(502L, "Hearit 502", LocalDateTime.now()),
@@ -153,7 +153,7 @@ class HearitControllerTest extends ControllerTest {
                         new HearitResponse(505L, "Hearit 505", LocalDateTime.now())
                 )
         );
-        var mockedResponse = List.of(itTrendCategory, category1, category2, category3, category4);
+        var mockedResponse = List.of(itTrendCategory, category1, category2, category3, randomCategory);
 
         given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
         given(hearitService.getHearitsWithRecommendCategory(any())).willReturn(mockedResponse);

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/presentation/HearitControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/presentation/HearitControllerTest.java
@@ -108,7 +108,7 @@ class HearitControllerTest extends ControllerTest {
     @DisplayName("추천 카테고리별 히어릿 조회 V1 - 200 OK")
     void readHearitsWithRecommendCategoryV1_OK() throws Exception {
         // given
-        var category1 = new HearitsWithRecommendCategoryResponse(1L, "Category A", "#FF0000",
+        var itTrendCategory = new HearitsWithRecommendCategoryResponse(1L, "IT 트랜드", "#FF0000",
                 List.of(
                         new HearitResponse(101L, "Hearit 101", LocalDateTime.now()),
                         new HearitResponse(102L, "Hearit 102", LocalDateTime.now()),
@@ -117,7 +117,7 @@ class HearitControllerTest extends ControllerTest {
                         new HearitResponse(105L, "Hearit 105", LocalDateTime.now())
                 )
         );
-        var category2 = new HearitsWithRecommendCategoryResponse(2L, "Category B", "#00FF00",
+        var category1 = new HearitsWithRecommendCategoryResponse(2L, "Category A", "#FF0000",
                 List.of(
                         new HearitResponse(201L, "Hearit 201", LocalDateTime.now()),
                         new HearitResponse(202L, "Hearit 202", LocalDateTime.now()),
@@ -126,7 +126,7 @@ class HearitControllerTest extends ControllerTest {
                         new HearitResponse(205L, "Hearit 205", LocalDateTime.now())
                 )
         );
-        var category3 = new HearitsWithRecommendCategoryResponse(3L, "Category C", "#0000FF",
+        var category2 = new HearitsWithRecommendCategoryResponse(3L, "Category B", "#00FF00",
                 List.of(
                         new HearitResponse(301L, "Hearit 301", LocalDateTime.now()),
                         new HearitResponse(302L, "Hearit 302", LocalDateTime.now()),
@@ -135,7 +135,25 @@ class HearitControllerTest extends ControllerTest {
                         new HearitResponse(305L, "Hearit 305", LocalDateTime.now())
                 )
         );
-        var mockedResponse = List.of(category1, category2, category3);
+        var category3 = new HearitsWithRecommendCategoryResponse(4L, "Category C", "#0000FF",
+                List.of(
+                        new HearitResponse(401L, "Hearit 401", LocalDateTime.now()),
+                        new HearitResponse(402L, "Hearit 402", LocalDateTime.now()),
+                        new HearitResponse(403L, "Hearit 403", LocalDateTime.now()),
+                        new HearitResponse(404L, "Hearit 404", LocalDateTime.now()),
+                        new HearitResponse(405L, "Hearit 405", LocalDateTime.now())
+                )
+        );
+        var category4 = new HearitsWithRecommendCategoryResponse(5L, "Category D", "#0000FF",
+                List.of(
+                        new HearitResponse(501L, "Hearit 501", LocalDateTime.now()),
+                        new HearitResponse(502L, "Hearit 502", LocalDateTime.now()),
+                        new HearitResponse(503L, "Hearit 503", LocalDateTime.now()),
+                        new HearitResponse(504L, "Hearit 504", LocalDateTime.now()),
+                        new HearitResponse(505L, "Hearit 505", LocalDateTime.now())
+                )
+        );
+        var mockedResponse = List.of(itTrendCategory, category1, category2, category3, category4);
 
         given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
         given(hearitService.getHearitsWithRecommendCategory(any())).willReturn(mockedResponse);


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

- 여러 카테고리 - 3개에서 5개로 수정
- (즐겨듣는) 3개는 사용자 기반 + 1개는 매번 랜덤 + 1개는 IT 트렌드
- 변경 이유: 홈화면에서 더 많은 선택지 제공

<img width="811" height="552" alt="image" src="https://github.com/user-attachments/assets/5a33a1d5-092b-4a9c-b7bf-2575cb37126b" />
- IT 트랜드부터 잘 나오는 모습~~

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #623 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * 추천 카테고리별 히어릿 조회 V1 테스트 데이터를 3개에서 5개로 확대했습니다.
  * 모의 응답의 항목 순서 검증을 명확히 하고, 각 항목의 색상 필드 포함 여부와 응답 구조 일관성을 강화했습니다.
  * 공개 API와 실제 동작 변경은 없으며 사용자 기능에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->