### PR TITLE
[AN] Refactor: 홈 화면 uiState 분리, StateFlow 도입

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/analytics/AnalyticsEventNames.kt
+++ b/android/app/src/main/java/com/onair/hearit/analytics/AnalyticsEventNames.kt
@@ -10,6 +10,7 @@ object AnalyticsEventNames {
         "home_recommendation_category_hearit_selected"
     const val HOME_BOOKMARK_SELECTED = "home_bookmark_selected"
     const val HOME_EXPLORE_SELECTED = "home_explore_selected"
+    const val HOME_WOOTAECO_SELECTED = "home_wootaeco_selected"
     const val SEARCH_CATEGORY_SELECTED = "search_category_selected"
     const val SEARCH_KEYWORD_ENTERED = "search_keyword_entered"
     const val SEARCH_KEYWORD_SELECTED = "search_keyword_selected"

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -15,6 +15,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.PagerSnapHelper
 import com.google.firebase.analytics.FirebaseAnalytics
@@ -26,6 +28,12 @@ import com.onair.hearit.analytics.AnalyticsParamKeys.SCREEN_NAME_HOME
 import com.onair.hearit.analytics.HearitSource
 import com.onair.hearit.databinding.FragmentHomeBinding
 import com.onair.hearit.di.AnalyticsProvider
+import com.onair.hearit.domain.model.Bookmark
+import com.onair.hearit.domain.model.PlayingHistoryHearit
+import com.onair.hearit.domain.model.RecentUploadHearit
+import com.onair.hearit.domain.model.RecommendHearit
+import com.onair.hearit.domain.model.RecommendationCategories
+import com.onair.hearit.domain.model.UserInfo
 import com.onair.hearit.presentation.HearitClickListener
 import com.onair.hearit.presentation.IntentKeys.CATEGORY_COLOR_KEY
 import com.onair.hearit.presentation.IntentKeys.CATEGORY_ID_KEY
@@ -36,6 +44,7 @@ import com.onair.hearit.presentation.main.DrawerClickListener
 import com.onair.hearit.presentation.main.MainActivity
 import com.onair.hearit.presentation.main.MainViewModel
 import com.onair.hearit.presentation.search.category.CategoryComposeFragment
+import kotlinx.coroutines.launch
 
 class HomeFragment :
     Fragment(),
@@ -91,8 +100,6 @@ class HomeFragment :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        binding.lifecycleOwner = viewLifecycleOwner
-        binding.viewModel = viewModel
         setupWindowInsets()
         setupListeners()
         setupRecyclerView()
@@ -171,50 +178,77 @@ class HomeFragment :
     }
 
     private fun observeViewModel() {
-        viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
-            binding.frHomeSkeleton.apply {
-                if (isLoading) startShimmer() else stopShimmer()
-            }
-        }
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    updateLoadingState(state.isLoading)
 
-        viewModel.isLoggedIn.observe(viewLifecycleOwner) { isLoggedIn ->
-            mainViewModel.updateLoginState(isLoggedIn)
-        }
+                    if (!state.isLoading) {
+                        updateUserInfo(state.userInfo, state.isLoggedIn)
+                        updateRecommendSection(state.recommendHearits)
+                        updatePlayingHistorySection(state.playingHistoryHearits)
+                        updateRecentUploadSection(state.recentUploadHearits)
+                        updateBookmarkSection(state.playingBookmarkHearits)
+                        updateCategoriesSection(state.recommendationCategories)
+                    }
 
-        viewModel.userInfo.observe(viewLifecycleOwner) { userInfo ->
-            binding.userInfo = userInfo
-        }
-
-        viewModel.recommendHearits.observe(viewLifecycleOwner) { recommendHearits ->
-            recommendAdapter.submitList(recommendHearits) {
-                if (view != null && viewLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
-                    scrollToMiddlePosition()
-                    setupIndicator()
+                    binding.tvHomeRecentUploadTitle.isVisible = state.showRecentUpload
+                    binding.tvHomePlayingHistoryHearitTitle.isVisible = state.showPlayingHistory
+                    binding.tvHomePlayingBookmarkTitle.isVisible = state.showBookmark
+                    binding.tvHomeShortcast.isVisible = !state.isLoading
+                    binding.tvHomeWootaeco.isVisible = !state.isLoading
                 }
             }
-        }
-
-        viewModel.playingHistoryHearits.observe(viewLifecycleOwner) { playingHistoryHearits ->
-            binding.rvHomePlayingHistoryHearit.isVisible = playingHistoryHearits.isNotEmpty()
-            playingHistoryAdapter.submitList(playingHistoryHearits)
-        }
-
-        viewModel.recentUploadHearits.observe(viewLifecycleOwner) { recentUploadHearits ->
-            recentUploadAdapter.submitList(recentUploadHearits)
-        }
-
-        viewModel.playingBookmarkHearits.observe(viewLifecycleOwner) { playingBookmarkHearits ->
-            binding.rvHomePlayingBookmark.isVisible = playingBookmarkHearits.isNotEmpty()
-            playingBookmarkAdapter.submitList(playingBookmarkHearits)
-        }
-
-        viewModel.recommendationCategories.observe(viewLifecycleOwner) { recommendationCategories ->
-            recommendationCategoryAdapter.submitList(recommendationCategories)
         }
 
         viewModel.toastMessage.observe(viewLifecycleOwner) { resId ->
             showToast(getString(resId))
         }
+    }
+
+    private fun updateLoadingState(isLoading: Boolean) {
+        if (isLoading) {
+            binding.frHomeSkeleton.isVisible = true
+            binding.frHomeSkeleton.startShimmer()
+        } else {
+            binding.frHomeSkeleton.stopShimmer()
+            binding.frHomeSkeleton.isVisible = false
+        }
+    }
+
+    private fun updateUserInfo(
+        userInfo: UserInfo,
+        isLoggedIn: Boolean,
+    ) {
+        mainViewModel.updateLoginState(isLoggedIn)
+        binding.userInfo = userInfo
+    }
+
+    private fun updateRecommendSection(recommendHearits: List<RecommendHearit>) {
+        recommendAdapter.submitList(recommendHearits) {
+            if (view != null && viewLifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+                scrollToMiddlePosition()
+                setupIndicator()
+            }
+        }
+    }
+
+    private fun updatePlayingHistorySection(playingHistoryHearits: List<PlayingHistoryHearit>) {
+        binding.rvHomePlayingHistoryHearit.isVisible = playingHistoryHearits.isNotEmpty()
+        playingHistoryAdapter.submitList(playingHistoryHearits)
+    }
+
+    private fun updateRecentUploadSection(recentUploadHearits: List<RecentUploadHearit>) {
+        recentUploadAdapter.submitList(recentUploadHearits)
+    }
+
+    private fun updateBookmarkSection(playingBookmarkHearits: List<Bookmark>) {
+        binding.rvHomePlayingBookmark.isVisible = playingBookmarkHearits.isNotEmpty()
+        playingBookmarkAdapter.submitList(playingBookmarkHearits)
+    }
+
+    private fun updateCategoriesSection(recommendationCategories: List<RecommendationCategories>) {
+        recommendationCategoryAdapter.submitList(recommendationCategories)
     }
 
     private fun setupIndicator(size: Int = 5) {

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -200,9 +200,7 @@ class HomeFragment :
             }
         }
 
-        viewModel.toastMessage.observe(viewLifecycleOwner) { resId ->
-            showToast(getString(resId))
-        }
+        viewModel.toastMessage.observe(viewLifecycleOwner) { resId -> showToast(resId) }
     }
 
     private fun updateLoadingState(isLoading: Boolean) {
@@ -322,8 +320,8 @@ class HomeFragment :
         }
     }
 
