### PR TITLE
[BE] docs: 최근 업로드된 히어릿 목록 API 문서 테스트 작성 #624

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitService.java
@@ -2,6 +2,7 @@ package com.onair.hearit.app.hearit.application;
 
 import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
+import com.onair.hearit.app.hearit.dto.RecentHearitResponse;
 import com.onair.hearit.core.domain.Bookmark;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
@@ -84,6 +85,10 @@ public class HearitService {
             return 0L;
         }
         return lastPlayTime;
+    }
+
+    public List<RecentHearitResponse> getRecentHearits(UserInfo userInfo) {
+        return List.of();
     }
 
     public List<HearitsWithRecommendCategoryResponse> getHearitsWithRecommendCategory(UserInfo userInfo) {

--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/dto/RecentHearitResponse.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/dto/RecentHearitResponse.java
@@ -1,0 +1,31 @@
+package com.onair.hearit.app.hearit.dto;
+
+import com.onair.hearit.core.domain.Category;
+import com.onair.hearit.core.domain.Hearit;
+import java.time.LocalDateTime;
+
+public record RecentHearitResponse(
+        Long id,
+        String title,
+        Integer playTime,
+        Long lastPlayTime,
+        LocalDateTime createdAt,
+        CategoryResponse category
+) {
+    public static RecentHearitResponse from(Hearit hearit, Long lastPlayTime) {
+        return new RecentHearitResponse(
+                hearit.getId(),
+                hearit.getTitle(),
+                hearit.getPlayTime(),
+                lastPlayTime,
+                hearit.getCreatedAt(),
+                CategoryResponse.from(hearit.getCategory())
+        );
+    }
+
+    public record CategoryResponse(Long id, String name, String colorCode) {
+        public static CategoryResponse from(Category category) {
+            return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
+        }
+    }
+}

--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/presentation/HearitController.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/presentation/HearitController.java
@@ -7,6 +7,7 @@ import com.onair.hearit.app.hearit.application.HearitService;
 import com.onair.hearit.app.hearit.dto.HearitDetailResponse;
 import com.onair.hearit.app.hearit.dto.HearitOfCategoryResponse;
 import com.onair.hearit.app.hearit.dto.HearitsWithRecommendCategoryResponse;
+import com.onair.hearit.app.hearit.dto.RecentHearitResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -28,6 +29,12 @@ public class HearitController {
             @AuthenticationPrincipal RequestUser requestUser) {
         HearitDetailResponse response = hearitService.getHearitDetail(hearitId, requestUser.getUserInfo());
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/v1/hearits/recent")
+    public ResponseEntity<List<RecentHearitResponse>> readRecentHearit(@AuthenticationPrincipal RequestUser requestUser) {
+        List<RecentHearitResponse> responses = hearitService.getRecentHearits(requestUser.getUserInfo());
+        return ResponseEntity.ok(responses);
     }
 
     @GetMapping("/api/v1/hearits/recommend-category")

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/presentation/HearitControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/presentation/HearitControllerTest.java
@@ -1,5 +1,6 @@
 package com.onair.hearit.app.hearit.presentation;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,7 +9,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.onair.hearit.app.auth.infrastructure.jwt.TokenStatus;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
@@ -21,6 +21,7 @@ import com.onair.hearit.app.hearit.dto.HearitDetailResponse.SourceResponse;
 import com.onair.hearit.app.hearit.dto.HearitOfCategoryResponse;
 import com.onair.hearit.app.hearit.dto.HearitsWithRecommendCategoryResponse;
 import com.onair.hearit.app.hearit.dto.HearitsWithRecommendCategoryResponse.HearitResponse;
+import com.onair.hearit.app.hearit.dto.RecentHearitResponse;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -67,7 +68,7 @@ class HearitControllerTest extends ControllerTest {
         mockMvc.perform(get("/api/v1/hearits/{hearitId}", hearitId)
                         .header("Authorization", "Bearer valid-token"))
                 .andExpect(status().isOk())
-                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearit-ok",
+                .andDo(document("v1-get-hearit-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
                                 .summary("단일 히어릿 조회 V1")
@@ -95,11 +96,58 @@ class HearitControllerTest extends ControllerTest {
         mockMvc.perform(get("/api/v1/hearits/{hearitId}", notFoundHearitId)
                         .header("Authorization", "Bearer valid-token"))
                 .andExpect(status().isNotFound())
-                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearit-not-found",
+                .andDo(document("v1-get-hearit-not-found",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
                                 .summary("단일 히어릿 조회 V1")
                                 .responseFields(com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFields())
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("최근 업로드된 히어릿 조회 - 200 OK")
+    void readRecentHearitsV1_OK() throws Exception {
+        // given
+        var responses = List.of(
+                new RecentHearitResponse(99L, "10월 15일 히어릿", 300, (long) 1_000,
+                        LocalDateTime.of(2024, 10, 15, 10, 0),
+                        new RecentHearitResponse.CategoryResponse(2L, "IT 트렌드", "#FFFFFF")),
+                new RecentHearitResponse(98L, "10월 14일 히어릿", 400, (long) 1_500,
+                        LocalDateTime.of(2024, 10, 14, 10, 0),
+                        new RecentHearitResponse.CategoryResponse(9L, "Spring", "#FFFFFF")),
+                new RecentHearitResponse(96L, "10월 13일 히어릿", 100, (long) 1_100,
+                        LocalDateTime.of(2024, 10, 13, 10, 0),
+                        new RecentHearitResponse.CategoryResponse(8L, "Android", "#FFFFFF")),
+                new RecentHearitResponse(94L, "10월 12일 히어릿", 250, (long) 1_080,
+                        LocalDateTime.of(2024, 10, 12, 10, 0),
+                        new RecentHearitResponse.CategoryResponse(7L, "React", "#FFFFFF")),
+                new RecentHearitResponse(92L, "10월 11일 히어릿", 330, (long) 1_900,
+                        LocalDateTime.of(2024, 10, 11, 10, 0),
+                        new RecentHearitResponse.CategoryResponse(2L, "IT 트렌드", "#FFFFFF")
+                ));
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(hearitService.getRecentHearits(any())).willReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/recent")
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-hearits-recent-ok",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Hearit API")
+                                .summary("최근 업로드된 히어릿 조회 V1")
+                                .description("최근 업로드된 히어릿을 최신순으로 5개 조회합니다.")
+                                .responseFields(
+                                        fieldWithPath("[].id").type(JsonFieldType.NUMBER).description("히어릿 ID"),
+                                        fieldWithPath("[].title").type(JsonFieldType.STRING).description("히어릿 제목"),
+                                        fieldWithPath("[].playTime").type(JsonFieldType.NUMBER).description("재생 시간(s)"),
+                                        fieldWithPath("[].lastPlayTime").type(JsonFieldType.NUMBER).description("마지막 재생 시간(ms)").optional(),
+                                        fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("생성 일시"),
+                                        fieldWithPath("[].category.id").type(JsonFieldType.NUMBER).description("카테고리 아이디"),
+                                        fieldWithPath("[].category.name").type(JsonFieldType.STRING).description("카테고리 이름"),
+                                        fieldWithPath("[].category.colorCode").type(JsonFieldType.STRING).description("카테고리 색상"))
                                 .build())
                 ));
     }
@@ -144,7 +192,7 @@ class HearitControllerTest extends ControllerTest {
         mockMvc.perform(get("/api/v1/hearits/recommend-category")
                         .header("Authorization", "Bearer valid-token"))
                 .andExpect(status().isOk())
-                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-recommend-category-ok",
+                .andDo(document("v1-get-hearits-recommend-category-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
                                 .summary("추천 카테고리별 히어릿 조회 V1")
@@ -185,7 +233,7 @@ class HearitControllerTest extends ControllerTest {
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isOk())
-                .andDo(MockMvcRestDocumentationWrapper.document("v1-get-hearits-by-category-ok",
+                .andDo(document("v1-get-hearits-by-category-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Hearit API")
                                 .summary("카테고리별 히어릿 목록 조회 V1")


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- HearitControllerTest에 최근 업로드된 히어릿 api 문서화 코드 작성했습니다.

## 📸 스크린샷 (선택)
<img width="1414" height="658" alt="image" src="https://github.com/user-attachments/assets/797b00f2-78b6-4123-bda4-e2f06781a5b8" />

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #624 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 기능
  - 최근 히어릿 목록 조회 API(GET /api/v1/hearits/recent) 추가. 응답에는 항목 ID, 제목, 재생시간, 마지막 재생 시각, 생성 시각, 카테고리 정보가 포함됩니다.
- 문서
  - 최근 히어릿 목록 API 명세 및 응답 필드 설명을 추가했습니다.
- 테스트
  - 최근 히어릿 목록 조회 컨트롤러 테스트를 추가하고, API 문서화 방식을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->