### PR TITLE
[BE] chore: prod cd를 self-hosted runner 방식에서 s3 업로드/다운 방식으로 변경 #730

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -1,5 +1,9 @@
 name: Backend CD to EC2 for prod
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
 #  push:
 #    branches: [ "release" ]

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -1,10 +1,12 @@
 name: Backend CD to EC2 for prod
 
 on:
-  push:
-    branches: [ "release" ]
-    paths:
-      - 'backend/**'
+#  push:
+#    branches: [ "release" ]
+  pull_request:
+    branches: [ "develop-be", "730-chore-prod-cd-change-to-s3" ]
+#    paths:
+#      - 'backend/**'
   workflow_dispatch:
 
 jobs:
@@ -50,32 +52,46 @@ jobs:
         working-directory: backend
         run: ./gradlew clean :boot:bootJar
 
-      - name: Rename jar to app.jar
+      - name: Rename jar with timestamp
         working-directory: backend/boot/build/libs
         run: |
+          TS=$(date +"%Y%m%d-%H%M%S")
           JAR_NAME=$(find . -name "*.jar" ! -name "*-plain.jar")
-          mv "$JAR_NAME" app.jar
+          NEW_NAME="app-${TS}.jar"
+          mv "$JAR_NAME" "$NEW_NAME"
+          echo "NEW_JAR_NAME=$NEW_NAME" >> $GITHUB_ENV
 
-      - name: Upload jar artifact
-        uses: actions/upload-artifact@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          name: backend-jar
-          path: backend/boot/build/libs/app.jar
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ap-northeast-2
+
+      - name: Upload jar to S3
+        run: |
+          aws s3 cp backend/boot/build/libs/${{ env.NEW_JAR_NAME }} \
+            s3://hearit-artifacts/prod/${{ env.NEW_JAR_NAME }}
 
   deploy:
     name: Deploy on EC2 for prod
     needs: build
-    runs-on: [ self-hosted, backend-prod, Linux, ARM64 ]
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Download jar artifact
-        uses: actions/download-artifact@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          name: backend-jar
-          path: ~/hearit
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: ap-northeast-2
 
-      - name: Make deploy script executable
-        run: sudo chmod +x ~/hearit/deploy.sh
-
-      - name: Run deploy script with sudo
-        run: sudo bash ~/hearit/deploy.sh
+      - name: Deploy using SSM
+        run: |
+          aws ssm send-command \
+            --instance-ids "${{ secrets.PROD_EC2_ID }}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Deploy hEARit backend" \
+            --parameters "commands=[
+              \"aws s3 cp s3://hearit-artifacts/prod/${{ env.NEW_JAR_NAME }} /home/ubuntu/hearit/app.jar\",
+              \"sudo bash /home/ubuntu/hearit/deploy.sh\"
+            ]" \
+            --region ap-northeast-2


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **시스템 개선 사항**
  * 배포 파이프라인을 클라우드 스토리지(S3) 기반으로 전환하여 아티팩트 관리와 내구성을 향상했습니다.
  * 원격 운영 방식이 SSH에서 시스템 관리 서비스(SSM) 기반으로 변경되어 배포 안정성이 높아졌습니다.
  * 빌드 출력에 타임스탬프를 포함해 고유 아티팩트 식별과 롤백·추적을 개선했습니다.
  * 빌드/배포 트리거와 권한 설정을 조정해 더 유연하고 안전한 배포 흐름을 구성했습니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->