### PR TITLE
[BE] feat: 서비스 라벨링(MDC) 추가 및 Admin 로깅 활성화 #737

### DIFF
--- a/backend/core/src/main/java/com/onair/hearit/core/log/ApiLoggingAspect.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/log/ApiLoggingAspect.java
@@ -53,19 +53,18 @@ public class ApiLoggingAspect {
     public void patchMapping() {
     }
 
-    @Pointcut("(getMapping() || postMapping() || deleteMapping() || putMapping() || patchMapping())"
-            + "&& !within(com.onair.hearit.admin..*)")
+    @Pointcut("(getMapping() || postMapping() || deleteMapping() || putMapping() || patchMapping())")
     public void allMapping() {
     }
 
     @Pointcut("(@within(org.springframework.web.bind.annotation.RestControllerAdvice)" +
-            "|| @within(org.springframework.web.bind.annotation.ControllerAdvice))" +
-            "&& !within(com.onair.hearit.admin..*)")
+              "|| @within(org.springframework.web.bind.annotation.ControllerAdvice))")
     public void exceptionHandler() {
     }
 
     @Before("allMapping()")
     public void logRequest(JoinPoint joinPoint) {
+        setServiceLabel(joinPoint);
         MDC.put(LOGGED_BY_AOP, TRUE);
         HttpServletRequest httpServletRequest = getHttpServletRequest();
         RequestLogProperty requestLogProperty = RequestLogProperty.of(httpServletRequest, joinPoint);
@@ -92,6 +91,7 @@ public class ApiLoggingAspect {
 
     @AfterReturning(value = "exceptionHandler()", returning = "problemDetail")
     public void logExceptionHandler(JoinPoint joinPoint, ProblemDetail problemDetail) {
+        setServiceLabel(joinPoint);
         if (!TRUE.equals(MDC.get(LOGGED_BY_AOP))) {
             logRequest(joinPoint);
             MDC.put(LOGGED_BY_AOP, TRUE);
@@ -119,6 +119,15 @@ public class ApiLoggingAspect {
         } catch (Exception e) {
             jsonLogger.error("Error 로깅 중 예외가 발생했습니다.", e);
         }
+    }
+
+    private void setServiceLabel(JoinPoint joinPoint) {
+        String declaringTypeName = joinPoint.getSignature().getDeclaringTypeName();
+        if (declaringTypeName.startsWith("com.onair.hearit.admin")) {
+            MDC.put("service", "hearit-admin");
+            return;
+        }
+        MDC.put("service", "hearit-app");
     }
 
     private Optional<Throwable> extractThrowableFromArgs(Object[] args) {

--- a/backend/core/src/main/resources/log4j2/log4j2.xml
+++ b/backend/core/src/main/resources/log4j2/log4j2.xml
@@ -46,10 +46,13 @@
                     objectMessageAsJsonObject="true"
                     charset="UTF-8">
                 <!-- log context-->
+                <KeyValuePair key="service" value="$${ctx:service}"/>
+                <KeyValuePair key="port" value="${spring:server.port}"/>
                 <KeyValuePair key="ip" value="$${ctx:ip}"/>
                 <KeyValuePair key="timestamp" value="$${ctx:timestamp}"/>
                 <KeyValuePair key="androidAppVersion" value="$${ctx:androidAppVersion}"/>
                 <KeyValuePair key="serverVersion" value="$${ctx:serverVersion}"/>
+                <KeyValuePair key="env" value="${env}"/>
 
                 <!-- user context -->
                 <KeyValuePair key="userType" value="$${ctx:userType}"/>
@@ -59,8 +62,6 @@
                 <!-- OpenTelemetry trace 정보 추가 -->
                 <KeyValuePair key="traceId" value="$${ctx:trace_id}"/>
                 <KeyValuePair key="spanId" value="$${ctx:span_id}"/>
-                <KeyValuePair key="port" value="${spring:server.port}"/>
-                <KeyValuePair key="env" value="${env}"/>
             </JsonLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>


### PR DESCRIPTION
## 📌 변경 내용 & 이유

### 1. service MDC 및 JSON 로깅 필드 추가 (hearit-app, hearit-admin)
- 서비스(Log Stream) 단위를 명확하게 분리하기 위해 MDC.put("service", …) 구조 추가
- AOP에서 호출되는 클래스 패키지(com.onair.hearit.admin..*) 기준으로 hearit-admin 또는 hearit-app
자동 라벨링 적용
- Log4j2 JSON Layout에 service 필드 추가
- Promtail → Loki 라벨링에서 service 값을 그대로 활용 가능
→ Promtail에서 서비스별 필터링, 대시보드 분리 지원

### 2. 기존 Admin API 로깅 제외 조건 제거
- 이전에는 AOP 포인트컷에 !within(com.onair.hearit.admin..*) 가 포함되어 admin API 로깅이 누락됨
- 이 조건을 제거하여 Admin 도 모든 요청/응답/예외 로깅 대상으로 변경
- 서비스 단위는 service 필드로 구분

### 3. JSON 로그 스키마 개선
- env를 message에서 발췌하지않고 가장 상위 depth에 추가
    - 기존: message.env -> 변경: env
    - 환경은 message가 없어도 일관되게 추가되어야하기 때문

### 4. Promtail 설정과의 일관성 확보
- 로그 JSON에 service/env 필드를 넣어 json → labels stage 에서 정상적으로 Promtail 라벨 생성됨
- Loki 조회 시
    - {service="hearit-app"}
    - {service="hearit-admin"}

## 📸 변경된 로그 예시 (발췌)

```
{
  "service": "hearit-app",
  "env": "dev",
  "ip": "10.0.1.12",
  "userType": "guest",
  "eventName": "Api_Response",
  "endPoint": "/api/v1/hearits",
  "timeTakenMs": 234,
  "status": 200
}
```

## 🧪 테스트 방법
1. App API 호출 테스트
- /api/v1/hearits 또는 임의의 사용자 API 호출
- all-level.log 내에서 "service": "hearit-app" 값 확인
- Loki → {service="hearit-app"} 조회로 확인

2. Admin API 호출 테스트
- /admin/... API 호출
- "service": "hearit-admin" 값이 정상 출력되는지 확인

3. 예외 발생 테스트
- 고의로 400/500 발생
- ExceptionLogProperty 출력 시에도 service 필드 포함되는지 확인


## 🧩 관련 이슈
close #737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로그에 서비스 식별자(service), 포트 및 환경(env) 정보를 추가해 모니터링 데이터가 확장되었습니다.
* **Bug Fixes**
  * 요청 및 예외 로그에서 서비스 레이블이 조기에 설정되도록 개선하여, 어드민/앱 구분이 일관되게 반영됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->