### PR TITLE
[BE] fix: CD 워크플로우에서 'chmod' 실행 시 권한 오류 발생 

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -75,7 +75,7 @@ jobs:
           path: ~/hearit
 
       - name: Make deploy script executable
-        run: chmod +x ~/hearit/deploy.sh
+        run: sudo chmod +x ~/hearit/deploy.sh
 
       - name: Run deploy script with sudo
         run: sudo bash ~/hearit/deploy.sh

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -75,7 +75,7 @@ jobs:
           path: ~/hearit
 
       - name: Make deploy script executable
-        run: chmod +x ~/hearit/deploy.sh
+        run: sudo chmod +x ~/hearit/deploy.sh
 
       - name: Run deploy script with sudo
         run: sudo bash ~/hearit/deploy.sh


### PR DESCRIPTION

### 🐞 버그 설명

GitHub Actions를 통한 개발/운영 서버 CD(지속적 배포) 워크플로우가 `Make deploy script executable` 단계에서 실패하고 있습니다.

**원인 분석:**

1.  **실행 주체:** EC2의 Self-hosted Runner는 `ubuntu` 사용자 권한으로 워크플로우를 실행합니다.
2.  **대상 파일:** 배포 대상인 `~/hearit/deploy.sh` 스크립트 파일의 소유주(owner)가 `root`로 설정되어 있습니다.
3.  **권한 충돌:** 일반 유저인 `ubuntu`가 `root` 소유 파일의 권한을 변경(`chmod`)하려고 시도하기 때문에, `Operation not permitted` 오류가 발생하며 워크플로우가 중단됩니다.

서버 내 스크립트는 `root` 권한으로 관리되어야 합니다.

### ✅ 기대 동작

`ubuntu` 권한으로 실행되는 워크플로우가 `root` 소유의 `deploy.sh` 파일에 실행 권한(`+x`)을 부여하고, 배포 스크립트를 정상적으로 실행하여 CD 파이프라인이 성공적으로 완료되어야 합니다.

### 🛠️ 해결 방안

워크플로우 파일(`.github/workflows/*.yml`)의 `Make deploy script executable` 단계에서 `chmod` 명령어를 `sudo`를 통해 실행하도록 수정합니다.

이렇게 수정하면 `ubuntu` 유저(Runner)가 `sudo`를 통해 일시적으로 관리자 권한을 얻어, `root` 소유 파일의 권한을 정상적으로 변경할 수 있게 됩니다.

  * **수정 전:**

    ```yaml
      - name: Make deploy script executable
        run: chmod +x ~/hearit/deploy.sh
    ```

  * **수정 후:**

    ```yaml
      - name: Make deploy script executable
        run: sudo chmod +x ~/hearit/deploy.sh
    ```

### 📎 관련 이슈/커밋

*(관련된 이슈 번호나 커밋 해시를 여기에 추가하세요)*

### 🧩 관련 로그/화면 (선택)

```
Run chmod +x ~/hearit/deploy.sh
chmod: changing permissions of '/home/ubuntu/hearit/deploy.sh': Operation not permitted
Error: Process completed with exit code 1.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 및 프로덕션 배포 파이프라인에서 배포 스크립트 실행 권한 처리 방식을 보강해 실행 안정성과 일관성을 개선했습니다.
  * 배포 단계의 실행 컨텍스트를 정리하여 환경에 따라 발생할 수 있는 권한 관련 오류를 예방했습니다.
  * 서비스 기능과 UI에는 변화가 없으며, 배포 신뢰성 향상을 통해 전반적인 가동 안정성을 높였습니다.
  * 운영 흐름과 산출물 처리에는 영향 없이 배포 단계의 실행 안정성만 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->