### PR TITLE
[BE] chore: Master/Replica 포트 환경변수 분리

### DIFF
--- a/backend/boot/src/main/resources/application-dev.properties
+++ b/backend/boot/src/main/resources/application-dev.properties
@@ -8,7 +8,7 @@ spring.config.import=optional:file:.env[.properties]
 # ==================================
 # Master (Primary)
 # ==================================
-spring.datasource.master.jdbc-url=jdbc:mysql://${MYSQL_WRITER_ENDPOINT}:${MYSQL_PORT}/${MYSQL_DATABASE}?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.master.jdbc-url=jdbc:mysql://${MYSQL_WRITER_ENDPOINT}:${MYSQL_WRITER_PORT}/${MYSQL_DATABASE}?rewriteBatchedStatements=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.master.username=${MYSQL_WRITER_USERNAME}
 spring.datasource.master.password=${MYSQL_WRITER_PASSWORD}
 spring.datasource.master.driver-class-name=com.mysql.cj.jdbc.Driver
@@ -27,7 +27,7 @@ spring.datasource.master.hikari.keepalive-time=300000
 # ==================================
 # Replica
 # ==================================
-spring.datasource.replica.jdbc-url=jdbc:mysql://${MYSQL_READER_ENDPOINT}:${MYSQL_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+spring.datasource.replica.jdbc-url=jdbc:mysql://${MYSQL_READER_ENDPOINT}:${MYSQL_READER_PORT}/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
 spring.datasource.replica.username=${MYSQL_READER_USERNAME}
 spring.datasource.replica.password=${MYSQL_READER_PASSWORD}
 spring.datasource.replica.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- application-properties에 있는 동일한 포트를 하나의 서버로 Replication을 구현하면서 포트 분리가 필요해 변경합니다.

## 📢 논의하고 싶은 내용
.env 가 변경되었으니 확인 부탁드립니다.

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #726 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 연결 설정을 최적화하여 마스터 및 복제 데이터베이스 서버의 포트 구성을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->