### PR TITLE
[BE] chore: prod cd 트리거를 release로 변경

### DIFF
--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -5,12 +5,10 @@ permissions:
   contents: read
 
 on:
-#  push:
-#    branches: [ "release" ]
-  pull_request:
-    branches: [ "develop-be", "730-chore-prod-cd-change-to-s3" ]
-#    paths:
-#      - 'backend/**'
+  push:
+    branches: [ "release" ]
+    paths:
+      - 'backend/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **Chores**
  * 백엔드 배포 자동화 워크플로우가 개선되었습니다. 릴리스 브랜치로의 푸시 시 프로덕션 배포가 자동으로 시작되도록 변경되었으며, 백엔드 관련 파일 변경 시에만 배포가 트리거됩니다. 수동 배포 트리거 옵션도 계속 지원됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->