-    private fun showToast(message: String?) {
-        Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
+    private fun showToast(messageResId: Int) {
+        Toast.makeText(requireContext(), getString(messageResId), Toast.LENGTH_SHORT).show()
     }
 
     private fun navigateToSearch(

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -74,13 +74,7 @@ class HomeFragment :
     private val recommendationCategoryAdapter: RecommendationCategoryAdapter by lazy {
         RecommendationCategoryAdapter(
             this,
-            navigateClickListener = { id, name, colorCode ->
-                navigateToSearch(
-                    id,
-                    name,
-                    colorCode,
-                )
-            },
+            navigateClickListener = ::navigateToSearch,
         )
     }
     private val snapHelper = PagerSnapHelper()
@@ -182,21 +176,26 @@ class HomeFragment :
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { state ->
                     updateLoadingState(state.isLoading)
+                    updateAdSections(state.isLoading)
+
+                    updatePlayingHistorySection(
+                        state.playingHistoryHearits,
+                        !state.isLoading && state.showPlayingHistory,
+                    )
+                    updateRecentUploadSection(
+                        state.recentUploadHearits,
+                        !state.isLoading && state.showRecentUpload,
+                    )
+                    updateBookmarkSection(
+                        state.playingBookmarkHearits,
+                        !state.isLoading && state.showBookmark,
+                    )
 
                     if (!state.isLoading) {
                         updateUserInfo(state.userInfo, state.isLoggedIn)
                         updateRecommendSection(state.recommendHearits)
-                        updatePlayingHistorySection(state.playingHistoryHearits)
-                        updateRecentUploadSection(state.recentUploadHearits)
-                        updateBookmarkSection(state.playingBookmarkHearits)
                         updateCategoriesSection(state.recommendationCategories)
                     }
-
-                    binding.tvHomeRecentUploadTitle.isVisible = state.showRecentUpload
-                    binding.tvHomePlayingHistoryHearitTitle.isVisible = state.showPlayingHistory
-                    binding.tvHomePlayingBookmarkTitle.isVisible = state.showBookmark
-                    binding.tvHomeShortcast.isVisible = !state.isLoading
-                    binding.tvHomeWootaeco.isVisible = !state.isLoading
                 }
             }
         }
@@ -207,12 +206,9 @@ class HomeFragment :
     }
 
     private fun updateLoadingState(isLoading: Boolean) {
-        if (isLoading) {
-            binding.frHomeSkeleton.isVisible = true
-            binding.frHomeSkeleton.startShimmer()
-        } else {
-            binding.frHomeSkeleton.stopShimmer()
-            binding.frHomeSkeleton.isVisible = false
+        binding.frHomeSkeleton.apply {
+            isVisible = isLoading
+            if (isLoading) startShimmer() else stopShimmer()
         }
     }
 
@@ -233,22 +229,39 @@ class HomeFragment :
         }
     }
 
