### PR TITLE
[BE] feat: DB Replication 어노테이션 기반 설정 추가

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -30,6 +30,8 @@ jobs:
       MYSQL_TEST_USER_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
+      MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+      MYSQL_WRITER_ENDPOINT: ${{ secrets.MYSQL_WRITER_ENDPOINT }}
 
     steps:
       - name: Checkout source

--- a/.github/workflows/backend-dev-ci.yml
+++ b/.github/workflows/backend-dev-ci.yml
@@ -33,6 +33,8 @@ jobs:
       MYSQL_TEST_USER_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
+      MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+      MYSQL_WRITER_ENDPOINT: ${{ secrets.MYSQL_WRITER_ENDPOINT }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -30,6 +30,8 @@ jobs:
       MYSQL_TEST_USER_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
+      MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+      MYSQL_WRITER_ENDPOINT: ${{ secrets.MYSQL_WRITER_ENDPOINT }}
 
     steps:
       - name: Checkout source

--- a/.github/workflows/backend-prod-ci.yml
+++ b/.github/workflows/backend-prod-ci.yml
@@ -33,6 +33,8 @@ jobs:
       MYSQL_TEST_USER_PASSWORD: ${{ secrets.MYSQL_TEST_USER_PASSWORD }}
       TEST_MYSQL_PORT: ${{ secrets.TEST_MYSQL_PORT }}
       DB_MYSQL_HOST: ${{ secrets.DB_MYSQL_HOST }}
+      MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+      MYSQL_WRITER_ENDPOINT: ${{ secrets.MYSQL_WRITER_ENDPOINT }}
 
     steps:
       - name: Checkout

--- a/backend/app/src/main/java/com/onair/hearit/app/bookmark/application/BookmarkService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/bookmark/application/BookmarkService.java
@@ -35,6 +35,7 @@ public class BookmarkService {
     private final MemberRepository memberRepository;
     private final BookmarkRepository bookmarkRepository;
 
+    @Transactional(readOnly = true)
     public PagedResponse<BookmarkHearitResponseV2> getBookmarkHearits(UserInfo userInfo,
                                                                       PagingRequest pagingRequest,
                                                                       BookmarkFilter filter,
@@ -50,6 +51,7 @@ public class BookmarkService {
     }
 
     /*will be deprecated after the client update*/
+    @Transactional(readOnly = true)
     public PagedResponse<BookmarkHearitResponseV2> getBookmarkHearitsV2(UserInfo userInfo,
                                                                         PagingRequest pagingRequest,
                                                                         BookmarkFilter filter) {

--- a/backend/app/src/main/java/com/onair/hearit/app/category/application/CategoryService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/category/application/CategoryService.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +18,7 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
+    @Transactional(readOnly = true)
     public PagedResponse<CategoryResponse> getCategories(PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Category> categories = categoryRepository.findAll(pageable);

--- a/backend/app/src/main/java/com/onair/hearit/app/explore/application/HearitExploreService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/explore/application/HearitExploreService.java
@@ -8,6 +8,7 @@ import com.onair.hearit.core.domain.UserInfo;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/app/src/main/java/com/onair/hearit/app/explore/application/scoreprocessor/AbstractExploreScoreProcessor.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/explore/application/scoreprocessor/AbstractExploreScoreProcessor.java
@@ -15,22 +15,25 @@ import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractExploreScoreProcessor implements ExploreScoreProcessor {
 
     protected static final int KEYWORDS_PER_HEARIT_FOR_RANDOM = 5;
+
     protected final HearitKeywordRepository hearitKeywordRepository;
     private final ExploreScoreInitializer exploreScoreInitializer;
     private final ExploredHearitQueryRepository exploredHearitQueryRepository;
 
     @Override
-    public final void refreshScores(UserInfo userInfo, long cursorId) {
+    public void refreshScores(UserInfo userInfo, long cursorId) {
         exploreScoreInitializer.refreshScores(cursorId, getUserUuid(userInfo), userInfo.getUserType());
     }
 
     @Override
-    public final List<ExploredHearitResponse> getExploreHearits(UserInfo userInfo, long cursorId, int size) {
+    @Transactional(readOnly = true)
+    public List<ExploredHearitResponse> getExploreHearits(UserInfo userInfo, long cursorId, int size) {
         String userUuid = getUserUuid(userInfo);
         List<ExploredHearitProjection> exploredHearitProjections =
                 exploredHearitQueryRepository.findExploredHearits(userUuid, cursorId, Pageable.ofSize(size));

--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitSearchService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitSearchService.java
@@ -24,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +35,7 @@ public class HearitSearchService {
     private final MemberRepository memberRepository;
     private final PlayingHistoryRepository playingHistoryRepository;
 
+    @Transactional(readOnly = true)
     public PagedResponse<HearitSearchResponse> search(String searchTerm, PagingRequest pagingRequest,
                                                       UserInfo userInfo) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());

--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitService.java
@@ -30,6 +30,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +44,7 @@ public class HearitService {
     private final HearitKeywordRepository hearitKeywordRepository;
     private final PlayingHistoryRepository playingHistoryRepository;
 
+    @Transactional(readOnly = true)
     public HearitDetailResponse getHearitDetail(Long hearitId, UserInfo userInfo) {
         Hearit hearit = getHearitById(hearitId);
         List<Keyword> keywords = hearitKeywordRepository.findKeywordsByHearitId(hearit.getId());
@@ -90,6 +92,7 @@ public class HearitService {
                 .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
     }
 
+    @Transactional(readOnly = true)
     public PagedResponse<HearitOverviewResponse> getFilteredHearits(
             Long categoryId, HearitSortRequest sortRequest, UserInfo userInfo, PagingRequest pagingRequest) {
         Long memberId = (userInfo == null || userInfo.isGuest()) ? null : userInfo.getMemberId();

--- a/backend/app/src/main/java/com/onair/hearit/app/keyword/application/KeywordService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/keyword/application/KeywordService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ public class KeywordService {
 
     private final KeywordRepository keywordRepository;
 
+    @Transactional(readOnly = true)
     public List<KeywordResponse> getKeywords(PagingRequest pagingRequest) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Keyword> keywords = keywordRepository.findAll(pageable);

--- a/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
@@ -1,12 +1,12 @@
 package com.onair.hearit.app.playinghistory.application;
 
+import com.onair.hearit.app.exception.custom.NotFoundException;
 import com.onair.hearit.app.playinghistory.dto.PlayingHistoryRequest;
 import com.onair.hearit.app.playinghistory.dto.RecentlyPlayedHearitResponse;
 import com.onair.hearit.app.playinghistory.infrastructure.scheduler.PlayingHistoryBuffer;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.domain.UserInfo;
-import com.onair.hearit.app.exception.custom.NotFoundException;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import java.util.Collections;
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class PlayingHistoryService {
     private final PlayingHistoryRepository playingHistoryRepository;
     private final PlayingHistoryBuffer playingHistoryBuffer;
 
+    @Transactional(readOnly = true)
     public List<RecentlyPlayedHearitResponse> getRecentPlayingHistory(UserInfo userInfo) {
         if (userInfo == null || userInfo.isGuest()) {
             return Collections.emptyList();

--- a/backend/app/src/main/java/com/onair/hearit/app/recommendation/application/RecommendationService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/recommendation/application/RecommendationService.java
@@ -8,6 +8,7 @@ import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +17,7 @@ public class RecommendationService {
     private final CategoryRecommender categoryRecommender;
     private final HearitRepository hearitRepository;
 
+    @Transactional(readOnly = true)
     public List<RecommendationByCategoryResponse> getCategoryRecommendations(UserInfo userInfo,
                                                                              int categorySize,
                                                                              int hearitSize) {

--- a/backend/app/src/main/java/com/onair/hearit/app/recommendhearit/application/RecommendHearitService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/recommendhearit/application/RecommendHearitService.java
@@ -6,6 +6,7 @@ import com.onair.hearit.core.domain.Hearit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +16,7 @@ public class RecommendHearitService {
 
     private final RecommendHearitStrategy recommendHearitStrategy;
 
+    @Transactional(readOnly = true)
     public List<RecommendHearitResponse> getRecommendedHearits() {
         List<Hearit> recommendHearits = recommendHearitStrategy.getRecommendHearit(RECOMMEND_HEARIT_COUNT);
         return recommendHearits.stream()

--- a/backend/app/src/test/java/com/onair/hearit/app/explore/application/ExploreScoreCalculatorTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/explore/application/ExploreScoreCalculatorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.onair.hearit.app.explore.application.scorefactor.ScoreFactor;
 import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.UserType;
@@ -30,7 +31,7 @@ import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
 @Sql("/dbclean.sql")
-@Import({DbHelper.class, TestJpaAuditingConfig.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class})
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 class ExploreScoreCalculatorTest {

--- a/backend/app/src/test/java/com/onair/hearit/app/explore/application/ExploreScoreInitializerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/explore/application/ExploreScoreInitializerTest.java
@@ -8,6 +8,7 @@ import com.onair.hearit.app.explore.application.scorefactor.DefaultRandomNumberG
 import com.onair.hearit.app.explore.application.scorefactor.RandomScoreFactor;
 import com.onair.hearit.app.explore.application.scorefactor.RecencyScoreFactor;
 import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.UserType;
@@ -30,7 +31,7 @@ import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
 @Sql("/dbclean.sql")
-@Import({DbHelper.class, TestJpaAuditingConfig.class, ExploreScoreCommandRepository.class,
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class, ExploreScoreCommandRepository.class,
         DefaultRandomNumberGenerator.class, RandomScoreFactor.class, RecencyScoreFactor.class,
         BookmarkScoreFactor.class, ExploreScoreCalculator.class})
 @ActiveProfiles("integration-test")

--- a/backend/app/src/test/java/com/onair/hearit/app/explore/application/HearitExploreServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/explore/application/HearitExploreServiceTest.java
@@ -69,7 +69,6 @@ class HearitExploreServiceTest {
                 List.of(guestExploreScoreProcessor, memberExploreScoreProcessor));
     }
 
-
     @DisplayName("회원이 처음 탐색 요청 시(cursorId=0), 최신, 랜덤, 북마크 점수 순으로 정렬하여 반환한다")
     @Test
     void getExploredHearitsForMember_firstRequest() {

--- a/backend/app/src/test/java/com/onair/hearit/app/explore/application/HearitExploreServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/explore/application/HearitExploreServiceTest.java
@@ -14,6 +14,7 @@ import com.onair.hearit.app.explore.dto.CursorRequest;
 import com.onair.hearit.app.explore.dto.CursorResponseV2;
 import com.onair.hearit.app.explore.dto.ExploredHearitResponse;
 import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Bookmark;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
@@ -40,9 +41,10 @@ import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
 @Sql("/dbclean.sql")
-@Import({DbHelper.class, TestJpaAuditingConfig.class, RandomScoreFactor.class, RecencyScoreFactor.class,
-        BookmarkScoreFactor.class, ExploreScoreCalculator.class, ExploreScoreCommandRepository.class,
-        ExploreScoreInitializer.class, GuestExploreScoreProcessor.class, MemberExploreScoreProcessor.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class, RandomScoreFactor.class,
+        RecencyScoreFactor.class, BookmarkScoreFactor.class, ExploreScoreCalculator.class,
+        ExploreScoreCommandRepository.class, ExploreScoreInitializer.class, GuestExploreScoreProcessor.class,
+        MemberExploreScoreProcessor.class})
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 class HearitExploreServiceTest {

--- a/backend/app/src/test/java/com/onair/hearit/app/explore/application/scoreprocessor/GuestExploreScoreProcessorTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/explore/application/scoreprocessor/GuestExploreScoreProcessorTest.java
@@ -11,6 +11,7 @@ import com.onair.hearit.app.explore.application.scorefactor.RandomScoreFactor;
 import com.onair.hearit.app.explore.application.scorefactor.RecencyScoreFactor;
 import com.onair.hearit.app.explore.dto.ExploredHearitResponse;
 import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.ExploreScore;
 import com.onair.hearit.core.domain.Hearit;
@@ -36,9 +37,9 @@ import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
 @Sql("/dbclean.sql")
-@Import({DbHelper.class, TestJpaAuditingConfig.class, RandomScoreFactor.class, RecencyScoreFactor.class,
-        BookmarkScoreFactor.class, ExploreScoreCalculator.class, ExploreScoreCommandRepository.class,
-        ExploreScoreInitializer.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class, RandomScoreFactor.class,
+        RecencyScoreFactor.class, BookmarkScoreFactor.class, ExploreScoreCalculator.class,
+        ExploreScoreCommandRepository.class, ExploreScoreInitializer.class})
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 class GuestExploreScoreProcessorTest {

--- a/backend/app/src/test/java/com/onair/hearit/app/explore/application/scoreprocessor/MemberExploreScoreProcessorTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/explore/application/scoreprocessor/MemberExploreScoreProcessorTest.java
@@ -11,6 +11,7 @@ import com.onair.hearit.app.explore.application.scorefactor.RandomScoreFactor;
 import com.onair.hearit.app.explore.application.scorefactor.RecencyScoreFactor;
 import com.onair.hearit.app.explore.dto.ExploredHearitResponse;
 import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.ExploreScore;
 import com.onair.hearit.core.domain.Hearit;
@@ -39,9 +40,9 @@ import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
 @Sql("/dbclean.sql")
-@Import({DbHelper.class, TestJpaAuditingConfig.class, RandomScoreFactor.class, RecencyScoreFactor.class,
-        BookmarkScoreFactor.class, ExploreScoreCalculator.class, ExploreScoreCommandRepository.class,
-        ExploreScoreInitializer.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class, RandomScoreFactor.class,
+        RecencyScoreFactor.class, BookmarkScoreFactor.class, ExploreScoreCalculator.class,
+        ExploreScoreCommandRepository.class, ExploreScoreInitializer.class})
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 class MemberExploreScoreProcessorTest {

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitSearchServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitSearchServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import com.onair.hearit.core.domain.Category;
@@ -37,7 +38,7 @@ import org.springframework.test.context.transaction.TestTransaction;
 @Sql("/dbclean.sql")
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({DbHelper.class, TestJpaAuditingConfig.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class})
 class HearitSearchServiceTest {
 
     @Autowired

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.auth.domain.RequestUser;
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import com.onair.hearit.core.domain.Category;
@@ -38,8 +39,8 @@ import org.springframework.test.context.jdbc.Sql;
 @Sql("/dbclean.sql")
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({DbHelper.class, TestJpaAuditingConfig.class, PlayingHistoryBuffer.class,
-        PlayingHistoryCommandRepository.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class,
+        PlayingHistoryBuffer.class, PlayingHistoryCommandRepository.class})
 class PlayingHistoryServiceTest {
 
     @Autowired

--- a/backend/boot/src/main/resources/application-dev.properties
+++ b/backend/boot/src/main/resources/application-dev.properties
@@ -4,11 +4,22 @@
 # secret import
 spring.config.import=optional:file:.env[.properties]
 
-# Dev-DataSource
-spring.datasource.url=jdbc:mysql://${MYSQL_WRITER_ENDPOINT}:${MYSQL_PORT}/${MYSQL_DATABASE}?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=${MYSQL_WRITER}
-spring.datasource.password=${MYSQL_WRITER_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+# DataSource
+# ==================================
+# Master (Primary)
+# ==================================
+spring.datasource.master.jdbc-url=jdbc:mysql://${MYSQL_WRITER_ENDPOINT}:${MYSQL_PORT}/${MYSQL_DATABASE}?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.master.username=${MYSQL_WRITER_USERNAME}
+spring.datasource.master.password=${MYSQL_WRITER_PASSWORD}
+spring.datasource.master.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# ==================================
+# Slave (Replica)
+# ==================================
+spring.datasource.slave.jdbc-url=jdbc:mysql://${MYSQL_READER_ENDPOINT}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.slave.username=${MYSQL_READER_USERNAME}
+spring.datasource.slave.password=${MYSQL_READER_PASSWORD}
+spring.datasource.slave.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
@@ -43,6 +54,7 @@ logging.config=classpath:log4j2/log4j2.xml
 server.forward-headers-strategy=native
 
 # Flyaway
+spring.flyway.url=jdbc:mysql://${MYSQL_WRITER_ENDPOINT}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.flyway.user=${MYSQL_MIGRATION_USER}
 spring.flyway.password=${MYSQL_MIGRATION_PASSWORD}
 spring.flyway.baseline-on-migrate=true

--- a/backend/boot/src/main/resources/application-dev.properties
+++ b/backend/boot/src/main/resources/application-dev.properties
@@ -14,12 +14,12 @@ spring.datasource.master.password=${MYSQL_WRITER_PASSWORD}
 spring.datasource.master.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # ==================================
-# Slave (Replica)
+# Replica
 # ==================================
-spring.datasource.slave.jdbc-url=jdbc:mysql://${MYSQL_READER_ENDPOINT}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.slave.username=${MYSQL_READER_USERNAME}
-spring.datasource.slave.password=${MYSQL_READER_PASSWORD}
-spring.datasource.slave.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.replica.jdbc-url=jdbc:mysql://${MYSQL_READER_ENDPOINT}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.replica.username=${MYSQL_READER_USERNAME}
+spring.datasource.replica.password=${MYSQL_READER_PASSWORD}
+spring.datasource.replica.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect

--- a/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
@@ -13,11 +13,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 @Configuration
-//@Profile("!integration-test")
 public class DataSourceConfig {
 
     public static final String MASTER_PROPERTY = "spring.datasource.master";

--- a/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
@@ -1,0 +1,64 @@
+package com.onair.hearit.core.config;
+
+import com.onair.hearit.core.infrastructure.datasource.DataSourceType;
+import com.onair.hearit.core.infrastructure.datasource.RoutingDataSource;
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+@Profile("!integration-test")
+public class DataSourceConfig {
+
+    public static final String MASTER_PROPERTY = "spring.datasource.master";
+    public static final String SLAVE_PROPERTY = "spring.datasource.slave";
+
+    @Bean
+    @ConfigurationProperties(MASTER_PROPERTY)
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    @ConfigurationProperties(SLAVE_PROPERTY)
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    @DependsOn({"masterDataSource", "slaveDataSource"})
+    public DataSource routingDataSource(
+            @Qualifier("masterDataSource") DataSource master,
+            @Qualifier("slaveDataSource") DataSource slave) {
+        Map<Object, Object> dataSources = new HashMap<>();
+        dataSources.put(DataSourceType.MASTER, master);
+        dataSources.put(DataSourceType.SLAVE, slave);
+
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+        routingDataSource.setDefaultTargetDataSource(master);
+        routingDataSource.setTargetDataSources(dataSources);
+        routingDataSource.afterPropertiesSet();
+        return routingDataSource;
+    }
+
+    @Bean
+    @Primary
+    @DependsOn("routingDataSource")
+    public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+}

--- a/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
@@ -41,10 +41,10 @@ public class DataSourceConfig {
     @DependsOn({"masterDataSource", "replicaDataSource"})
     public DataSource routingDataSource(
             @Qualifier("masterDataSource") DataSource master,
-            @Qualifier("replicaDataSource") DataSource slave) {
+            @Qualifier("replicaDataSource") DataSource replica) {
         Map<Object, Object> dataSources = new HashMap<>();
         dataSources.put(DataSourceType.MASTER, master);
-        dataSources.put(DataSourceType.REPLICA, slave);
+        dataSources.put(DataSourceType.REPLICA, replica);
 
         RoutingDataSource routingDataSource = new RoutingDataSource();
         routingDataSource.setDefaultTargetDataSource(master);

--- a/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
@@ -17,11 +17,11 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 
 @Configuration
-@Profile("!integration-test")
+//@Profile("!integration-test")
 public class DataSourceConfig {
 
     public static final String MASTER_PROPERTY = "spring.datasource.master";
-    public static final String SLAVE_PROPERTY = "spring.datasource.slave";
+    public static final String REPLICA_PROPERTY = "spring.datasource.replica";
 
     @Bean
     @ConfigurationProperties(MASTER_PROPERTY)
@@ -32,21 +32,21 @@ public class DataSourceConfig {
     }
 
     @Bean
-    @ConfigurationProperties(SLAVE_PROPERTY)
-    public DataSource slaveDataSource() {
+    @ConfigurationProperties(REPLICA_PROPERTY)
+    public DataSource replicaDataSource() {
         return DataSourceBuilder.create()
                 .type(HikariDataSource.class)
                 .build();
     }
 
     @Bean
-    @DependsOn({"masterDataSource", "slaveDataSource"})
+    @DependsOn({"masterDataSource", "replicaDataSource"})
     public DataSource routingDataSource(
             @Qualifier("masterDataSource") DataSource master,
-            @Qualifier("slaveDataSource") DataSource slave) {
+            @Qualifier("replicaDataSource") DataSource slave) {
         Map<Object, Object> dataSources = new HashMap<>();
         dataSources.put(DataSourceType.MASTER, master);
-        dataSources.put(DataSourceType.SLAVE, slave);
+        dataSources.put(DataSourceType.REPLICA, slave);
 
         RoutingDataSource routingDataSource = new RoutingDataSource();
         routingDataSource.setDefaultTargetDataSource(master);

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/datasource/DataSourceType.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/datasource/DataSourceType.java
@@ -1,0 +1,6 @@
+package com.onair.hearit.core.infrastructure.datasource;
+
+public enum DataSourceType {
+    MASTER,
+    SLAVE;
+}

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/datasource/DataSourceType.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/datasource/DataSourceType.java
@@ -2,5 +2,5 @@ package com.onair.hearit.core.infrastructure.datasource;
 
 public enum DataSourceType {
     MASTER,
-    SLAVE;
+    REPLICA;
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/datasource/RoutingDataSource.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/datasource/RoutingDataSource.java
@@ -8,7 +8,7 @@ public class RoutingDataSource extends AbstractRoutingDataSource {
     protected Object determineCurrentLookupKey() {
         boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
         if (isReadOnly) {
-            return DataSourceType.SLAVE;
+            return DataSourceType.REPLICA;
         }
         return DataSourceType.MASTER;
     }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/datasource/RoutingDataSource.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/datasource/RoutingDataSource.java
@@ -1,0 +1,15 @@
+package com.onair.hearit.core.infrastructure.datasource;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        if (isReadOnly) {
+            return DataSourceType.SLAVE;
+        }
+        return DataSourceType.MASTER;
+    }
+}

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jdbc/ExploreScoreCommandRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jdbc/ExploreScoreCommandRepositoryTest.java
@@ -3,6 +3,7 @@ package com.onair.hearit.core.infrastructure.jdbc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.Member;
@@ -22,7 +23,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
-@Import({ExploreScoreCommandRepository.class, DbHelper.class, TestJpaAuditingConfig.class})
+@Import({ExploreScoreCommandRepository.class, DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class})
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 public class ExploreScoreCommandRepositoryTest {

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositorySearchTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositorySearchTest.java
@@ -3,6 +3,7 @@ package com.onair.hearit.core.infrastructure.jpa;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.HearitKeyword;
@@ -30,7 +31,7 @@ import org.springframework.test.context.transaction.TestTransaction;
 @Sql("/dbclean.sql")
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({DbHelper.class, TestJpaAuditingConfig.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class})
 public class HearitRepositorySearchTest {
 
     @Autowired

--- a/backend/core/src/testFixtures/resources/application-integration-test.properties
+++ b/backend/core/src/testFixtures/resources/application-integration-test.properties
@@ -1,11 +1,22 @@
 # secret import
 spring.config.import=optional:file:../.env[.properties]
 
-# Dev-DataSource
-spring.datasource.url=jdbc:mysql://localhost:13307/hearit_db?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=root
-spring.datasource.password=${MYSQL_TEST_USER_PASSWORD}
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+# DataSource
+# ==================================
+# Master (Primary)
+# ==================================
+spring.datasource.master.jdbc-url=jdbc:mysql://${MYSQL_WRITER_ENDPOINT}:${TEST_MYSQL_PORT}/${MYSQL_DATABASE}?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.master.username=root
+spring.datasource.master.password=${MYSQL_TEST_USER_PASSWORD}
+spring.datasource.master.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# ==================================
+# Replica
+# ==================================
+spring.datasource.replica.jdbc-url=jdbc:mysql://${MYSQL_WRITER_ENDPOINT}:${TEST_MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.replica.username=root
+spring.datasource.replica.password=${MYSQL_TEST_USER_PASSWORD}
+spring.datasource.replica.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Dev-JPA
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- Master/Replica 구조의 DataSource 구성 적용
  - 기존 단일 DB 연결 구조에서 Master/Replica 분리 구조로 변경했습니다.
  - RoutingDataSource를 통해 트랜잭션의 readOnly 여부에 따라 DB 연결을 동적으로 분기합니다.
    - readOnly = true → Replica
    - 그 외 → Master
- 테스트 환경에서도 Replication 적용
    - integration-test 프로필에서도 실제 MySQL Master/Replica 구조를 반영하도록 설정했습니다.
    - 테스트 시에는 master DB에서만 동작합니다.
- 조회 서비스 메서드에 `@Transactional(readOnly = true)` 적용
    - 조회 로직의 성능 최적화 및 의도 명시를 위해, 읽기 전용 트랜잭션 설정을 추가했습니다.
    - 이로써 읽기 요청은 자동으로 Replica DB로 분기됩니다.

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->
현재 `@Transactional(readOnly = true)` 기반으로만 라우팅하고 있는데, 명시적으로 Master를 강제할 수 있는 
커스텀 어노테이션 도입 시기에 대한 검토가 필요합니다.

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #653 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 주요 읽기 API들에 읽기 전용 트랜잭션을 적용하고 일부 탐색/스코어 처리 메서드의 오버라이드 허용을 개선했습니다.

* **Chores**
  * 마스터/리플리카 멀티 데이터소스와 라우팅(읽기 전용일 때 리플리카 사용) 구성을 도입하고 개발 설정과 CI 환경 변수 구성을 업데이트했습니다.

* **Tests**
  * 통합/단위 테스트의 스프링 컨텍스트에 새 데이터소스 구성을 포함하도록 테스트 설정을 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->