### PR TITLE
[BE] docs: 북마크 미완료 히어릿 조회 API 추가 #621

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/bookmark/application/BookmarkService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/bookmark/application/BookmarkService.java
@@ -1,20 +1,23 @@
 package com.onair.hearit.app.bookmark.application;
 
 import com.onair.hearit.app.bookmark.dto.BookmarkHearitResponseV2;
-import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.bookmark.dto.BookmarkInfoResponse;
-import com.onair.hearit.core.domain.Bookmark;
-import com.onair.hearit.core.domain.Hearit;
-import com.onair.hearit.core.domain.Member;
-import com.onair.hearit.core.domain.UserInfo;
+import com.onair.hearit.app.bookmark.dto.BookmarkUnfinishedHearitResponse;
+import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.exception.custom.AlreadyExistException;
 import com.onair.hearit.app.exception.custom.ForbiddenException;
 import com.onair.hearit.app.exception.custom.NotFoundException;
 import com.onair.hearit.app.exception.custom.UnauthenticatedException;
-import com.onair.hearit.core.infrastructure.projection.BookmarkWithPlayingHistoryProjection;
+import com.onair.hearit.core.domain.Bookmark;
+import com.onair.hearit.core.domain.Hearit;
+import com.onair.hearit.core.domain.Member;
+import com.onair.hearit.core.domain.UserInfo;
 import com.onair.hearit.core.infrastructure.jpa.BookmarkRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.core.infrastructure.jpa.MemberRepository;
+import com.onair.hearit.core.infrastructure.projection.BookmarkWithPlayingHistoryProjection;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -41,12 +44,18 @@ public class BookmarkService {
         return toBookmarkHearitResponse(projections);
     }
 
-    private Page<BookmarkHearitResponseV2> toBookmarkHearitResponse(Page<BookmarkWithPlayingHistoryProjection> projections) {
+    private Page<BookmarkHearitResponseV2> toBookmarkHearitResponse(
+            Page<BookmarkWithPlayingHistoryProjection> projections) {
         return projections.map(p -> BookmarkHearitResponseV2.of(
                 p.getBookmark(),
                 p.getBookmark().getHearit(),
                 p.getPlayingHistory()
         ));
+    }
+
+    public List<BookmarkUnfinishedHearitResponse> getBookmarkUnfinishedHearit(UserInfo userInfo) {
+        //TODO: API Docs 우선 배포하여 비지니스 로직 구현 필요
+        return Collections.emptyList();
     }
 
     @Transactional

--- a/backend/app/src/main/java/com/onair/hearit/app/bookmark/dto/BookmarkUnfinishedHearitResponse.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/bookmark/dto/BookmarkUnfinishedHearitResponse.java
@@ -1,0 +1,31 @@
+package com.onair.hearit.app.bookmark.dto;
+
+import com.onair.hearit.core.domain.Category;
+import com.onair.hearit.core.domain.Hearit;
+import java.time.LocalDateTime;
+
+public record BookmarkUnfinishedHearitResponse(
+        Long id,
+        String title,
+        Integer playTime,
+        Long lastPlayTime,
+        LocalDateTime createdAt,
+        CategoryResponse category
+) {
+    public static BookmarkUnfinishedHearitResponse from(Hearit hearit, Long lastPlayTime) {
+        return new BookmarkUnfinishedHearitResponse(
+                hearit.getId(),
+                hearit.getTitle(),
+                hearit.getPlayTime(),
+                lastPlayTime,
+                hearit.getCreatedAt(),
+                CategoryResponse.from(hearit.getCategory())
+        );
+    }
+
+    public record CategoryResponse(Long id, String name, String colorCode) {
+        public static CategoryResponse from(Category category) {
+            return new CategoryResponse(category.getId(), category.getName(), category.getColorCode());
+        }
+    }
+}

--- a/backend/app/src/main/java/com/onair/hearit/app/bookmark/presentation/BookmarkController.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/bookmark/presentation/BookmarkController.java
@@ -1,12 +1,14 @@
 package com.onair.hearit.app.bookmark.presentation;
 
+import com.onair.hearit.app.auth.domain.RequestUser;
 import com.onair.hearit.app.bookmark.application.BookmarkService;
 import com.onair.hearit.app.bookmark.dto.BookmarkHearitResponseV1;
 import com.onair.hearit.app.bookmark.dto.BookmarkHearitResponseV2;
 import com.onair.hearit.app.bookmark.dto.BookmarkInfoResponse;
+import com.onair.hearit.app.bookmark.dto.BookmarkUnfinishedHearitResponse;
 import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
-import com.onair.hearit.app.auth.domain.RequestUser;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -47,6 +49,14 @@ public class BookmarkController {
                 requestUser.getUserInfo(),
                 pagingRequest);
         return ResponseEntity.ok(PagedResponse.from(bookmarkHearits));
+    }
+
+    @GetMapping("/api/v1/bookmarks/hearits/unfinished")
+    public ResponseEntity<List<BookmarkUnfinishedHearitResponse>> readBookmarkUnfinishedHearits(
+            @AuthenticationPrincipal RequestUser requestUser) {
+        List<BookmarkUnfinishedHearitResponse> response =
+                bookmarkService.getBookmarkUnfinishedHearit(requestUser.getUserInfo());
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/api/v1/bookmarks/hearits/{hearitId}")

--- a/backend/app/src/test/java/com/onair/hearit/app/bookmark/presentation/BookmarkControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/bookmark/presentation/BookmarkControllerTest.java
@@ -19,6 +19,7 @@ import com.onair.hearit.app.auth.infrastructure.jwt.TokenStatus;
 import com.onair.hearit.app.bookmark.application.BookmarkService;
 import com.onair.hearit.app.bookmark.dto.BookmarkHearitResponseV2;
 import com.onair.hearit.app.bookmark.dto.BookmarkInfoResponse;
+import com.onair.hearit.app.bookmark.dto.BookmarkUnfinishedHearitResponse;
 import com.onair.hearit.app.exception.custom.AlreadyExistException;
 import com.onair.hearit.app.exception.custom.ForbiddenException;
 import com.onair.hearit.app.fixture.ControllerTest;
@@ -52,7 +53,8 @@ class BookmarkControllerTest extends ControllerTest {
                         100 + i,
                         (long) 200 + i - 2,
                         false,
-                        List.of(new BookmarkHearitResponseV2.SourceResponse("source1", "url1"), new BookmarkHearitResponseV2.SourceResponse("source2", "url2")),
+                        List.of(new BookmarkHearitResponseV2.SourceResponse("source1", "url1"),
+                                new BookmarkHearitResponseV2.SourceResponse("source2", "url2")),
                         new BookmarkHearitResponseV2.CategoryResponse((long) i, "categoryName", "#FFFFFF")
                 ))
                 .toList();
