### PR TITLE
[BE] chore: bump version to 1.2.3 #664

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -11,7 +11,7 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
 
     group = 'com.onair'
-    version = '1.2.2'
+    version = '1.2.3'
 
     java {
         toolchain {


### PR DESCRIPTION
bump version Only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * 백엔드 버전을 1.2.2 → 1.2.3으로 상향했습니다. 기능 변경은 없습니다.
  * 배포 아티팩트 버전 일관성을 개선해 추적성과 릴리스 관리가 용이해졌습니다.
  * 사용자 경험과 API 동작에는 영향이 없으며, 추가 설정이나 조치는 필요하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->