### PR TITLE
[BE] chore: 프로메테우스 설정 추가 #646

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 
     // Jwt

--- a/backend/boot/build.gradle
+++ b/backend/boot/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation project(':admin')
 
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/backend/boot/src/main/resources/application-dev.properties
+++ b/backend/boot/src/main/resources/application-dev.properties
@@ -47,3 +47,8 @@ spring.flyway.user=${MYSQL_MIGRATION_USER}
 spring.flyway.password=${MYSQL_MIGRATION_PASSWORD}
 spring.flyway.baseline-on-migrate=true
 spring.flyway.baseline-version=1
+
+# Prometheus
+management.endpoints.web.exposure.include=prometheus,health,info
+management.metrics.tags.application=hearit
+management.metrics.tags.environment=${ENV}


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

- 프로메테우스 관련 의존성 + properties 추가
- actuator + prometheus 같은 의존성은 Application이 실행되는 boot 모듈로 옮김

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #646 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 모니터링 강화: Actuator 엔드포인트와 Prometheus 메트릭 노출(개발 환경). 헬스/정보/프로메테우스 엔드포인트 이용 가능.
  - 메트릭 태그 추가: application=“hearit”, environment=ENV 기본 태그 설정으로 지표 필터링 용이.

- Chores
  - 빌드 구성 정리: 모듈 간 의존성 위치 조정으로 Actuator/Prometheus 관련 설정을 일원화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->