@@ -83,9 +85,11 @@ class BookmarkControllerTest extends ControllerTest {
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].summary").description("히어릿 요약"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
-                                                        fieldWithPath("content[].lastPlayTime").description("히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].lastPlayTime").description(
+                                                                "히어릿 마지막 재생 시간(ms)").optional(),
                                                         fieldWithPath("content[].categoryColor").description("카테고리 색상 코드")
-                                                }), Arrays.stream(com.onair.hearit.fixture.ApiDocSnippets.getCustomPagedResponseFields()))
+                                                }), Arrays.stream(
+                                                        com.onair.hearit.fixture.ApiDocSnippets.getCustomPagedResponseFields()))
                                         .toArray(FieldDescriptor[]::new)
                                 )
                                 .build())
@@ -104,7 +108,8 @@ class BookmarkControllerTest extends ControllerTest {
                         100 + i,
                         (long) 200 + i - 2,
                         false,
-                        List.of(new BookmarkHearitResponseV2.SourceResponse("source1", "url1"), new BookmarkHearitResponseV2.SourceResponse("source2", "url2")),
+                        List.of(new BookmarkHearitResponseV2.SourceResponse("source1", "url1"),
+                                new BookmarkHearitResponseV2.SourceResponse("source2", "url2")),
                         new BookmarkHearitResponseV2.CategoryResponse((long) i, "categoryName", "#FFFFFF")
                 ))
                 .toList();
@@ -135,8 +140,10 @@ class BookmarkControllerTest extends ControllerTest {
                                                         fieldWithPath("content[].title").description("히어릿 제목"),
                                                         fieldWithPath("content[].summary").description("히어릿 요약"),
                                                         fieldWithPath("content[].playTime").description("히어릿 재생 시간(초)"),
-                                                        fieldWithPath("content[].lastPlayTime").description("히어릿 마지막 재생 시간(ms)").optional(),
-                                                        fieldWithPath("content[].isFinished").description("히어릿 재생 완료 여부").optional(),
+                                                        fieldWithPath("content[].lastPlayTime").description(
+                                                                "히어릿 마지막 재생 시간(ms)").optional(),
+                                                        fieldWithPath("content[].isFinished").description(
+                                                                "히어릿 재생 완료 여부").optional(),
                                                         fieldWithPath("content[].sources").description("출처 정보"),
                                                         fieldWithPath("content[].sources[].sourceName").description("출처 이름"),
                                                         fieldWithPath("content[].sources[].sourceUrl").description("출처 URL"),
@@ -144,7 +151,8 @@ class BookmarkControllerTest extends ControllerTest {
                                                         fieldWithPath("content[].category.id").description("카테고리 ID"),
                                                         fieldWithPath("content[].category.name").description("카테고리 이름"),
                                                         fieldWithPath("content[].category.colorCode").description("카테고리 색상코드")
-                                                }), Arrays.stream(com.onair.hearit.fixture.ApiDocSnippets.getCustomPagedResponseFields()))
+                                                }), Arrays.stream(
+                                                        com.onair.hearit.fixture.ApiDocSnippets.getCustomPagedResponseFields()))
                                         .toArray(FieldDescriptor[]::new)
                                 )
                                 .build())
