### PR TITLE
[BE] fix: 탐색 API 트랜잭션 readOnly=true 전파 문제 해결 #661

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/explore/application/HearitExploreService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/explore/application/HearitExploreService.java
@@ -16,6 +16,7 @@ public class HearitExploreService {
 
     private final List<ExploreScoreProcessor> exploreScoreProcessors;
 
+    @Transactional
     public CursorResponseV2<ExploredHearitResponse> getExploredHearits(UserInfo userInfo,
                                                                        CursorRequest cursorRequest) {
         ExploreScoreProcessor exploreScoreProcessor = getExploreScoreProcessor(userInfo);


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
ExploreScoreInitializer의 refreshScores() 메서드 내부에서
`@transactional`을 사용했음에도 불구하고, 초기 탐색 요청(cursorId = 0) 시에만 수행되어야 하는 insert 쿼리가
의도대로 MASTER로 라우팅 되지 않는 문제가 발생했습니다.

원인은 LazyConnectionDataSourceProxy를 사용하면서 sql 쿼리 실행 시점에 DataSource가 선택되면서,
JPA repository에 붙어 있는 readOnly=true 설정에 따르게 되어 발생했습니다.

따라서 탐색 서비스 로직에 트랜잭션을 명시적으로 붙여 Master DB로 가게 하고
추후 커스텀 어노테이션과 트랜잭션 전파 설정을 통해 추가 성능 최적화도 진행하고자 합니다.

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #661 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 탐색 기능 실행 중 발생하던 간헐적 데이터 불일치와 부분 저장 문제를 방지해 결과의 신뢰성을 높였습니다.
  * 예외 발생 시 작업이 안전하게 롤백되도록 개선하여 오류로 인한 상태 꼬임 가능성을 줄였습니다.
  * 데이터 조회·처리 과정의 일관성을 강화해 탐색 결과의 안정성과 예측 가능성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->