### PR TITLE
[BE] fix : ProblemDetail json 반환 형식 버그 수정

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -1,8 +1,8 @@
 package com.onair.hearit.app.auth.infrastructure.jwt;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.onair.hearit.app.exception.ErrorCode;
 import com.onair.hearit.app.auth.domain.RequestUser;
+import com.onair.hearit.app.exception.ErrorCode;
 import com.onair.hearit.core.log.exception.FilterExceptionLogger;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ProblemDetail;
@@ -109,8 +110,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(errorCode.getHttpStatus(), detail);
         problemDetail.setTitle(errorCode.getTitle());
         problemDetail.setType(URI.create(request.getRequestURI()));
-        problemDetail.setProperty("code", errorCode.name());
-        problemDetail.setProperty("reissuable", errorCode == ErrorCode.ACCESS_TOKEN_EXPIRED);
+        String code = errorCode.name();
+        boolean reissuable = (errorCode == ErrorCode.ACCESS_TOKEN_EXPIRED);
+        problemDetail.setProperty("code", code);
+        problemDetail.setProperty("reissuable", reissuable);
+        Map<String, Object> properties = Map.of(
+                "code", code,
+                "reissuable", reissuable
+        );
+        problemDetail.setProperty("properties", properties);
         return problemDetail;
     }
 

--- a/backend/app/src/main/java/com/onair/hearit/app/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -108,7 +108,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private ProblemDetail buildProblemDetail(ErrorCode errorCode, String detail, HttpServletRequest request) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(errorCode.getHttpStatus(), detail);
-        problemDetail.setTitle(errorCode.getTitle());
+        problemDetail.setTitle(errorCode.getHttpStatus().getReasonPhrase());
         problemDetail.setType(URI.create(request.getRequestURI()));
         String code = errorCode.name();
         boolean reissuable = (errorCode == ErrorCode.ACCESS_TOKEN_EXPIRED);

--- a/backend/app/src/test/java/com/onair/hearit/app/auth/config/ApiSecurityConfigTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/auth/config/ApiSecurityConfigTest.java
@@ -6,16 +6,16 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.auth.infrastructure.jwt.JwtTokenProvider;
+import com.onair.hearit.app.fixture.IntegrationTest;
 import com.onair.hearit.core.domain.Member;
 import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.app.fixture.IntegrationTest;
 import io.restassured.RestAssured;
