### PR TITLE
[AN] bug: 공유하기로 앱 접속 시 히어릿 단일 조회 안되는 현상

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/detail/PlayerDetailActivity.kt
@@ -140,10 +140,10 @@ class PlayerDetailActivity :
         // 딥링크로부터 받은 id를 추출하기 위함
         val deepLinkHearitId =
             intent.data
-                ?.takeIf { uri -> uri.scheme?.startsWith("kakao") == true && uri.host == "kakaolink" }
+                ?.takeIf { uri -> uri.scheme?.startsWith("kakao") == true }
                 ?.getQueryParameter("id")
                 ?.toLongOrNull()
-                ?.takeIf { it > 0 }
+                ?.takeIf { it > -1 }
 
         // 딥링크 id -> Activity가 최초 실행될 때 저장된 id
         val targetId = deepLinkHearitId ?: hearitId

--- a/android/app/src/main/java/com/onair/hearit/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/splash/SplashActivity.kt
@@ -47,6 +47,7 @@ class SplashActivity : AppCompatActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        viewModel.checkValidAccessTokenWithDelay()
     }
 
     private fun setupWindowInsets() {
@@ -91,11 +92,7 @@ class SplashActivity : AppCompatActivity() {
 
     private fun observeViewModel() {
         viewModel.checkToken.observe(this) { isValid ->
-            if (isValid) {
-                viewModel.handleDeeplink(intent?.data)
-            } else {
-                navigateToLogin()
-            }
+            if (isValid) processIncomingIntent() else navigateToLogin()
         }
         viewModel.navigateToMain.observe(this) { hearitId ->
             navigateToMain(hearitId)
@@ -103,6 +100,13 @@ class SplashActivity : AppCompatActivity() {
         viewModel.toastMessage.observe(this) { messageResId ->
             Toast.makeText(this, getString(messageResId), Toast.LENGTH_SHORT).show()
         }
+    }
+
+    private fun processIncomingIntent() {
+        val uri = intent?.data
+        viewModel.handleDeeplink(uri)
+        intent?.data = null
+        intent?.removeExtra(HEARIT_ID_KEY)
     }
 
     private fun navigateToMain(deeplinkHearitId: Long?) {


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 릴리즈 환경에서 외부 공유하기 버튼을 통해 들어올 때 히어릿 조회가 안되는 문제 발생
- 어디서 조회해도 항상 히어릿이 조회되도록 하는 기능

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#681 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 딥링크 검증 로직을 개선하여 Kakao 스킴 지원 범위 확대
  * 액세스 토큰 검증 프로세스 개선
  * 앱 시작 시 딥링크 및 인텐트 처리 로직 안정화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->