### PR TITLE
[BE] chore: Loki 도입을 위한 Log4j2 설정 변경 #648

### DIFF
--- a/backend/boot/src/main/resources/application-dev.properties
+++ b/backend/boot/src/main/resources/application-dev.properties
@@ -51,4 +51,4 @@ spring.flyway.baseline-version=1
 # Prometheus
 management.endpoints.web.exposure.include=prometheus,health,info
 management.metrics.tags.application=hearit
-management.metrics.tags.environment=${ENV}
+management.metrics.tags.env=${ENV}

--- a/backend/core/src/main/java/com/onair/hearit/core/log/LoggingAspect.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/log/LoggingAspect.java
@@ -38,7 +38,6 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @RequiredArgsConstructor
 public class LoggingAspect {
 
-    private static final Logger errorLogger = LogManager.getLogger("errorLogger");
     private static final Logger consoleLogger = LogManager.getLogger("consoleLogger");
     private static final Logger jsonLogger = LogManager.getLogger("jsonLogger");
 
@@ -177,7 +176,7 @@ public class LoggingAspect {
                                               ErrorDetail errorDetail, Throwable throwable) {
         ExceptionLog exceptionLog = ExceptionLog.error(LocalDateTime.now(), requestInfo, httpStatus, errorDetail);
         jsonLogger.error(maskingSupport.mask(exceptionLog));
-        errorLogger.error(exceptionLog, throwable);
+        jsonLogger.error(exceptionLog, throwable);
         consoleLogger.error("[ERROR] {} {} from {} → {}",
                 requestInfo.getHttpMethod(),
                 requestInfo.getRequestUri(),
@@ -191,7 +190,7 @@ public class LoggingAspect {
                                                  ErrorDetail errorDetail, Throwable throwable) {
         ExceptionLog exceptionLog = ExceptionLog.error(LocalDateTime.now(), requestInfo, httpStatus, errorDetail);
         jsonLogger.error(maskingSupport.mask(exceptionLog));
-        errorLogger.error(exceptionLog);
+        jsonLogger.error(exceptionLog);
         consoleLogger.error("[ERROR] {} {} from {} → {}",
                 requestInfo.getHttpMethod(),
                 requestInfo.getRequestUri(),

--- a/backend/core/src/main/resources/log4j2/log4j2.xml
+++ b/backend/core/src/main/resources/log4j2/log4j2.xml
@@ -44,13 +44,14 @@
         <!-- 7개 파일 쌓이면 오래된 로그부터 삭제 -->
         <RollingFile name="RollingFile">
             <FileName>${logDir}/all-level.log</FileName>
-            <FilePattern>${logDir}/archive/all-level/%d{yyyy_MM_dd}.zip</FilePattern>
+            <FilePattern>${logDir}/app-%d{yyyy-MM-dd}.log.gz</FilePattern>
             <JsonLayout
                     complete="false"
                     compact="true"
                     eventEol="true"
                     objectMessageAsJsonObject="true"
-                    charset="UTF-8">
+                    charset="UTF-8"
+                    properties="true">
                 <KeyValuePair key="port" value="${spring:server.port}"/>
                 <KeyValuePair key="env" value="${env}"/>
             </JsonLayout>
@@ -58,40 +59,15 @@
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
             </Policies>
             <DefaultRolloverStrategy>
-                <Delete basePath="${logDir}/archive/all-level" maxDepth="1">
-                    <IfLastModified age="7d"/>
-                </Delete>
-            </DefaultRolloverStrategy>
-        </RollingFile>
-
-        <!-- ERROR, FATAL 로그 파일-->
-        <!-- json 파일로 저장 -->
-        <!-- 1일마다 0시에 롤오버 발생 (날짜 디렉토리에 저장 ex C:/hearit/log/archive/error/2025_08_07.zip) -->
-        <!-- 20개 파일 쌓이면 오래된 로그부터 삭제 -->
-        <RollingFile name="RollingErrorFile">
-            <FileName>${logDir}/error.log</FileName>
-            <FilePattern>${logDir}/archive/error/%d{yyyy_MM_dd}.zip</FilePattern>
-            <JsonLayout complete="false"
-                        compact="true"
-                        eventEol="true"
-                        objectMessageAsJsonObject="true"
-                        includeStacktrace="true">
-                <KeyValuePair key="port" value="${spring:server.port}"/>
-                <KeyValuePair key="env" value="${env}"/>
-            </JsonLayout>
-            <Policies>
-                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
-            </Policies>
-            <DefaultRolloverStrategy>
-                <Delete basePath="${logDir}/archive/error" maxDepth="1">
-                    <IfLastModified age="20d"/>
+                <Delete basePath="${logDir}" maxDepth="1">
+                    <IfFileName glob="app-*.log.gz"/>
+                    <IfLastModified age="3d"/>
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingFile>
     </Appenders>
 
     <Loggers>
-
         <!-- 최상위 로거 (모든 로그 이벤트 처리) -->
         <Root level="info">
             <AppenderRef ref="Console"/>
@@ -106,11 +82,6 @@
         <!-- JSON 파일 Logger-->
         <Logger name="jsonLogger" level="info" additivity="false">
             <AppenderRef ref="RollingFile"/>
-        </Logger>
-
-        <!-- 에러 Logger-->
-        <Logger name="errorLogger" level="error" additivity="false">
-            <AppenderRef ref="RollingErrorFile"/>
         </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
## 📌 변경 내용 & 이유
중앙 집중식 로그 관리 시스템 **Loki 도입에 맞춰 Log4j2 설정을 최적화**했습니다.

-   **로그 파일 단일화 (`error.log` 제거)**
    - 기존에 `all-level.log`와 `error.log`로 분리되어 있던 로그 파일을 `all-level.log` 하나로 통합했습니다.
    - **(이유)** Promtail이 단일 로그 스트림을 수집하고, Grafana(Loki)에서 `level` 레이블을 통해 에러를 필터링하는 것이 중앙 집중식 환경에 더 효율적이기 때문입니다.

-   **JSON 로그에 MDC 컨텍스트 정보 추가**
    - `JsonLayout`에 `properties="true"` 속성을 추가했습니다.
    - **(이유)** 향후 분산 추적 시스템(Tempo) 연동 시, `traceId`와 같은 요청 컨텍스트 정보를 로그에 포함시켜 추적성을 높이기 위함입니다.

-   **로그 롤오버(Rollover) 정책 수정**
    - 로그 파일의 압축 형식을 `.zip`에서 `.gz`로 변경하고, 서버 보관 주기를 3일로 단축했습니다.
    - **(이유)** 로그의 영구 보관은 Loki가 담당하므로, EC2 서버에서는 디스크 공간 효율을 위해 최소한의 기간만 로그를 유지하도록 변경했습니다.

## 📸 스크린샷 (선택)
<img width="1507" height="824" alt="image" src="https://github.com/user-attachments/assets/7b8ad313-e5ae-493c-be32-c5c2e4769c05" />

## 📢 논의하고 싶은 내용
기존 `LoggingAspect` 코드와의 호환성을 유지하고, **콘솔(디버깅용)과 파일(수집용) 로그의 출력 형식을 다르게 가져가기 위해** `consoleLogger`와 `jsonLogger`를 분리하는 구조는 그대로 유지했습니다.

## 🧩 관련 이슈
close #648 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 없음

- 리팩터
  - 로그 구성 단순화: 에러 전용 로거/파일 제거하고 단일 로그 채널로 통합
  - 에러 로그를 포함해 모든 로그를 JSON 로깅으로 일원화하고 추가 속성 기록 지원

- 잡무(Chores)
  - 로그 파일명 형식을 app-YYYY-MM-DD.log.gz로 변경
  - 로그 보관 정책을 3일로 단축해 기간 경과 파일 자동 삭제
  - 메트릭 환경 태그 키를 management.metrics.tags.env로 이름 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->