### PR TITLE
[BE] release: 1.3.1

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/auth/domain/RequestUser.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/auth/domain/RequestUser.java
@@ -21,9 +21,8 @@ public class RequestUser {
     }
 
     public static RequestUser guest(String guestId) {
-
         if (guestId == null || guestId.isBlank()) {
-            log.warn("현재 X-Device-UUID Header가 비어있습니다.");
+            log.warn("현재 Device-Uuid Header가 비어있습니다.");
             return new RequestUser(null, FALLBACK_GUEST_ID);
         }
         return new RequestUser(null, guestId);

--- a/backend/app/src/main/java/com/onair/hearit/app/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -28,7 +28,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    @Deprecated(since = "android version 1.3.0", forRemoval = true)
     private static final String DEVICE_UUID_HEADER = "X-Device-UUID";
+
+    private static final String DEVICE_UUID_HEADER_V2 = "Device-Uuid";
 
     private final JsonLogger jsonLogger;
     private final ConsoleLogger consoleLogger;
@@ -41,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
-
+        MDC.put("loggedByAop", "true");
         try {
             String token = extractTokenFromHeader(request.getHeader("Authorization"));
 
@@ -79,7 +82,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void authenticateAsGuest(HttpServletRequest request) {
-        String deviceUuid = request.getHeader(DEVICE_UUID_HEADER);
+        String deviceUuid = getDeviceUuid(request);
         RequestUser guestUser = RequestUser.guest(deviceUuid);
 
         setMdcForUser(guestUser);
@@ -87,6 +90,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UsernamePasswordAuthenticationToken auth =
                 new UsernamePasswordAuthenticationToken(guestUser, null, null);
         SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    private static String getDeviceUuid(HttpServletRequest request) {
+        String deviceUuid = request.getHeader(DEVICE_UUID_HEADER_V2);
+        if (deviceUuid == null) {
+            return request.getHeader(DEVICE_UUID_HEADER);
+        }
+        return deviceUuid;
     }
 
     private void authenticateAsMember(String token) {

--- a/backend/app/src/test/java/com/onair/hearit/app/auth/config/ApiSecurityConfigTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/auth/config/ApiSecurityConfigTest.java
@@ -29,7 +29,7 @@ class ApiSecurityConfigTest extends IntegrationTest {
     void canAccessPublicGetListPathWithoutAuth() {
         // when & then
         RestAssured.given().log().all()
-                .header("X-Device-UUID", UUID.randomUUID().toString())
+                .header("Device-Uuid", UUID.randomUUID().toString())
                 .when()
                 .get("/api/v1/categories") // 인증 필요없는 경로
                 .then().log().all()

--- a/backend/boot/src/main/resources/application.properties
+++ b/backend/boot/src/main/resources/application.properties
@@ -17,3 +17,5 @@ spring.jackson.time-zone=Asia/Seoul
 # logging
 logging.config=classpath:log4j2/log4j2.xml
 server.forward-headers-strategy=native
+app.version=${version}
+

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -11,7 +11,7 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
 
     group = 'com.onair'
-    version = '1.3.0'
+    version = '1.3.1'
 
     java {
         toolchain {
@@ -26,6 +26,12 @@ subprojects {
     configurations {
         configureEach {
             exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+        }
+    }
+
+    processResources {
+        filesMatching("**/application.properties") {
+            expand(project.properties)
         }
     }
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/log/MdcSetupFilter.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/log/MdcSetupFilter.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -21,6 +22,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class MdcSetupFilter implements Filter {
 
+    @Value("${app.version}")
+    private String appVersionServer;
+
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
@@ -28,9 +32,9 @@ public class MdcSetupFilter implements Filter {
 
         MDC.put("ip", httpServletRequest.getRemoteAddr());
         MDC.put("timestamp", LocalDateTime.now(ZoneId.of("Asia/Seoul")).toString());
-        MDC.put("deviceModel", httpServletRequest.getHeader("Device-Model"));
-        MDC.put("appVersion", httpServletRequest.getHeader("App-Version"));
-        MDC.put("guestId", httpServletRequest.getHeader("X-Device-UUID"));
+        MDC.put("androidAppVersion", httpServletRequest.getHeader("App-Version"));
+        MDC.put("serverVersion", appVersionServer);
+        MDC.put("guestId", httpServletRequest.getHeader("Device-Uuid"));
 
         /* JwtAuthenticationFilter 에서 설정해주지만, filter 에러 발생 시 빈 값 방지를 위한 초기화 설정입니다. */
         MDC.put("userType", "unspecified");

--- a/backend/core/src/main/resources/log4j2/log4j2.xml
+++ b/backend/core/src/main/resources/log4j2/log4j2.xml
@@ -48,8 +48,8 @@
                 <!-- log context-->
                 <KeyValuePair key="ip" value="$${ctx:ip}"/>
                 <KeyValuePair key="timestamp" value="$${ctx:timestamp}"/>
-                <KeyValuePair key="deviceModel" value="$${ctx:deviceModel}"/>
-                <KeyValuePair key="appVersion" value="$${ctx:appVersion}"/>
+                <KeyValuePair key="androidAppVersion" value="$${ctx:androidAppVersion}"/>
+                <KeyValuePair key="serverVersion" value="$${ctx:serverVersion}"/>
 
                 <!-- user context -->
                 <KeyValuePair key="userType" value="$${ctx:userType}"/>

--- a/backend/core/src/testFixtures/java/com/onair/hearit/core/fixture/ApiTest.java
+++ b/backend/core/src/testFixtures/java/com/onair/hearit/core/fixture/ApiTest.java
@@ -18,7 +18,7 @@ public abstract class ApiTest {
     void setUp() {
         RestAssured.port = port;
         this.spec = new RequestSpecBuilder()
-                .addHeader("X-Device-UUID", UUID.randomUUID().toString())
+                .addHeader("Device-Uuid", UUID.randomUUID().toString())
                 .build();
     }
 }

--- a/backend/core/src/testFixtures/resources/application-fake-test.properties
+++ b/backend/core/src/testFixtures/resources/application-fake-test.properties
@@ -29,3 +29,4 @@ kakao.user-info.connectTimeout=2s
 kakao.user-info.readTimeout=3s
 
 spring.flyway.enabled=false
+app.version=test

--- a/backend/core/src/testFixtures/resources/application-integration-test.properties
+++ b/backend/core/src/testFixtures/resources/application-integration-test.properties
@@ -51,3 +51,5 @@ server.tomcat.max-part-count=30
 spring.flyway.url=jdbc:mysql://localhost:13307/hearit_db?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.flyway.user=root
 spring.flyway.password=root
+
+app.version=test


### PR DESCRIPTION
1.3.1 배포

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 새로운 Device-Uuid 헤더를 지원합니다. 기존 X-Device-UUID는 하위 호환으로 계속 동작합니다.
  * 로그에 androidAppVersion, serverVersion 메타데이터가 추가되어 진단 정보가 확장되었습니다.
  * 애플리케이션 버전이 설정을 통해 런타임에서 확인 가능합니다.
* 테스트
  * 새 헤더 키 반영으로 테스트를 업데이트했습니다.
* 기타
  * 애플리케이션 버전을 1.3.1로 상향했습니다.
  * 빌드 과정에서 설정 파일에 프로젝트 속성을 주입하도록 구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->