@@ -167,7 +175,8 @@ class BookmarkControllerTest extends ControllerTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
                                 .summary("북마크 목록 조회 V2")
-                                .responseFields(com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(
+                                        com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
                 ));
     }
@@ -187,7 +196,49 @@ class BookmarkControllerTest extends ControllerTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
                                 .summary("북마크 목록 조회 V2")
-                                .responseFields(com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
+                                .responseFields(
+                                        com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFieldsWithAuthProperties())
+                                .build())
+                ));
+    }
+
+    @Test
+    @DisplayName("북마크 미 완료 목록 조회 V1 - 200 OK")
+    void readBookmarkUnFinishedHearit_Ok() throws Exception {
+        // given
+        var responses = List.of(
+                new BookmarkUnfinishedHearitResponse(1L, "title1", 120, 30L, null,
+                        new BookmarkUnfinishedHearitResponse.CategoryResponse(1L, "카테고리1", "#000000")),
+                new BookmarkUnfinishedHearitResponse(2L, "title2", 150, 60L, null,
+                        new BookmarkUnfinishedHearitResponse.CategoryResponse(2L, "카테고리2", "#111111")),
+                new BookmarkUnfinishedHearitResponse(3L, "title3", 150, 60L, null,
+                        new BookmarkUnfinishedHearitResponse.CategoryResponse(3L, "카테고리3", "#222222")),
+                new BookmarkUnfinishedHearitResponse(4L, "title4", 150, 60L, null,
+                        new BookmarkUnfinishedHearitResponse.CategoryResponse(4L, "카테고리1", "#333333")
+                ));
+
+        given(jwtTokenProvider.getTokenStatus("valid-token")).willReturn(TokenStatus.VALID);
+        given(bookmarkService.getBookmarkUnfinishedHearit(any())).willReturn(responses);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/bookmarks/hearits/unfinished")
+                        .header("Authorization", "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-bookmark-unfinished-ok",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Bookmark API")
+                                .summary("미완료 북마크 API V1")
+                                .description("로그인한 사용자는 다 듣지 않은 북마크 목록을 최대 10개까지 조회합니다.")
+                                .responseFields(
+                                        fieldWithPath("[].id").description("히어릿 ID"),
+                                        fieldWithPath("[].title").description("히어릿 제목"),
+                                        fieldWithPath("[].playTime").description("히어릿 전체 재생 시간(s)"),
+                                        fieldWithPath("[].lastPlayTime").description("사용자가 마지막으로 재생한 시간(ms)"),
+                                        fieldWithPath("[].createdAt").description("히어릿 생성일").optional(),
+                                        fieldWithPath("[].category.id").description("카테고리 ID"),
+                                        fieldWithPath("[].category.name").description("카테고리 이름"),
+                                        fieldWithPath("[].category.colorCode").description("카테고리 색상 코드")
+                                )
                                 .build())
                 ));
     }
@@ -239,7 +290,8 @@ class BookmarkControllerTest extends ControllerTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
                                 .summary("북마크 생성 V1")
-                                .responseFields(com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(
+                                        com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
                 ));
     }
@@ -287,7 +339,8 @@ class BookmarkControllerTest extends ControllerTest {
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Bookmark API")
                                 .summary("북마크 삭제 V1")
-                                .responseFields(com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFields())
+                                .responseFields(
+                                        com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFields())
                                 .build())
                 ));
     }

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryIntegrationTest.java
@@ -58,10 +58,10 @@ class PlayingHistoryIntegrationTest extends IntegrationTest {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        for (int i = 0; i < 2; i++) {
-            Hearit hearit = dbHelper.insertHearit(createHearitWith(100 + i, category));
-            dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L * i));
-        }
+        Hearit hearit = dbHelper.insertHearit(createHearitWith(101, category));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L));
+        Hearit hearit2 = dbHelper.insertHearit(createHearitWith(102, category));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit2, 20L));
 
         // when & then
         List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
@@ -73,7 +73,7 @@ class PlayingHistoryIntegrationTest extends IntegrationTest {
                 .extract().as(new TypeRef<>() {
                 });
 
-        assertThat(response).hasSize(0);
+        assertThat(response).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
- Controller에 `/api/v1/bookmarks/hearits/unfinished` 요청 처리 엔드포인트 추가
- `BookmarkControllerTest`에 관련 테스트 코드 추가

<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

<img width="1442" height="937" alt="image" src="https://github.com/user-attachments/assets/0e05a0ab-69f9-4b1b-8ced-b4f2e009ca93" />

api 추가했습니다

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 북마크한 미완료 히어릿 목록을 조회하는 새 GET API를 추가했습니다. 응답에 ID, 제목, 전체 재생시간, 마지막 재생 시각, 생성일 및 카테고리 정보가 포함됩니다.
- 테스트
  - 미완료 히어릿 조회에 대한 컨트롤러 테스트를 V1/V2 경로에 추가하고 응답 필드를 문서화했습니다.
  - 재생 이력 관련 통합 테스트의 게스트 시나리오 검증을 보다 명확한 방식으로 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->