### PR TITLE
[BE] chore: CD 워크플로우 jar 선택 로직 수정 및 Datasource 이름 명시 #667

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -46,9 +46,9 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Build with Gradle
+      - name: Build executable Spring Boot jar
         working-directory: backend
-        run: ./gradlew clean build
+        run: ./gradlew clean :boot:bootJar
 
       - name: Rename jar to app.jar
         working-directory: backend/boot/build/libs

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -46,14 +46,14 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      - name: Build with Gradle
+      - name: Build executable Spring Boot jar
         working-directory: backend
-        run: ./gradlew clean build
+        run: ./gradlew clean :boot:bootJar
 
       - name: Rename jar to app.jar
         working-directory: backend/boot/build/libs
         run: |
-          JAR_NAME=$(ls *.jar | head -n 1)
+          JAR_NAME=$(find . -name "*.jar" ! -name "*-plain.jar")
           mv "$JAR_NAME" app.jar
 
       - name: Upload jar artifact

--- a/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/config/DataSourceConfig.java
@@ -24,17 +24,21 @@ public class DataSourceConfig {
     @Bean
     @ConfigurationProperties(MASTER_PROPERTY)
     public DataSource masterDataSource() {
-        return DataSourceBuilder.create()
+        HikariDataSource ds = DataSourceBuilder.create()
                 .type(HikariDataSource.class)
                 .build();
+        ds.setPoolName(MASTER_PROPERTY);
+        return ds;
     }
 
     @Bean
     @ConfigurationProperties(REPLICA_PROPERTY)
     public DataSource replicaDataSource() {
-        return DataSourceBuilder.create()
+        HikariDataSource ds = DataSourceBuilder.create()
                 .type(HikariDataSource.class)
                 .build();
+        ds.setPoolName(REPLICA_PROPERTY);
+        return ds;
     }
 
     @Bean


### PR DESCRIPTION
## 📌 변경 내용 & 이유
- 기존 prod-CD에서 plain.jar가 잘못 배포되어 no main manifest attribute 오류 발생
- dev-CD와 동일하게 bootJar만 빌드하도록 수정 (`./gradlew clean :boot:bootJar`)
- plain.jar 제외 조건(! -name "*-plain.jar") 유지하여 실행 가능한 jar만 업로드
- CI/CD 간 jar 선택 로직 일관성 확보
- Master/Replica DataSource 이름 명시

## 🧩 관련 이슈
close #667 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능: 해당 없음
- 개선
  - 데이터베이스 연결 풀에 명시적 풀 이름을 부여하여 모니터링과 운영 가시성을 향상하고 안정성을 개선했습니다.
- 작업(Chores)
  - 배포 파이프라인을 정비해 실행형 애플리케이션 패키지만 생성하도록 조정했습니다.
  - 배포 아티팩트 선택 로직을 개선하여 보다 일관된 파일이 사용되도록 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->