-    private fun updatePlayingHistorySection(playingHistoryHearits: List<PlayingHistoryHearit>) {
-        binding.rvHomePlayingHistoryHearit.isVisible = playingHistoryHearits.isNotEmpty()
+    private fun updatePlayingHistorySection(
+        playingHistoryHearits: List<PlayingHistoryHearit>,
+        shouldShow: Boolean,
+    ) {
+        binding.tvHomePlayingHistoryHearitTitle.isVisible = shouldShow
+        binding.rvHomePlayingHistoryHearit.isVisible = shouldShow
         playingHistoryAdapter.submitList(playingHistoryHearits)
     }
 
-    private fun updateRecentUploadSection(recentUploadHearits: List<RecentUploadHearit>) {
+    private fun updateRecentUploadSection(
+        recentUploadHearits: List<RecentUploadHearit>,
+        shouldShow: Boolean,
+    ) {
+        binding.tvHomeRecentUploadTitle.isVisible = shouldShow
         recentUploadAdapter.submitList(recentUploadHearits)
     }
 
-    private fun updateBookmarkSection(playingBookmarkHearits: List<Bookmark>) {
-        binding.rvHomePlayingBookmark.isVisible = playingBookmarkHearits.isNotEmpty()
+    private fun updateBookmarkSection(
+        playingBookmarkHearits: List<Bookmark>,
+        shouldShow: Boolean,
+    ) {
+        binding.tvHomePlayingBookmarkTitle.isVisible = shouldShow
+        binding.rvHomePlayingBookmark.isVisible = shouldShow
         playingBookmarkAdapter.submitList(playingBookmarkHearits)
     }
 
     private fun updateCategoriesSection(recommendationCategories: List<RecommendationCategories>) {
         recommendationCategoryAdapter.submitList(recommendationCategories)
+    }
+
+    private fun updateAdSections(isLoading: Boolean) {
+        binding.tvHomeShortcast.isVisible = !isLoading
+        binding.tvHomeWootaeco.isVisible = !isLoading
     }
 
     private fun setupIndicator(size: Int = 5) {

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -40,6 +40,11 @@ import com.onair.hearit.presentation.IntentKeys.CATEGORY_ID_KEY
 import com.onair.hearit.presentation.IntentKeys.CATEGORY_NAME_KEY
 import com.onair.hearit.presentation.detail.PlayerDetailActivity
 import com.onair.hearit.presentation.dpToPx
+import com.onair.hearit.presentation.home.adapter.PlayingBookmarkHearitAdapter
+import com.onair.hearit.presentation.home.adapter.PlayingHistoryHearitAdapter
+import com.onair.hearit.presentation.home.adapter.RecentUploadHearitAdapter
+import com.onair.hearit.presentation.home.adapter.RecommendHearitAdapter
+import com.onair.hearit.presentation.home.adapter.RecommendationCategoryAdapter
 import com.onair.hearit.presentation.main.DrawerClickListener
 import com.onair.hearit.presentation.main.MainActivity
 import com.onair.hearit.presentation.main.MainViewModel

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeFragment.kt
@@ -134,6 +134,7 @@ class HomeFragment :
         }
 
         binding.tvHomeWootaeco.setOnClickListener {
+            AnalyticsProvider.get().logEvent(AnalyticsEventNames.HOME_WOOTAECO_SELECTED)
             navigateToSearch(id = 13, name = "우아한테크코스", colorCode = "#12C6B0")
         }
     }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeLoadKey.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeLoadKey.kt
@@ -1,0 +1,9 @@
+package com.onair.hearit.presentation.home
+
+enum class HomeLoadKey {
+    RECOMMEND,
+    PLAYING_HISTORY,
+    RECENT_UPLOAD,
+    PLAYING_BOOKMARKS,
+    RECOMMENDATION_CATEGORIES,
+}

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeUiState.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeUiState.kt
@@ -15,7 +15,7 @@ data class HomeUiState(
     val recentUploadHearits: List<RecentUploadHearit> = emptyList(),
     val playingBookmarkHearits: List<Bookmark> = emptyList(),
     val recommendationCategories: List<RecommendationCategories> = emptyList(),
-    val isLoading: Boolean,
+    val loadingKeys: Set<HomeLoadKey> = emptySet(),
 ) {
     val showRecentUpload: Boolean
         get() = !isLoading && recentUploadHearits.isNotEmpty()
@@ -25,4 +25,7 @@ data class HomeUiState(
 
     val showBookmark: Boolean
         get() = !isLoading && playingBookmarkHearits.isNotEmpty()
+
+    val isLoading: Boolean
+        get() = loadingKeys.isNotEmpty()
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeUiState.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeUiState.kt
@@ -1,0 +1,28 @@
+package com.onair.hearit.presentation.home
+
+import com.onair.hearit.domain.model.Bookmark
+import com.onair.hearit.domain.model.PlayingHistoryHearit
+import com.onair.hearit.domain.model.RecentUploadHearit
+import com.onair.hearit.domain.model.RecommendHearit
+import com.onair.hearit.domain.model.RecommendationCategories
+import com.onair.hearit.domain.model.UserInfo
+
+data class HomeUiState(
+    val userInfo: UserInfo = UserInfo.default(),
+    val isLoggedIn: Boolean = false,
+    val recommendHearits: List<RecommendHearit> = emptyList(),
+    val playingHistoryHearits: List<PlayingHistoryHearit> = emptyList(),
+    val recentUploadHearits: List<RecentUploadHearit> = emptyList(),
+    val playingBookmarkHearits: List<Bookmark> = emptyList(),
+    val recommendationCategories: List<RecommendationCategories> = emptyList(),
+    val isLoading: Boolean,
+) {
+    val showRecentUpload: Boolean
+        get() = !isLoading && recentUploadHearits.isNotEmpty()
+
+    val showPlayingHistory: Boolean
+        get() = !isLoading && playingHistoryHearits.isNotEmpty()
+
+    val showBookmark: Boolean
+        get() = !isLoading && playingBookmarkHearits.isNotEmpty()
+}

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -35,7 +35,7 @@ class HomeViewModel(
     val toastMessage: LiveData<Int> = _toastMessage
 
     // 로딩 중인 작업 개수 추적
-    private val loadingJobs = mutableSetOf<String>()
+    private val loadingJobs = mutableSetOf<HomeLoadKey>()
 
     init {
         fetchUserInfo()
@@ -50,12 +50,12 @@ class HomeViewModel(
         fetchCategories()
     }
 
-    private fun startLoading(jobKey: String) {
+    private fun startLoading(jobKey: HomeLoadKey) {
         loadingJobs.add(jobKey)
         _uiState.update { it.copy(isLoading = true) }
     }
 
-    private fun finishLoading(jobKey: String) {
+    private fun finishLoading(jobKey: HomeLoadKey) {
         loadingJobs.remove(jobKey)
         if (loadingJobs.isEmpty()) {
             _uiState.update { it.copy(isLoading = false) }
@@ -64,7 +64,7 @@ class HomeViewModel(
 
     private fun fetchRecommendHearits() {
         viewModelScope.launch {
-            safeLoad("recommend") {
+            safeLoad(HomeLoadKey.RECOMMEND) {
                 hearitRepository
                     .getRecommendHearits()
                     .onSuccess { hearits ->
@@ -79,7 +79,7 @@ class HomeViewModel(
 
     private fun fetchPlayingHistory() {
         viewModelScope.launch {
-            safeLoad("history") {
+            safeLoad(HomeLoadKey.PLAYING_HISTORY) {
                 playingHistoryRepository
                     .getPlayingHistories()
                     .onSuccess { history ->
@@ -94,7 +94,7 @@ class HomeViewModel(
 
     private fun fetchRecentUpload() {
         viewModelScope.launch {
-            safeLoad("recentUpload") {
+            safeLoad(HomeLoadKey.RECENT_UPLOAD) {
                 hearitRepository
                     .getRecentUploadHearits(size = 10)
                     .onSuccess { response ->
@@ -109,7 +109,7 @@ class HomeViewModel(
 
     private fun fetchBookmarks() {
         viewModelScope.launch {
-            safeLoad("bookmark") {
+            safeLoad(HomeLoadKey.PLAYING_BOOKMARKS) {
                 bookmarkRepository
                     .getBookmarks(
                         page = 0,
@@ -127,7 +127,7 @@ class HomeViewModel(
 
     private fun fetchCategories() {
         viewModelScope.launch {
-            safeLoad("categories") {
+            safeLoad(HomeLoadKey.RECOMMENDATION_CATEGORIES) {
                 recommendationRepository
                     .getRecommendationCategories()
                     .onSuccess { categories ->
@@ -167,7 +167,7 @@ class HomeViewModel(
     }
 
     private suspend inline fun <T> safeLoad(
-        jobKey: String,
+        jobKey: HomeLoadKey,
         block: () -> T,
     ): T? {
         startLoading(jobKey)

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -1,16 +1,10 @@
 package com.onair.hearit.presentation.home
 
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.onair.hearit.R
 import com.onair.hearit.domain.DomainException.UserNotRegistered
-import com.onair.hearit.domain.model.Bookmark
-import com.onair.hearit.domain.model.PlayingHistoryHearit
-import com.onair.hearit.domain.model.RecentUploadHearit
-import com.onair.hearit.domain.model.RecommendHearit
-import com.onair.hearit.domain.model.RecommendationCategories
 import com.onair.hearit.domain.model.UserInfo
 import com.onair.hearit.domain.repository.BookmarkRepository
 import com.onair.hearit.domain.repository.HearitRepository
@@ -18,7 +12,10 @@ import com.onair.hearit.domain.repository.MemberRepository
 import com.onair.hearit.domain.repository.PlayingHistoryRepository
 import com.onair.hearit.domain.repository.RecommendationRepository
 import com.onair.hearit.presentation.SingleLiveData
-import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -29,36 +26,14 @@ class HomeViewModel(
     private val playingHistoryRepository: PlayingHistoryRepository,
     private val recommendationRepository: RecommendationRepository,
 ) : ViewModel() {
-    private val _userInfo: MutableLiveData<UserInfo> = MutableLiveData()
-    val userInfo: LiveData<UserInfo> = _userInfo
-
-    private val _isLoggedIn: MutableLiveData<Boolean> = MutableLiveData()
-    val isLoggedIn: LiveData<Boolean> = _isLoggedIn
-
-    private val _recommendHearits: MutableLiveData<List<RecommendHearit>> = MutableLiveData()
-    val recommendHearits: LiveData<List<RecommendHearit>> = _recommendHearits
-
-    private val _playingHistoryHearits: MutableLiveData<List<PlayingHistoryHearit>> =
-        MutableLiveData()
-    val playingHistoryHearits: LiveData<List<PlayingHistoryHearit>> = _playingHistoryHearits
-
-    private val _recentUploadHearits: MutableLiveData<List<RecentUploadHearit>> = MutableLiveData()
-    val recentUploadHearits: LiveData<List<RecentUploadHearit>> = _recentUploadHearits
-
-    private val _playingBookmarkHearits: MutableLiveData<List<Bookmark>> =
-        MutableLiveData()
-    val playingBookmarkHearits: LiveData<List<Bookmark>> = _playingBookmarkHearits
-
-    private val _recommendationCategories: MutableLiveData<List<RecommendationCategories>> =
-        MutableLiveData()
-    val recommendationCategories: LiveData<List<RecommendationCategories>> =
-        _recommendationCategories
+    private val _uiState = MutableStateFlow(HomeUiState(isLoading = true))
+    val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     private val _toastMessage = SingleLiveData<Int>()
     val toastMessage: LiveData<Int> = _toastMessage
 
-    private val _isLoading = MutableLiveData(false)
-    val isLoading: LiveData<Boolean> = _isLoading
+    // 로딩 중인 작업 개수 추적
+    private val loadingJobs = mutableSetOf<String>()
 
     init {
         fetchUserInfo()
@@ -66,56 +41,100 @@ class HomeViewModel(
     }
 
     private fun fetchData() {
-        _isLoading.value = true
+        fetchRecommendHearits()
+        fetchPlayingHistory()
+        fetchRecentUpload()
+        fetchBookmarks()
+        fetchCategories()
+    }
 
+    private fun startLoading(jobKey: String) {
+        loadingJobs.add(jobKey)
+        _uiState.update { it.copy(isLoading = true) }
+    }
+
+    private fun finishLoading(jobKey: String) {
+        loadingJobs.remove(jobKey)
+        if (loadingJobs.isEmpty()) {
+            _uiState.update { it.copy(isLoading = false) }
+        }
+    }
+
+    private fun fetchRecommendHearits() {
         viewModelScope.launch {
-            val recommendDeferred = async { hearitRepository.getRecommendHearits() }
-            val playingHistoryDeferred = async { playingHistoryRepository.getPlayingHistories() }
-            val recentUploadDeferred = async { hearitRepository.getRecentUploadHearits(size = 10) }
-            val playingBookmarkDeferred =
-                async {
-                    bookmarkRepository.getBookmarks(
-                        page = 0,
-                        size = 10,
-                        filter = "unfinished",
-                    )
+            startLoading("recommend")
+            hearitRepository
+                .getRecommendHearits()
+                .onSuccess { hearits ->
+                    _uiState.update { it.copy(recommendHearits = hearits) }
+                }.onFailure { throwable ->
+                    Timber.w(throwable)
+                    _toastMessage.value = R.string.home_toast_recommend_load_fail
                 }
-            val groupedDeferred = async { recommendationRepository.getRecommendationCategories() }
+            finishLoading("recommend")
+        }
+    }
 
-            val recommendResult = recommendDeferred.await()
-            val playingHistoryResult = playingHistoryDeferred.await()
-            val recentUploadResult = recentUploadDeferred.await()
-            val playingBookmarkResult = playingBookmarkDeferred.await()
-            val groupedResult = groupedDeferred.await()
+    private fun fetchPlayingHistory() {
+        viewModelScope.launch {
+            startLoading("history")
+            playingHistoryRepository
+                .getPlayingHistories()
+                .onSuccess { history ->
+                    _uiState.update { it.copy(playingHistoryHearits = history) }
+                }.onFailure { throwable ->
+                    Timber.w(throwable)
+                    _toastMessage.value = R.string.home_toast_playing_history_load_fail
+                }
+            finishLoading("history")
+        }
+    }
 
-            recommendResult.onFailure { throwable ->
-                Timber.w(throwable)
-                _toastMessage.value = R.string.home_toast_recommend_load_fail
-            }
-            playingHistoryResult.onFailure { throwable ->
-                Timber.w(throwable)
-                _toastMessage.value = R.string.home_toast_playing_history_load_fail
-            }
-            recentUploadResult.onFailure { throwable ->
-                Timber.w(throwable)
-                _toastMessage.value = R.string.home_toast_recent_upload_load_fail
-            }
-            playingBookmarkResult.onFailure { throwable ->
-                Timber.w(throwable)
-                _toastMessage.value = R.string.home_toast_playing_bookmark_load_fail
-            }
-            groupedResult.onFailure { throwable ->
-                Timber.w(throwable)
-                _toastMessage.value = R.string.home_toast_grouped_category_load_fail
-            }
+    private fun fetchRecentUpload() {
+        viewModelScope.launch {
+            startLoading("recentUpload")
+            hearitRepository
+                .getRecentUploadHearits(size = 10)
+                .onSuccess { response ->
+                    _uiState.update { it.copy(recentUploadHearits = response.items) }
+                }.onFailure { throwable ->
+                    Timber.w(throwable)
+                    _toastMessage.value = R.string.home_toast_recent_upload_load_fail
+                }
+            finishLoading("recentUpload")
+        }
+    }
 
-            recommendResult.onSuccess { _recommendHearits.value = it }
-            playingHistoryResult.onSuccess { _playingHistoryHearits.value = it }
-            recentUploadResult.onSuccess { _recentUploadHearits.value = it.items }
-            playingBookmarkResult.onSuccess { _playingBookmarkHearits.value = it.items }
-            groupedResult.onSuccess { _recommendationCategories.value = it }
+    private fun fetchBookmarks() {
+        viewModelScope.launch {
+            startLoading("bookmark")
+            bookmarkRepository
+                .getBookmarks(
+                    page = 0,
+                    size = 10,
+                    filter = "unfinished",
+                ).onSuccess { pageResult ->
+                    _uiState.update { it.copy(playingBookmarkHearits = pageResult.items) }
+                }.onFailure { throwable ->
+                    Timber.w(throwable)
+                    _toastMessage.value = R.string.home_toast_playing_bookmark_load_fail
+                }
+            finishLoading("bookmark")
+        }
+    }
 
-            _isLoading.value = false
+    private fun fetchCategories() {
+        viewModelScope.launch {
+            startLoading("categories")
+            recommendationRepository
+                .getRecommendationCategories()
+                .onSuccess { categories ->
+                    _uiState.update { it.copy(recommendationCategories = categories) }
+                }.onFailure { throwable ->
+                    Timber.w(throwable)
+                    _toastMessage.value = R.string.home_toast_grouped_category_load_fail
+                }
+            finishLoading("categories")
         }
     }
 
@@ -124,17 +143,21 @@ class HomeViewModel(
             memberRepository
                 .getUserInfo()
                 .onSuccess { userInfo ->
-                    _userInfo.value = userInfo
-                    _isLoggedIn.value = true
+                    _uiState.update {
+                        it.copy(userInfo = userInfo, isLoggedIn = true)
+                    }
                 }.onFailure { throwable ->
-                    _isLoggedIn.value = false
-
                     when (throwable) {
-                        is UserNotRegistered -> _userInfo.value = UserInfo.default()
+                        is UserNotRegistered -> {
+                            _uiState.update {
+                                it.copy(userInfo = UserInfo.default(), isLoggedIn = false)
+                            }
+                        }
 
                         else -> {
                             Timber.w(throwable)
                             _toastMessage.value = R.string.all_toast_user_info_load_fail
+                            _uiState.update { it.copy(isLoggedIn = false) }
                         }
                     }
                 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -131,7 +131,7 @@ class HomeViewModel(
                         _uiState.update { it.copy(recommendationCategories = categories) }
                     }.onFailure { throwable ->
                         Timber.w(throwable)
-                        _toastMessage.value = R.string.home_toast_grouped_category_load_fail
+                        _toastMessage.value = R.string.home_toast_recommendation_category_load_fail
                     }
             }
         }
@@ -163,12 +163,12 @@ class HomeViewModel(
         }
     }
 
-    private suspend inline fun <T> safeLoad(
+    private suspend inline fun safeLoad(
         jobKey: HomeLoadKey,
-        block: () -> T,
-    ): T? {
+        block: () -> Unit,
+    ) {
         startLoading(jobKey)
-        return try {
+        try {
             block()
         } finally {
             withContext(NonCancellable) { finishLoading(jobKey) }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -28,14 +28,11 @@ class HomeViewModel(
     private val playingHistoryRepository: PlayingHistoryRepository,
     private val recommendationRepository: RecommendationRepository,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(HomeUiState(isLoading = true))
+    private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     private val _toastMessage = SingleLiveData<Int>()
     val toastMessage: LiveData<Int> = _toastMessage
-
-    // 로딩 중인 작업 개수 추적
-    private val loadingJobs = mutableSetOf<HomeLoadKey>()
 
     init {
         fetchUserInfo()
@@ -51,14 +48,14 @@ class HomeViewModel(
     }
 
     private fun startLoading(jobKey: HomeLoadKey) {
-        loadingJobs.add(jobKey)
-        _uiState.update { it.copy(isLoading = true) }
+        _uiState.update { state ->
+            state.copy(loadingKeys = state.loadingKeys + jobKey)
+        }
     }
 
     private fun finishLoading(jobKey: HomeLoadKey) {
-        loadingJobs.remove(jobKey)
-        if (loadingJobs.isEmpty()) {
-            _uiState.update { it.copy(isLoading = false) }
+        _uiState.update { state ->
+            state.copy(loadingKeys = state.loadingKeys - jobKey)
         }
     }
 

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/HomeViewModel.kt
@@ -12,11 +12,13 @@ import com.onair.hearit.domain.repository.MemberRepository
 import com.onair.hearit.domain.repository.PlayingHistoryRepository
 import com.onair.hearit.domain.repository.RecommendationRepository
 import com.onair.hearit.presentation.SingleLiveData
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class HomeViewModel(
@@ -62,79 +64,79 @@ class HomeViewModel(
 
     private fun fetchRecommendHearits() {
         viewModelScope.launch {
-            startLoading("recommend")
-            hearitRepository
-                .getRecommendHearits()
-                .onSuccess { hearits ->
-                    _uiState.update { it.copy(recommendHearits = hearits) }
-                }.onFailure { throwable ->
-                    Timber.w(throwable)
-                    _toastMessage.value = R.string.home_toast_recommend_load_fail
-                }
-            finishLoading("recommend")
+            safeLoad("recommend") {
+                hearitRepository
+                    .getRecommendHearits()
+                    .onSuccess { hearits ->
+                        _uiState.update { it.copy(recommendHearits = hearits) }
+                    }.onFailure { throwable ->
+                        Timber.w(throwable)
+                        _toastMessage.value = R.string.home_toast_recommend_load_fail
+                    }
+            }
         }
     }
 
     private fun fetchPlayingHistory() {
         viewModelScope.launch {
-            startLoading("history")
-            playingHistoryRepository
-                .getPlayingHistories()
-                .onSuccess { history ->
-                    _uiState.update { it.copy(playingHistoryHearits = history) }
-                }.onFailure { throwable ->
-                    Timber.w(throwable)
-                    _toastMessage.value = R.string.home_toast_playing_history_load_fail
-                }
-            finishLoading("history")
+            safeLoad("history") {
+                playingHistoryRepository
+                    .getPlayingHistories()
+                    .onSuccess { history ->
+                        _uiState.update { it.copy(playingHistoryHearits = history) }
+                    }.onFailure { throwable ->
+                        Timber.w(throwable)
+                        _toastMessage.value = R.string.home_toast_playing_history_load_fail
+                    }
+            }
         }
     }
 
     private fun fetchRecentUpload() {
         viewModelScope.launch {
-            startLoading("recentUpload")
-            hearitRepository
-                .getRecentUploadHearits(size = 10)
-                .onSuccess { response ->
-                    _uiState.update { it.copy(recentUploadHearits = response.items) }
-                }.onFailure { throwable ->
-                    Timber.w(throwable)
-                    _toastMessage.value = R.string.home_toast_recent_upload_load_fail
-                }
-            finishLoading("recentUpload")
+            safeLoad("recentUpload") {
+                hearitRepository
+                    .getRecentUploadHearits(size = 10)
+                    .onSuccess { response ->
+                        _uiState.update { it.copy(recentUploadHearits = response.items) }
+                    }.onFailure { throwable ->
+                        Timber.w(throwable)
+                        _toastMessage.value = R.string.home_toast_recent_upload_load_fail
+                    }
+            }
         }
     }
 
     private fun fetchBookmarks() {
         viewModelScope.launch {
-            startLoading("bookmark")
-            bookmarkRepository
-                .getBookmarks(
-                    page = 0,
-                    size = 10,
-                    filter = "unfinished",
-                ).onSuccess { pageResult ->
-                    _uiState.update { it.copy(playingBookmarkHearits = pageResult.items) }
-                }.onFailure { throwable ->
-                    Timber.w(throwable)
-                    _toastMessage.value = R.string.home_toast_playing_bookmark_load_fail
-                }
-            finishLoading("bookmark")
+            safeLoad("bookmark") {
+                bookmarkRepository
+                    .getBookmarks(
+                        page = 0,
+                        size = 10,
+                        filter = "unfinished",
+                    ).onSuccess { pageResult ->
+                        _uiState.update { it.copy(playingBookmarkHearits = pageResult.items) }
+                    }.onFailure { throwable ->
+                        Timber.w(throwable)
+                        _toastMessage.value = R.string.home_toast_playing_bookmark_load_fail
+                    }
+            }
         }
     }
 
     private fun fetchCategories() {
         viewModelScope.launch {
-            startLoading("categories")
-            recommendationRepository
-                .getRecommendationCategories()
-                .onSuccess { categories ->
-                    _uiState.update { it.copy(recommendationCategories = categories) }
-                }.onFailure { throwable ->
-                    Timber.w(throwable)
-                    _toastMessage.value = R.string.home_toast_grouped_category_load_fail
-                }
-            finishLoading("categories")
+            safeLoad("categories") {
+                recommendationRepository
+                    .getRecommendationCategories()
+                    .onSuccess { categories ->
+                        _uiState.update { it.copy(recommendationCategories = categories) }
+                    }.onFailure { throwable ->
+                        Timber.w(throwable)
+                        _toastMessage.value = R.string.home_toast_grouped_category_load_fail
+                    }
+            }
         }
     }
 
@@ -161,6 +163,18 @@ class HomeViewModel(
                         }
                     }
                 }
+        }
+    }
+
+    private suspend inline fun <T> safeLoad(
+        jobKey: String,
+        block: () -> T,
+    ): T? {
+        startLoading(jobKey)
+        return try {
+            block()
+        } finally {
+            withContext(NonCancellable) { finishLoading(jobKey) }
         }
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/CategoryItemAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/CategoryItemAdapter.kt
@@ -1,4 +1,4 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/CategoryItemViewHolder.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/CategoryItemViewHolder.kt
@@ -1,4 +1,4 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/PlayingBookmarkHearitAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/PlayingBookmarkHearitAdapter.kt
@@ -1,4 +1,4 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/PlayingBookmarkHearitViewHolder.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/PlayingBookmarkHearitViewHolder.kt
@@ -1,4 +1,4 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/PlayingHistoryHearitAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/PlayingHistoryHearitAdapter.kt
@@ -1,4 +1,4 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/PlayingHistoryHearitViewHolder.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/PlayingHistoryHearitViewHolder.kt
@@ -1,15 +1,15 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.onair.hearit.analytics.HearitSource
-import com.onair.hearit.databinding.ItemRecentUploadHearitBinding
-import com.onair.hearit.domain.model.RecentUploadHearit
+import com.onair.hearit.databinding.ItemPlayingHistoryHearitBinding
+import com.onair.hearit.domain.model.PlayingHistoryHearit
 import com.onair.hearit.presentation.HearitClickListener
 
-class RecentUploadHearitViewHolder private constructor(
-    private val binding: ItemRecentUploadHearitBinding,
+class PlayingHistoryHearitViewHolder private constructor(
+    private val binding: ItemPlayingHistoryHearitBinding,
     private val source: HearitSource,
     hearitClickListener: HearitClickListener,
 ) : RecyclerView.ViewHolder(binding.root) {
@@ -18,8 +18,8 @@ class RecentUploadHearitViewHolder private constructor(
         binding.source = source
     }
 
-    fun bind(item: RecentUploadHearit) {
-        binding.recentUploadHearit = item
+    fun bind(item: PlayingHistoryHearit) {
+        binding.playingHistoryHearit = item
     }
 
     companion object {
@@ -27,10 +27,10 @@ class RecentUploadHearitViewHolder private constructor(
             parent: ViewGroup,
             source: HearitSource,
             hearitClickListener: HearitClickListener,
-        ): RecentUploadHearitViewHolder {
+        ): PlayingHistoryHearitViewHolder {
             val inflater = LayoutInflater.from(parent.context)
-            val binding = ItemRecentUploadHearitBinding.inflate(inflater, parent, false)
-            return RecentUploadHearitViewHolder(binding, source, hearitClickListener)
+            val binding = ItemPlayingHistoryHearitBinding.inflate(inflater, parent, false)
+            return PlayingHistoryHearitViewHolder(binding, source, hearitClickListener)
         }
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecentUploadHearitAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecentUploadHearitAdapter.kt
@@ -1,36 +1,36 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.onair.hearit.analytics.HearitSource
-import com.onair.hearit.domain.model.RecommendHearit
+import com.onair.hearit.domain.model.RecentUploadHearit
 import com.onair.hearit.presentation.HearitClickListener
 
-class RecommendHearitAdapter(
+class RecentUploadHearitAdapter(
     private val hearitClickListener: HearitClickListener,
-) : ListAdapter<RecommendHearit, RecommendViewHolder>(DiffCallback) {
+) : ListAdapter<RecentUploadHearit, RecentUploadHearitViewHolder>(DiffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): RecommendViewHolder = RecommendViewHolder.create(parent, HearitSource.RECOMMEND, hearitClickListener)
+    ): RecentUploadHearitViewHolder = RecentUploadHearitViewHolder.create(parent, HearitSource.RECENT_UPLOAD, hearitClickListener)
 
     override fun onBindViewHolder(
-        holder: RecommendViewHolder,
+        holder: RecentUploadHearitViewHolder,
         position: Int,
     ) = holder.bind(getItem(position))
 
     companion object {
-        val DiffCallback =
-            object : DiffUtil.ItemCallback<RecommendHearit>() {
+        private val DiffCallback =
+            object : DiffUtil.ItemCallback<RecentUploadHearit>() {
                 override fun areItemsTheSame(
-                    oldItem: RecommendHearit,
-                    newItem: RecommendHearit,
+                    oldItem: RecentUploadHearit,
+                    newItem: RecentUploadHearit,
                 ): Boolean = oldItem.id == newItem.id
 
                 override fun areContentsTheSame(
-                    oldItem: RecommendHearit,
-                    newItem: RecommendHearit,
+                    oldItem: RecentUploadHearit,
+                    newItem: RecentUploadHearit,
                 ): Boolean = oldItem == newItem
             }
     }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecentUploadHearitViewHolder.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecentUploadHearitViewHolder.kt
@@ -1,25 +1,25 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.onair.hearit.analytics.HearitSource
-import com.onair.hearit.databinding.ItemRecommendHearitBinding
-import com.onair.hearit.domain.model.RecommendHearit
+import com.onair.hearit.databinding.ItemRecentUploadHearitBinding
+import com.onair.hearit.domain.model.RecentUploadHearit
 import com.onair.hearit.presentation.HearitClickListener
 
-class RecommendViewHolder(
-    private val binding: ItemRecommendHearitBinding,
+class RecentUploadHearitViewHolder private constructor(
+    private val binding: ItemRecentUploadHearitBinding,
     private val source: HearitSource,
     hearitClickListener: HearitClickListener,
 ) : RecyclerView.ViewHolder(binding.root) {
     init {
-        binding.recommendClickListener = hearitClickListener
+        binding.clickListener = hearitClickListener
         binding.source = source
     }
 
-    fun bind(item: RecommendHearit) {
-        binding.item = item
+    fun bind(item: RecentUploadHearit) {
+        binding.recentUploadHearit = item
     }
 
     companion object {
@@ -27,10 +27,10 @@ class RecommendViewHolder(
             parent: ViewGroup,
             source: HearitSource,
             hearitClickListener: HearitClickListener,
-        ): RecommendViewHolder {
+        ): RecentUploadHearitViewHolder {
             val inflater = LayoutInflater.from(parent.context)
-            val binding = ItemRecommendHearitBinding.inflate(inflater, parent, false)
-            return RecommendViewHolder(binding, source, hearitClickListener)
+            val binding = ItemRecentUploadHearitBinding.inflate(inflater, parent, false)
+            return RecentUploadHearitViewHolder(binding, source, hearitClickListener)
         }
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecommendHearitAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecommendHearitAdapter.kt
@@ -1,36 +1,36 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import com.onair.hearit.analytics.HearitSource
-import com.onair.hearit.domain.model.RecentUploadHearit
+import com.onair.hearit.domain.model.RecommendHearit
 import com.onair.hearit.presentation.HearitClickListener
 
-class RecentUploadHearitAdapter(
+class RecommendHearitAdapter(
     private val hearitClickListener: HearitClickListener,
-) : ListAdapter<RecentUploadHearit, RecentUploadHearitViewHolder>(DiffCallback) {
+) : ListAdapter<RecommendHearit, RecommendViewHolder>(DiffCallback) {
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int,
-    ): RecentUploadHearitViewHolder = RecentUploadHearitViewHolder.create(parent, HearitSource.RECENT_UPLOAD, hearitClickListener)
+    ): RecommendViewHolder = RecommendViewHolder.create(parent, HearitSource.RECOMMEND, hearitClickListener)
 
     override fun onBindViewHolder(
-        holder: RecentUploadHearitViewHolder,
+        holder: RecommendViewHolder,
         position: Int,
     ) = holder.bind(getItem(position))
 
     companion object {
-        private val DiffCallback =
-            object : DiffUtil.ItemCallback<RecentUploadHearit>() {
+        val DiffCallback =
+            object : DiffUtil.ItemCallback<RecommendHearit>() {
                 override fun areItemsTheSame(
-                    oldItem: RecentUploadHearit,
-                    newItem: RecentUploadHearit,
+                    oldItem: RecommendHearit,
+                    newItem: RecommendHearit,
                 ): Boolean = oldItem.id == newItem.id
 
                 override fun areContentsTheSame(
-                    oldItem: RecentUploadHearit,
-                    newItem: RecentUploadHearit,
+                    oldItem: RecommendHearit,
+                    newItem: RecommendHearit,
                 ): Boolean = oldItem == newItem
             }
     }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecommendViewHolder.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecommendViewHolder.kt
@@ -1,25 +1,25 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.onair.hearit.analytics.HearitSource
-import com.onair.hearit.databinding.ItemPlayingHistoryHearitBinding
-import com.onair.hearit.domain.model.PlayingHistoryHearit
+import com.onair.hearit.databinding.ItemRecommendHearitBinding
+import com.onair.hearit.domain.model.RecommendHearit
 import com.onair.hearit.presentation.HearitClickListener
 
-class PlayingHistoryHearitViewHolder private constructor(
-    private val binding: ItemPlayingHistoryHearitBinding,
+class RecommendViewHolder(
+    private val binding: ItemRecommendHearitBinding,
     private val source: HearitSource,
     hearitClickListener: HearitClickListener,
 ) : RecyclerView.ViewHolder(binding.root) {
     init {
-        binding.clickListener = hearitClickListener
+        binding.recommendClickListener = hearitClickListener
         binding.source = source
     }
 
-    fun bind(item: PlayingHistoryHearit) {
-        binding.playingHistoryHearit = item
+    fun bind(item: RecommendHearit) {
+        binding.item = item
     }
 
     companion object {
@@ -27,10 +27,10 @@ class PlayingHistoryHearitViewHolder private constructor(
             parent: ViewGroup,
             source: HearitSource,
             hearitClickListener: HearitClickListener,
-        ): PlayingHistoryHearitViewHolder {
+        ): RecommendViewHolder {
             val inflater = LayoutInflater.from(parent.context)
-            val binding = ItemPlayingHistoryHearitBinding.inflate(inflater, parent, false)
-            return PlayingHistoryHearitViewHolder(binding, source, hearitClickListener)
+            val binding = ItemRecommendHearitBinding.inflate(inflater, parent, false)
+            return RecommendViewHolder(binding, source, hearitClickListener)
         }
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecommendationCategoryAdapter.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecommendationCategoryAdapter.kt
@@ -1,4 +1,4 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil

--- a/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecommendationCategoryViewHolder.kt
+++ b/android/app/src/main/java/com/onair/hearit/presentation/home/adapter/RecommendationCategoryViewHolder.kt
@@ -1,4 +1,4 @@
-package com.onair.hearit.presentation.home
+package com.onair.hearit.presentation.home.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -7,6 +7,7 @@ import com.onair.hearit.databinding.ItemRecommendationCategoryBinding
 import com.onair.hearit.domain.model.RecommendationCategories
 import com.onair.hearit.presentation.HearitClickListener
 import com.onair.hearit.presentation.dpToPx
+import com.onair.hearit.presentation.home.HorizontalMarginItemDecoration
 
 class RecommendationCategoryViewHolder(
     private val binding: ItemRecommendationCategoryBinding,

--- a/android/app/src/main/res/layout/fragment_home.xml
+++ b/android/app/src/main/res/layout/fragment_home.xml
@@ -9,9 +9,6 @@
             name="userInfo"
             type="com.onair.hearit.domain.model.UserInfo" />
 
-        <variable
-            name="viewModel"
-            type="com.onair.hearit.presentation.home.HomeViewModel" />
     </data>
 
     <androidx.core.widget.NestedScrollView
@@ -52,8 +49,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:shimmer_auto_start="true"
-                app:visibleIfCondition="@{viewModel.isLoading}">
+                app:shimmer_auto_start="true">
 
                 <include layout="@layout/item_home_skeleton" />
             </com.facebook.shimmer.ShimmerFrameLayout>
@@ -117,7 +113,6 @@
                 android:text="@{@string/home_playing_history_hearit_title(userInfo.nickname)}"
                 app:layout_constraintStart_toStartOf="@id/tv_home_recommend"
                 app:layout_constraintTop_toBottomOf="@id/indicator_container"
-                app:visibleIfCondition="@{!viewModel.isLoading &amp;&amp; viewModel.playingHistoryHearits.size() != 0}"
                 tools:text="hEARit님이 듣고 있는 팟캐스트" />
 
             <androidx.recyclerview.widget.RecyclerView
@@ -170,7 +165,6 @@
                 app:drawableEndCompat="@drawable/ic_right"
                 app:layout_constraintStart_toStartOf="@id/tv_home_recommend"
                 app:layout_constraintTop_toBottomOf="@id/rv_home_recent_upload"
-                app:visibleIfCondition="@{!viewModel.isLoading &amp;&amp; viewModel.playingHistoryHearits.size() != 0}"
                 tools:text="북마크한 팟캐스트를 들어보세요" />
 
             <androidx.recyclerview.widget.RecyclerView
@@ -201,8 +195,7 @@
                 app:drawableEndCompat="@drawable/ic_home_arrow"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/rv_home_playing_bookmark"
-                app:visibleIfCondition="@{!viewModel.isLoading}" />
+                app:layout_constraintTop_toBottomOf="@id/rv_home_playing_bookmark" />
 
             <TextView
                 android:id="@+id/tv_home_wootaeco"
@@ -218,8 +211,7 @@
                 app:drawableEndCompat="@drawable/ic_home_arrow"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_home_shortcast"
-                app:visibleIfCondition="@{!viewModel.isLoading}" />
+                app:layout_constraintTop_toBottomOf="@id/tv_home_shortcast" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_home_recommendation_categories"

--- a/android/app/src/main/res/layout/item_recommendation_category.xml
+++ b/android/app/src/main/res/layout/item_recommendation_category.xml
@@ -29,7 +29,7 @@
             android:drawablePadding="8dp"
             android:gravity="center_vertical"
             android:onClick="@{() -> navigateClickListener.invoke(recommendationCategory.categoryId, recommendationCategory.categoryName, recommendationCategory.colorCode)}"
-            android:text="@{@string/home_grouped_category_text(recommendationCategory.categoryName)}"
+            android:text="@{@string/home_recommendation_category_text(recommendationCategory.categoryName)}"
             app:drawableEndCompat="@drawable/ic_right"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -12,15 +12,15 @@
     <string name="all_account_info">설정 및 계정 정보</string>
     <string name="all_login_button_text">로그인 하러가기</string>
     <string name="all_feedback">피드백 및 문의하기</string>
-    <string name="all_toast_categories_load_fail">카테고리 조회에 실패했습니다.</string>
-    <string name="all_toast_user_info_load_fail">유저 정보 조회에 실패했습니다.</string>
-    <string name="all_toast_save_user_info_fail">유저 정보 저장에 실패했습니다.</string>
-    <string name="all_toast_add_bookmark_fail">북마크 저장에 실패했습니다.</string>
-    <string name="all_toast_delete_bookmark_fail">북마크 삭제에 실패했습니다.</string>
-    <string name="logout_success">로그아웃 되었습니다.</string>
-    <string name="logout_fail">로그아웃에 실패했습니다.</string>
-    <string name="withdraw_success">회원탈퇴에 성공했습니다.</string>
-    <string name="withdraw_fail">회원탈퇴에 실패했습니다.</string>
+    <string name="all_toast_categories_load_fail">카테고리 조회에 실패했습니다</string>
+    <string name="all_toast_user_info_load_fail">유저 정보 조회에 실패했습니다</string>
+    <string name="all_toast_save_user_info_fail">유저 정보 저장에 실패했습니다</string>
+    <string name="all_toast_add_bookmark_fail">북마크 저장에 실패했습니다</string>
+    <string name="all_toast_delete_bookmark_fail">북마크 삭제에 실패했습니다</string>
+    <string name="logout_success">로그아웃 되었습니다</string>
+    <string name="logout_fail">로그아웃에 실패했습니다</string>
+    <string name="withdraw_success">회원탈퇴에 성공했습니다</string>
+    <string name="withdraw_fail">회원탈퇴에 실패했습니다</string>
     <string name="all_keyword_name"># %s</string>
     <string name="all_login_dialog_message_body"><font color="#B677F3">북마크 기능</font>은\n <font color="#B677F3">로그인</font>을 하셔야 이용할 수 있어요!</string>
     <string name="all_dialog_login_positive">로그인</string>
@@ -28,28 +28,27 @@
 
     <!-- HomeFragment-->
     <string name="home_logo_description">IT를 쉽게 들을 수 있는 팟캐스트, 히어릿</string>
-    <string name="home_recent_hearit_text">최근에 들은 히어릿</string>
     <string name="home_recommend_hearit_text">오늘 추천하는 팟캐스트</string>
-    <string name="home_grouped_category_text">%s 카테고리</string>
+    <string name="home_recommendation_category_text">%s 카테고리</string>
     <string name="home_playing_history_hearit_title">%s님이 듣고 있는 팟캐스트</string>
     <string name="home_recent_upload_hearit_title">최근 추가된 팟캐스트</string>
     <string name="home_playing_bookmark_hearit_title">북마크한 팟캐스트를 들어보세요</string>
     <string name="home_navigate_explore_text">숏캐스트를 구경하고\n더 많은 팟캐스트를 북마크해보세요!</string>
     <string name="home_navigate_wootaeco_text">우테코 합격비법이 궁금하다면?\n선배님들의 후기를 들어보세요!</string>
-    <string name="home_toast_recommend_load_fail">추천 히어릿 목록 조회에 실패했습니다.</string>
-    <string name="home_toast_playing_history_load_fail">최근 들은 히어릿 조회에 실패했습니다.</string>
-    <string name="home_toast_recent_upload_load_fail">최근 업로드된 히어릿 조회에 실패했습니다.</string>
-    <string name="home_toast_playing_bookmark_load_fail">듣고 있는 북마크 조회에 실패했습니다.</string>
-    <string name="home_toast_grouped_category_load_fail">카테고리별 히어릿 조회에 실패했습니다.</string>
+    <string name="home_toast_recommend_load_fail">추천 히어릿 목록 조회에 실패했습니다</string>
+    <string name="home_toast_playing_history_load_fail">최근 들은 히어릿 조회에 실패했습니다</string>
+    <string name="home_toast_recent_upload_load_fail">최근 업로드된 히어릿 조회에 실패했습니다</string>
+    <string name="home_toast_playing_bookmark_load_fail">듣고 있는 북마크 조회에 실패했습니다</string>
+    <string name="home_toast_recommendation_category_load_fail">카테고리별 히어릿 조회에 실패했습니다</string>
 
     <!--CategoryFragment-->
     <string name="category_text">전체 카테고리 목록</string>
     <string name="category_toast_searched_hearits_load_fail">카테고리 히어릿 목록 조회에 실패했습니다</string>
 
     <!-- CreateHearitActivity-->
-    <string name="create_hearit_main_title"><font color="#B677F3">생성하고자 하는 텍스트</font><font color="#EFF1F2">를 입력해주세요.</font></string>
-    <string name="create_hearit_sub_title">AI가 자동으로 텍스트를 요약해서 히어릿을 생성해 드립니다.</string>
-    <string name="create_hearit_hearit_source">HTTP와 HTTPS는 보안에서 차이가 있습니다.</string>
+    <string name="create_hearit_main_title"><font color="#B677F3">생성하고자 하는 텍스트</font><font color="#EFF1F2">를 입력해주세요</font></string>
+    <string name="create_hearit_sub_title">AI가 자동으로 텍스트를 요약해서 히어릿을 생성해 드립니다</string>
+    <string name="create_hearit_hearit_source">HTTP와 HTTPS는 보안에서 차이가 있습니다</string>
     <string name="create_hearit_source_count">0 자</string>
     <string name="create_hearit_button">hEARit 생성하기</string>
 
@@ -72,23 +71,23 @@
     <string name="player_detail_source_text"><u>%s</u></string>
     <string name="player_detail_player_duration_remaining">-%1$s</string>
     <string name="player_detail_player_speed_label">%1$sx</string>
-    <string name="player_detail_toast_single_hearit_load_fail">단일 히어릿 조회에 실패했습니다.</string>
-    <string name="player_detail_toast_hearit_load_fail">히어릿 조회에 실패했습니다.</string>
-    <string name="player_detail_toast_recent_save_fail">최근 들은 히어릿 저장에 실패했습니다.</string>
-    <string name="player_detail_invite_error_kakao">카카오톡으로 공유하는 중 오류가 발생했습니다.</string>
+    <string name="player_detail_toast_single_hearit_load_fail">단일 히어릿 조회에 실패했습니다</string>
+    <string name="player_detail_toast_hearit_load_fail">히어릿 조회에 실패했습니다</string>
+    <string name="player_detail_toast_recent_save_fail">최근 들은 히어릿 저장에 실패했습니다</string>
+    <string name="player_detail_invite_error_kakao">카카오톡으로 공유하는 중 오류가 발생했습니다</string>
     <string name="player_detail_invite_error_browser">웹 브라우저를 찾을 수 없어 공유할 수 없습니다</string>
 
     <!-- ExploreFragment-->
     <string name="explore_hearit_guide"><font color="#B677F3">1분 미리듣기</font> 로 원하는 히어릿을 찾아보세요!</string>
-    <string name="explore_toast_random_hearits_load_fail">랜덤 히어릿 목록 조회에 실패했습니다.</string>
-    <string name="explore_toast_shorts_hearits_load_fail">탐색 쇼츠 목록 조회에 실패했습니다.</string>
+    <string name="explore_toast_random_hearits_load_fail">랜덤 히어릿 목록 조회에 실패했습니다</string>
+    <string name="explore_toast_shorts_hearits_load_fail">탐색 쇼츠 목록 조회에 실패했습니다</string>
     <string name="explore_navigate_to_detail_hearit">팟캐스트 이어 듣기</string>
 
     <!-- SettingFragment-->
     <string name="setting_notification">알림</string>
     <string name="setting_recommend_notification">히어릿 추천 알림</string>
     <string name="setting_app_version">앱 버전 v%s</string>
-    <string name="setting_toast_user_info_load_fail">유저 정보 조회에 실패했습니다.</string>
+    <string name="setting_toast_user_info_load_fail">유저 정보 조회에 실패했습니다</string>
 
     <!-- LibraryFragment-->
     <string name="library_guide">오늘은 어떤 <font color="#B677F3">히어릿</font>을 들어볼까요?</string>
@@ -96,7 +95,7 @@
     <string name="library_guide_when_no_bookmark">북마크한 <font color="#B677F3">히어릿</font>이 없어요!\n히어릿과 함께 IT 트렌드를 모아볼까요?</string>
     <string name="library_guide_when_no_login"><font color="#B677F3">히어릿</font>을 모아서 듣고 싶다면,\n로그인을 해주세요!</string>
     <string name="library_login_button_text">로그인 하러가기</string>
-    <string name="library_toast_bookmark_load_fail">북마크 조회에 실패했습니다.</string>
+    <string name="library_toast_bookmark_load_fail">북마크 조회에 실패했습니다</string>
     <string name="library_bottom_sheet_bookmark_delete">북마크에서 삭제하기</string>
     <string name="library_bookmarked_hearit_total_count">히어릿 %d개</string>
 
@@ -116,8 +115,8 @@
 
     <!-- SearchResultFragment-->
     <string name="search_result_searched_hearit">검색된 히어릿 목록</string>
-    <string name="search_toast_searched_hearits_load_fail">검색 히어릿 목록 조회에 실패했습니다.</string>
-    <string name="search_toast_recent_hearit_save_fail">최근 검색어 저장에 실패했습니다.</string>
+    <string name="search_toast_searched_hearits_load_fail">검색 히어릿 목록 조회에 실패했습니다</string>
+    <string name="search_toast_recent_hearit_save_fail">최근 검색어 저장에 실패했습니다</string>
 
     <!-- SplashActivity-->
     <string name="splash_toast_access_token_load_fail">저장된 토큰 조회에 실패했습니다</string>
@@ -127,16 +126,16 @@
 
     <!-- LoginActivity-->
     <string name="login_with_hearit">회원가입 없이 <font color="#B677F3">히어릿</font>을 이용하고 싶어요</string>
-    <string name="login_toast_kakao_login_fail">카카오 로그인에 실패했습니다.</string>
-    <string name="login_toast_save_token_fail">토큰 저장에 실패했습니다.</string>
+    <string name="login_toast_kakao_login_fail">카카오 로그인에 실패했습니다</string>
+    <string name="login_toast_save_token_fail">토큰 저장에 실패했습니다</string>
 
     <!-- MainActivity-->
-    <string name="main_toast_recent_load_fail">최근 들은 히어릿 조회에 실패했습니다.</string>
-    <string name="main_toast_load_player_hearit_fail">플레이어 설정에 실패했습니다.</string>
+    <string name="main_toast_recent_load_fail">최근 들은 히어릿 조회에 실패했습니다</string>
+    <string name="main_toast_load_player_hearit_fail">플레이어 설정에 실패했습니다</string>
     <string name="main_bottom_player_default_title">제목 없음</string>
-    <string name="main_toast_finish_back_pressed">뒤로가기 버튼을 한 번 더 누르면 종료됩니다.</string>
-    <string name="main_toast_player_last_position_save_fail">마지막 포지션 저장에 실패했습니다.</string>
-    <string name="main_toast_clear_token_fail">액세스 토큰 삭제에 실패했습니다.</string>
+    <string name="main_toast_finish_back_pressed">뒤로가기 버튼을 한 번 더 누르면 종료됩니다</string>
+    <string name="main_toast_player_last_position_save_fail">마지막 포지션 저장에 실패했습니다</string>
+    <string name="main_toast_clear_token_fail">액세스 토큰 삭제에 실패했습니다</string>
 
     <!-- BottomPlayerView-->
     <string name="bottom_player_view_default_duration">--:--</string>
@@ -144,15 +143,15 @@
     <!-- PlaybackService-->
     <string name="notification_channel_name">Hearit 재생 알림</string>
     <string name="notification_title_preparing">히어릿 재생 준비 중</string>
-    <string name="notification_text_preparing">재생을 준비하고 있어요.</string>
+    <string name="notification_text_preparing">재생을 준비하고 있어요</string>
     <string name="notification_title_playing">히어릿 재생 중</string>
-    <string name="notification_text_playing">음악이 재생되고 있어요.</string>
+    <string name="notification_text_playing">음악이 재생되고 있어요</string>
 
     <!-- Dialog-->
     <string name="dialog_logout_loading_text">로그아웃 중입니다..</string>
     <string name="dialog_withdraw">탈퇴</string>
     <string name="dialog_withdraw_title">회원탈퇴</string>
-    <string name="dialog_withdraw_message">"정말 탈퇴하시겠습니까?\n탈퇴 시 모든 데이터가 삭제됩니다."</string>
+    <string name="dialog_withdraw_message">정말 탈퇴하시겠습니까?\n탈퇴 시 모든 데이터가 삭제됩니다</string>
 
     <!-- PlaylistBottomSheet-->
     <string name="playlist_bottom_sheet_playlist_title">재생목록</string>


### PR DESCRIPTION
## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- viewModel에 livedata 변수가 너무 많음
- homeUiState로 uiState + 로딩 상태 관리
- LiveData -> StateFlow로 변환

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->
- viewModel에 흩어져있던 상태변수들을 HomeUiState로 묶어서 관리했습니다.
- 또한, 바꾸는 김에 LiveData -> StateFlow로 변경했습니다.
- 로딩 상태에 따른 visible에서도 dataBinding등도 다 없애고 fragment에서 처리하도록  변경했습니다.

- async/await으로 api 5개를 관리하고 있었는데, api호출 함수를 각각으로 분리하고 loading중인 api호출 작업과 finish된 작업을 key로 관리하도록 바꿨는데, 어떻게 생각하시나요??
```
private fun startLoading(jobKey: String) {
    loadingJobs.add(jobKey)
    _uiState.update { it.copy(isLoading = true) }
}

private fun finishLoading(jobKey: String) {
    loadingJobs.remove(jobKey)
    if (loadingJobs.isEmpty()) {
        _uiState.update { it.copy(isLoading = false) }
    }
}
```


## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#711 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Wootaeco 항목 선택 시 분석 이벤트 로그 추가

* **리팩토링**
  * 홈 화면을 통합된 UI 상태로 전환해 섹션별(추천, 재생 기록, 최근 업로드, 북마크 등) 동기화된 업데이트 제공
  * 라이프사이클 기반 코루틴 수집으로 UI 업데이트 신뢰성 향상
  * 섹션별 개별 로딩 키 도입으로 로딩 표시 및 오류 처리 개선

* **문서/문구**
  * 여러 UI 문자열 문구·구두점 정리 및 리소스 키 일부명 변경 (홈 추천 카테고리 텍스트)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->