### PR TITLE
[AN] fix: AccessToken 만료 시 Refresh 로직 수정

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/TokenAuthenticator.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/TokenAuthenticator.kt
@@ -10,7 +10,6 @@ import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
-import timber.log.Timber
 
 class TokenAuthenticator(
     private val preferenceProvider: () -> PreferencesLocalDataSource,
@@ -76,7 +75,6 @@ class TokenAuthenticator(
         val refreshToken =
             preferencesLocalDataSource.getRefreshToken().getOrNull() ?: return null
         return try {
-            Timber.d("aaa")
             val response = authService.postRefreshToken(TokenReissueRequest(refreshToken))
             val tokenResponse = response.body() ?: return null
             preferencesLocalDataSource.saveAccessToken(tokenResponse.accessToken)

--- a/android/app/src/main/java/com/onair/hearit/data/TokenAuthenticator.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/TokenAuthenticator.kt
@@ -10,6 +10,7 @@ import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
+import timber.log.Timber
 
 class TokenAuthenticator(
     private val preferenceProvider: () -> PreferencesLocalDataSource,
@@ -34,7 +35,7 @@ class TokenAuthenticator(
 
             return when {
                 // 토큰 만료 - 갱신 가능
-                errorResponse?.properties?.reissuable == true -> {
+                errorResponse?.reissuable == true -> {
                     refreshTokenAndRetry(response.request)
                 }
 
@@ -75,6 +76,7 @@ class TokenAuthenticator(
         val refreshToken =
             preferencesLocalDataSource.getRefreshToken().getOrNull() ?: return null
         return try {
+            Timber.d("aaa")
             val response = authService.postRefreshToken(TokenReissueRequest(refreshToken))
             val tokenResponse = response.body() ?: return null
             preferencesLocalDataSource.saveAccessToken(tokenResponse.accessToken)

--- a/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/TokenInterceptorProvider.kt
@@ -18,7 +18,7 @@ object TokenInterceptorProvider {
         Interceptor { chain ->
             val originalRequest = chain.request()
 
-            if (originalRequest.header(NO_AUTH_KEY) != null) {
+            if (originalRequest.header(NO_AUTH_KEY) != "true") {
                 val newRequest =
                     originalRequest
                         .newBuilder()

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -193,10 +193,9 @@ class HomeFragment :
             }
         }
 
-        viewModel.playingHistoryHearits.observe(viewLifecycleOwner) { recentHearits ->
-            binding.tvHomePlayingHistoryHearitTitle.isVisible = recentHearits.isNotEmpty()
-            binding.rvHomePlayingHistoryHearit.isVisible = recentHearits.isNotEmpty()
-            playingHistoryAdapter.submitList(recentHearits)
+        viewModel.playingHistoryHearits.observe(viewLifecycleOwner) { playingHistoryHearits ->
+            binding.rvHomePlayingHistoryHearit.isVisible = playingHistoryHearits.isNotEmpty()
+            playingHistoryAdapter.submitList(playingHistoryHearits)
         }
 
         viewModel.recentUploadHearits.observe(viewLifecycleOwner) { recentUploadHearits ->
@@ -204,7 +203,6 @@ class HomeFragment :
         }
 
         viewModel.playingBookmarkHearits.observe(viewLifecycleOwner) { playingBookmarkHearits ->
-            binding.tvHomePlayingBookmarkTitle.isVisible = playingBookmarkHearits.isNotEmpty()
             binding.rvHomePlayingBookmark.isVisible = playingBookmarkHearits.isNotEmpty()
             playingBookmarkAdapter.submitList(playingBookmarkHearits)
         }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -151,7 +151,7 @@ class HomeFragment :
             centerScrollListener?.let { addOnScrollListener(it) }
         }
 
-        binding.rvHomePlayingHearit.apply {
+        binding.rvHomePlayingHistoryHearit.apply {
             adapter = playingHistoryAdapter
             addItemDecoration(HorizontalMarginItemDecoration(SIDE_MARGIN.dpToPx(requireContext())))
         }
@@ -195,6 +195,7 @@ class HomeFragment :
 
         viewModel.playingHistoryHearits.observe(viewLifecycleOwner) { recentHearits ->
             binding.tvHomePlayingHistoryHearitTitle.isVisible = recentHearits.isNotEmpty()
+            binding.rvHomePlayingHistoryHearit.isVisible = recentHearits.isNotEmpty()
             playingHistoryAdapter.submitList(recentHearits)
         }
 
@@ -204,6 +205,7 @@ class HomeFragment :
 
         viewModel.playingBookmarkHearits.observe(viewLifecycleOwner) { playingBookmarkHearits ->
             binding.tvHomePlayingBookmarkTitle.isVisible = playingBookmarkHearits.isNotEmpty()
+            binding.rvHomePlayingBookmark.isVisible = playingBookmarkHearits.isNotEmpty()
             playingBookmarkAdapter.submitList(playingBookmarkHearits)
         }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
@@ -43,12 +43,10 @@ class LoginViewModel(
     ) {
         viewModelScope.launch {
             val result =
-                preferencesLocalDataSource
-                    .saveAccessToken(accessToken)
-                    .fold(
-                        onSuccess = { preferencesLocalDataSource.saveRefreshToken(refreshToken) },
-                        onFailure = { Result.failure(it) },
-                    )
+                runCatching {
+                    preferencesLocalDataSource.saveAccessToken(accessToken).getOrThrow()
+                    preferencesLocalDataSource.saveRefreshToken(refreshToken).getOrThrow()
+                }
 
             result
                 .onSuccess {

--- a/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/login/LoginViewModel.kt
@@ -46,6 +46,10 @@ class LoginViewModel(
                 runCatching {
                     preferencesLocalDataSource.saveAccessToken(accessToken).getOrThrow()
                     preferencesLocalDataSource.saveRefreshToken(refreshToken).getOrThrow()
+                }.recoverCatching { throwable ->
+                    // saveAccessToken이 성공했지만 saveRefreshToken이 실패하는 경우 롤백
+                    preferencesLocalDataSource.clearData()
+                    throw throwable
                 }
 
             result

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -101,7 +101,6 @@
                 android:layout_height="20dp"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginTop="12dp"
-                android:layout_marginBottom="16dp"
                 android:gravity="center"
                 android:orientation="horizontal"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -114,15 +113,15 @@
                 style="@style/pretendard_main_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
+                android:layout_marginTop="16dp"
                 android:text="@{@string/home_playing_history_hearit_title(userInfo.nickname)}"
                 app:layout_constraintStart_toStartOf="@id/tv_home_recommend"
                 app:layout_constraintTop_toBottomOf="@id/indicator_container"
-                app:visibleIfCondition="@{!viewModel.isLoading}"
+                app:visibleIfCondition="@{!viewModel.isLoading &amp;&amp; viewModel.playingHistoryHearits.size() != 0}"
                 tools:text="hEARit님이 듣고 있는 팟캐스트" />
 
             <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rv_home_playing_hearit"
+                android:id="@+id/rv_home_playing_history_hearit"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
@@ -142,7 +141,8 @@
                 android:layout_marginTop="24dp"
                 android:text="@string/home_recent_upload_hearit_title"
                 app:layout_constraintStart_toStartOf="@id/tv_home_recommend"
-                app:layout_constraintTop_toBottomOf="@id/rv_home_playing_hearit"
+                app:layout_constraintTop_toBottomOf="@id/rv_home_playing_history_hearit"
+                app:layout_goneMarginTop="24dp"
                 app:visibleIfCondition="@{!viewModel.isLoading}"
                 tools:text="최근 추가된 팟캐스트" />
 
@@ -166,11 +166,12 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="24dp"
                 android:drawablePadding="8dp"
+                android:gravity="center_vertical"
                 android:text="@string/home_playing_bookmark_hearit_title"
                 app:drawableEndCompat="@drawable/ic_right"
                 app:layout_constraintStart_toStartOf="@id/tv_home_recommend"
                 app:layout_constraintTop_toBottomOf="@id/rv_home_recent_upload"
-                app:visibleIfCondition="@{!viewModel.isLoading}"
+                app:visibleIfCondition="@{!viewModel.isLoading &amp;&amp; viewModel.playingBookmarkHearits.size() != 0}"
                 tools:text="북마크한 팟캐스트를 들어보세요" />
 
             <androidx.recyclerview.widget.RecyclerView
@@ -192,7 +193,7 @@
                 android:layout_width="0dp"
                 android:layout_height="92dp"
                 android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="16dp"
+                android:layout_marginTop="20dp"
                 android:background="@drawable/bg_gradient_home_shortcast"
                 android:drawablePadding="4dp"
                 android:gravity="center_vertical"
@@ -210,7 +211,7 @@
                 android:layout_width="0dp"
                 android:layout_height="92dp"
                 android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="24dp"
+                android:layout_marginTop="20dp"
                 android:background="@drawable/bg_gradient_home_wootaeco"
                 android:gravity="center_vertical"
                 android:paddingHorizontal="16dp"

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -143,7 +143,6 @@
                 app:layout_constraintStart_toStartOf="@id/tv_home_recommend"
                 app:layout_constraintTop_toBottomOf="@id/rv_home_playing_history_hearit"
                 app:layout_goneMarginTop="24dp"
-                app:visibleIfCondition="@{!viewModel.isLoading}"
                 tools:text="최근 추가된 팟캐스트" />
 
             <androidx.recyclerview.widget.RecyclerView
@@ -171,7 +170,7 @@
                 app:drawableEndCompat="@drawable/ic_right"
                 app:layout_constraintStart_toStartOf="@id/tv_home_recommend"
                 app:layout_constraintTop_toBottomOf="@id/rv_home_recent_upload"
-                app:visibleIfCondition="@{!viewModel.isLoading &amp;&amp; viewModel.playingBookmarkHearits.size() != 0}"
+                app:visibleIfCondition="@{!viewModel.isLoading &amp;&amp; viewModel.playingHistoryHearits.size() != 0}"
                 tools:text="북마크한 팟캐스트를 들어보세요" />
 
             <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- AccessToken 만료 시 Refresh 로직 수정
- 홈 화면 Rv 아이템 없을 시 Textview, Rv 같이 사라짐 처리 + margin 조절

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#693 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 홈 화면에서 재생 이력 및 북마크 목록이 데이터 유무에 따라 올바르게 표시되지 않던 문제 개선
  
* **스타일**
  * 홈 화면 레이아웃 간격 및 정렬 조정으로 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->