### PR TITLE
[BE] fix: S3 버킷명 설정 오류 수정 #683

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/FileSourceService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/FileSourceService.java
@@ -15,7 +15,7 @@ public class FileSourceService {
     private final String sourceBaseUrl;
     private final HearitRepository hearitRepository;
 
-    public FileSourceService(@Value("${amazon.s3.bucket}") String sourceBaseUrl, HearitRepository hearitRepository) {
+    public FileSourceService(@Value("${aws.s3.bucket.url}") String sourceBaseUrl, HearitRepository hearitRepository) {
         this.sourceBaseUrl = sourceBaseUrl;
         this.hearitRepository = hearitRepository;
     }

--- a/backend/boot/src/main/resources/application-dev.properties
+++ b/backend/boot/src/main/resources/application-dev.properties
@@ -27,8 +27,8 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.format_sql=true
 
 # S3
-aws.s3.bucket=${AMAZON_S3_BUCKET_URL}
-amazon.s3.bucket=${AMAZON_S3_BUCKET_URL}
+aws.s3.bucket=${S3_BUCKET}
+aws.s3.bucket.url=${AMAZON_S3_BUCKET_URL}
 spring.servlet.multipart.max-file-size=128MB
 spring.servlet.multipart.max-request-size=200MB
 server.tomcat.max-part-count=30

--- a/backend/core/src/main/java/com/onair/hearit/core/log/mask/UrlMasker.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/log/mask/UrlMasker.java
@@ -10,7 +10,7 @@ public class UrlMasker {
     public static final int SUFFIX_LEN = 10;
     public static final int PREFIX_LEN = 10;
 
-    @Value("${amazon.s3.bucket}")
+    @Value("${aws.s3.bucket.url}")
     private String baseBucketUrl;
 
     public String maskUrl(String url) {

--- a/backend/core/src/testFixtures/resources/application-integration-test.properties
+++ b/backend/core/src/testFixtures/resources/application-integration-test.properties
@@ -24,9 +24,6 @@ spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-# S3 public URL
-amazon.s3.bucket=https://test.com
-
 # kakao base-url
 kakao.user-info.base-url=https://kapi.kakao.com
 kakao.user-info.connectTimeout=2000
@@ -42,6 +39,7 @@ hearit.profile.default-image-url=http://hearit.o-r.kr/images/default-profile.jpg
 
 # S3
 aws.region=fake-region
+aws.s3.bucket.url=https://test.com
 aws.s3.bucket=fake-bucket
 spring.servlet.multipart.max-file-size=30MB
 spring.servlet.multipart.max-request-size=100MB


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
- application.yml 내 aws.s3.bucket 설정값 수정
- `amazon.s3.bucket `-> `aws.s3.bucket.url` 변경으로 순수버킷명과 전체url을 나타내는 설정면 구분을 확실히 함
- 기존에 전체 URL을 사용하던 부분을 순수 버킷명으로 변경
- AWS에서 정확한 버킷명만 허용하도록 동작 변경된 것으로 추정됨 ㅜㅜ (진짠지는 모름)

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #683 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* AWS S3 관련 구성 키가 재정리되었습니다: 기존 S3 버킷 설정 키가 변경되고 S3 퍼블릭 URL이 별도 aws.s3.bucket.url로 분리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->