+import io.restassured.path.json.JsonPath;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.contract.spec.internal.HttpStatus;
-import org.springframework.http.ProblemDetail;
 
 class ApiSecurityConfigTest extends IntegrationTest {
 
@@ -85,7 +85,7 @@ class ApiSecurityConfigTest extends IntegrationTest {
     @Test
     @DisplayName("인증 실패 시 application/problem+json 형식으로 응답하며 토큰재발급 여부를 위한 properties를 포함한다.")
     void returnProblemDetailOnAuthFailure() {
-        ProblemDetail problemDetail = RestAssured.given().log().all()
+        JsonPath jsonPath = RestAssured.given().log().all()
                 .header("Authorization", "Bearer invalid-token")
                 .when()
                 .get("/api/v1/bookmarks/hearits") // 인증 필요한 경로
@@ -93,13 +93,13 @@ class ApiSecurityConfigTest extends IntegrationTest {
                 .statusCode(401)
                 .header("Content-Type", containsString("application/problem+json"))
                 .extract()
-                .as(ProblemDetail.class);
+                .jsonPath();
 
         assertAll(
-                () -> assertThat(problemDetail.getTitle()).isEqualTo("엑세스 토큰이 유효하지 않습니다."),
-                () -> assertThat(problemDetail.getDetail()).isEqualTo("유효하지 않은 토큰입니다."),
-                () -> assertThat(problemDetail.getProperties().get("code")).isNotNull(),
-                () -> assertThat(problemDetail.getProperties().get("reissuable")).isNotNull()
+                () -> assertThat(jsonPath.getString("title")).isEqualTo("엑세스 토큰이 유효하지 않습니다."),
+                () -> assertThat(jsonPath.getString("detail")).isEqualTo("유효하지 않은 토큰입니다."),
+                () -> assertThat(jsonPath.getString("code")).isNotNull(),
+                () -> assertThat(jsonPath.getObject("reissuable", Boolean.class)).isNotNull()
         );
     }
 

--- a/backend/app/src/test/java/com/onair/hearit/app/auth/config/ApiSecurityConfigTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/auth/config/ApiSecurityConfigTest.java
@@ -96,7 +96,7 @@ class ApiSecurityConfigTest extends IntegrationTest {
                 .jsonPath();
 
         assertAll(
-                () -> assertThat(jsonPath.getString("title")).isEqualTo("엑세스 토큰이 유효하지 않습니다."),
+                () -> assertThat(jsonPath.getString("title")).isEqualTo("Unauthorized"),
                 () -> assertThat(jsonPath.getString("detail")).isEqualTo("유효하지 않은 토큰입니다."),
                 () -> assertThat(jsonPath.getString("code")).isNotNull(),
                 () -> assertThat(jsonPath.getObject("reissuable", Boolean.class)).isNotNull()

--- a/backend/app/src/test/java/com/onair/hearit/app/fixture/ApiDocSnippets.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/fixture/ApiDocSnippets.java
@@ -40,8 +40,10 @@ public class ApiDocSnippets {
                 fieldWithPath("title").type(JsonFieldType.STRING).description("문제 유형에 대한 요약 (에러 코드 제목)"),
                 fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                 fieldWithPath("detail").type(JsonFieldType.STRING).description("문제 발생에 대한 상세 설명"),
-                fieldWithPath("instance").type(JsonFieldType.STRING).description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
-                fieldWithPath("properties").type(JsonFieldType.OBJECT).description("문제 유형에 대한 추가 세부 정보 (현재는 사용되지 않아 null)").optional()
+                fieldWithPath("instance").type(JsonFieldType.STRING)
+                        .description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
+                fieldWithPath("properties").type(JsonFieldType.OBJECT)
+                        .description("문제 유형에 대한 추가 세부 정보 (현재는 사용되지 않아 null)").optional()
         };
     }
 
@@ -51,9 +53,13 @@ public class ApiDocSnippets {
                 fieldWithPath("title").type(JsonFieldType.STRING).description("문제 유형에 대한 요약 (에러 코드 제목)"),
                 fieldWithPath("status").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
                 fieldWithPath("detail").type(JsonFieldType.STRING).description("문제 발생에 대한 상세 설명"),
-                fieldWithPath("instance").type(JsonFieldType.STRING).description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
+                fieldWithPath("instance").type(JsonFieldType.STRING)
+                        .description("문제의 특정 발생을 식별하는 URI (현재는 사용되지 않아 null)").optional(),
                 fieldWithPath("code").type(JsonFieldType.STRING).description("에러 코드 (예: UNAUTHENTICATED)"),
-                fieldWithPath("reissuable").type(JsonFieldType.BOOLEAN).description("토큰 재발급 가능 여부")
+                fieldWithPath("reissuable").type(JsonFieldType.BOOLEAN).description("토큰 재발급 가능 여부"),
+                fieldWithPath("properties").description("속성 객체"),
+                fieldWithPath("properties.reissuable").description("토큰 재발급 가능 여부"),
+                fieldWithPath("properties.code").description("에러 코드 (예: UNAUTHENTICATED)")
         };
     }
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/log/config/LogMessageConfig.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/log/config/LogMessageConfig.java
@@ -2,22 +2,11 @@ package com.onair.hearit.core.log.config;
 
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class LogMessageConfig {
-
-    @Bean
-    public ObjectMapper logObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        return mapper;
-    }
 
     @Bean
     public DefaultPrettyPrinter logPrettyPrinter() {


### PR DESCRIPTION
## 📌 변경 내용 & 이유

* **문제 상황**

  * 인증 실패 시 반환되는 응답이 `properties` 객체로 감싸져 내려감.
  *단, 이를 해결해도 클라이언트(특히 안드)에서는 기존처럼 `code`, `reissuable`을 최상위 필드에서 직접 접근하기 때문에 호환성 이슈 발생.
  * detail 필드에 들어가는 내용이 title에도 들어감..
* **조치**

  * 일시적으로 응답 JSON에 `code`, `reissuable`을 **최상위 필드**에도 함께 노출.
  * 동시에 `properties` 안에도 중첩된 형태로 유지 → 기존 응답과 호환 보장.
  * title에는 HttpStatus 코드의 이름이 들어가도록 변
  * 추후 클라이언트 대응 완료 후 `properties` 제거 예정.

---

## 📸 실제 응답 구조

### 과거 응답 (문제)

```json
{
  "type": "/api/v1/bookmarks/hearits",
  "title": "인증이 필요한 요청입니다.",
  "status": 401,
  "detail": "인증이 필요한 요청입니다.",
  "instance": null,
  "properties": {
    "code": "AUTHENTICATION_REQUIRED",
    "reissuable": false
  }
}
```

### pr의 응답 (임시 호환 구조, properties는 제거예쩡)

```json
{
  "type": "/api/v1/bookmarks/hearits",
  "title": "Unauthorized",
  "status": 401,
  "detail": "인증이 필요한 요청입니다.",
  "instance": null,
  "code": "AUTHENTICATION_REQUIRED",
  "reissuable": false,
  "properties": { 
    "code": "AUTHENTICATION_REQUIRED",
    "reissuable": false
  }
}
```

---

## 🧪 테스트 방법


---

## 📢 논의할 내용

* 안드로이드/프론트엔드에서 최상위 `code`, `reissuable` 사용 → 추후 `properties` 제거 

---

# 원인 분석

### 왜 `ProblemDetail` 평탄화가 안 되었는가?

1. **ObjectMapper Bean 직접 등록**

   * `LogMessageConfig`에서 `logObjectMapper`를 Bean으로 등록.
2. **Spring Boot 자동설정 중단**

   * 프로젝트 내 `ObjectMapper` Bean이 하나라도 있으면, Spring Boot는 Jackson 자동 설정을 모두 중단.
3. **ProblemDetailJacksonMixin 미적용**

   * `ProblemDetail` 평탄화는 Spring Boot 자동 설정 기반.
   * 자동설정이 꺼져 버려 평탄화 미적용.
4. **logObjectMapper 기본 사용**

   * 유일한 `ObjectMapper` Bean이라 MVC 요청/응답도 해당 매퍼 사용.
   * 평탄화 설정이 없어 기본 구조(`properties` 중첩)로 직렬화됨.

---

## 🧩 관련 이슈

* close #639 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 오류 응답에 properties 객체 추가(코드, 재발급 가능 여부 노출).
  - 오류 제목이 HTTP 상태 사유구절로 표기되어 메시지 일관성 개선.
- 문서
  - API 문서에 properties, properties.code, properties.reissuable 필드 설명 추가.
- 테스트
  - 오류 응답을 JSON 기반으로 검증하도록 업데이트.
- 리팩터
  - 로깅 관련 내부 설정 정리(외부 동작에는 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->