### PR TITLE
[BE] refactor: 재생기록 관련 로직의 식별 기준을 memberId에서 userUuid로 전환

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/bookmark/application/BookmarkService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/bookmark/application/BookmarkService.java
@@ -45,7 +45,7 @@ public class BookmarkService {
         }
         Member member = getMemberByUserInfo(userInfo);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size(), sort.toSort());
-        Page<BookmarkWithPlayingHistoryProjection> projections = bookmarkRepository.findFilteredByMember(member.getId(),
+        Page<BookmarkWithPlayingHistoryProjection> projections = bookmarkRepository.findFilteredByMember(member.getUuid(),
                 filter.isFinished(), pageable);
         return PagedResponse.from(toBookmarkHearitResponse(projections));
     }
@@ -58,7 +58,7 @@ public class BookmarkService {
         Member member = getMemberByUserInfo(userInfo);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size(),
                 Sort.by(Direction.DESC, "createdAt"));
-        Page<BookmarkWithPlayingHistoryProjection> projections = bookmarkRepository.findFilteredByMember(member.getId(),
+        Page<BookmarkWithPlayingHistoryProjection> projections = bookmarkRepository.findFilteredByMember(member.getUuid(),
                 filter.isFinished(), pageable);
         return PagedResponse.from(toBookmarkHearitResponse(projections));
     }

--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitSearchService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitSearchService.java
@@ -3,17 +3,14 @@ package com.onair.hearit.app.hearit.application;
 import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.hearit.dto.HearitSearchResponse;
+import com.onair.hearit.app.userInfo.application.UserInfoService;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.HearitKeyword;
 import com.onair.hearit.core.domain.Keyword;
-import com.onair.hearit.core.domain.Member;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.domain.UserInfo;
-import com.onair.hearit.app.exception.custom.NotFoundException;
-import com.onair.hearit.app.exception.custom.UnauthenticatedException;
 import com.onair.hearit.core.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
-import com.onair.hearit.core.infrastructure.jpa.MemberRepository;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import java.util.Arrays;
 import java.util.List;
@@ -32,19 +29,16 @@ public class HearitSearchService {
 
     private final HearitRepository hearitRepository;
     private final HearitKeywordRepository hearitKeywordRepository;
-    private final MemberRepository memberRepository;
     private final PlayingHistoryRepository playingHistoryRepository;
+    private final UserInfoService userInfoService;
 
     @Transactional(readOnly = true)
     public PagedResponse<HearitSearchResponse> search(String searchTerm, PagingRequest pagingRequest,
                                                       UserInfo userInfo) {
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size());
         Page<Hearit> hearits = hearitRepository.searchByTerm(toBooleanModeQuery(searchTerm), pageable);
-        if (userInfo == null || userInfo.isGuest()) {
-            return PagedResponse.from(toHearitSearchResponseForGuest(hearits));
-        }
-        Member member = getMemberByUserInfo(userInfo);
-        return PagedResponse.from(toHearitSearchResponseForMember(hearits, member));
+        String userUuid = userInfoService.getUuid(userInfo);
+        return PagedResponse.from(toHearitSearchResponse(hearits, userUuid));
     }
 
     private String toBooleanModeQuery(String searchTerm) {
@@ -59,17 +53,11 @@ public class HearitSearchService {
         return token.replaceAll("[+\\-~<>()\"*@]", "");
     }
 
-    private Page<HearitSearchResponse> toHearitSearchResponseForGuest(Page<Hearit> hearits) {
-        List<Long> hearitIds = hearits.getContent().stream().map(Hearit::getId).toList();
-        Map<Long, List<Keyword>> hearitKeywords = getHearitKeywords(hearitIds);
-        return hearits.map(hearit -> HearitSearchResponse.of(hearit, hearitKeywords.get(hearit.getId()), null));
-    }
-
-    private Page<HearitSearchResponse> toHearitSearchResponseForMember(Page<Hearit> hearits, Member member) {
+    private Page<HearitSearchResponse> toHearitSearchResponse(Page<Hearit> hearits, String userUuid) {
         List<Long> hearitIds = hearits.getContent().stream().map(Hearit::getId).toList();
         Map<Long, List<Keyword>> hearitKeywords = getHearitKeywords(hearitIds);
         Map<Long, PlayingHistory> playingHistories =
-                playingHistoryRepository.findByMemberIdAndHearitIdIn(member.getId(), hearitIds)
+                playingHistoryRepository.findByUserUuidAndHearitIdIn(userUuid, hearitIds)
                         .stream()
                         .collect(Collectors.toMap(
                                 PlayingHistory::getHearitId,
@@ -85,17 +73,5 @@ public class HearitSearchService {
                 .stream()
                 .collect(Collectors.groupingBy(hk -> hk.getHearit().getId(),
                         Collectors.mapping(HearitKeyword::getKeyword, Collectors.toList())));
-    }
-
-    private Member getMemberByUserInfo(UserInfo useruserInfo) {
-        if (useruserInfo == null || useruserInfo.isGuest()) {
-            throw new UnauthenticatedException();
-        }
-        return getMemberById(useruserInfo.getMemberId());
-    }
-
-    private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NotFoundException("memberId", memberId.toString()));
     }
 }

--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitSearchService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitSearchService.java
@@ -3,7 +3,7 @@ package com.onair.hearit.app.hearit.application;
 import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.hearit.dto.HearitSearchResponse;
-import com.onair.hearit.app.userInfo.application.UserInfoService;
+import com.onair.hearit.app.userinfo.application.UserInfoService;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.HearitKeyword;
 import com.onair.hearit.core.domain.Keyword;

--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitService.java
@@ -7,7 +7,7 @@ import com.onair.hearit.app.exception.custom.UnauthenticatedException;
 import com.onair.hearit.app.hearit.dto.HearitDetailResponse;
 import com.onair.hearit.app.hearit.dto.HearitOverviewResponse;
 import com.onair.hearit.app.hearit.dto.HearitSortRequest;
-import com.onair.hearit.app.userInfo.application.UserInfoService;
+import com.onair.hearit.app.userinfo.application.UserInfoService;
 import com.onair.hearit.core.domain.Bookmark;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.HearitKeyword;

--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitService.java
@@ -7,6 +7,7 @@ import com.onair.hearit.app.exception.custom.UnauthenticatedException;
 import com.onair.hearit.app.hearit.dto.HearitDetailResponse;
 import com.onair.hearit.app.hearit.dto.HearitOverviewResponse;
 import com.onair.hearit.app.hearit.dto.HearitSortRequest;
+import com.onair.hearit.app.userInfo.application.UserInfoService;
 import com.onair.hearit.core.domain.Bookmark;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.HearitKeyword;
@@ -43,6 +44,7 @@ public class HearitService {
     private final BookmarkRepository bookmarkRepository;
     private final HearitKeywordRepository hearitKeywordRepository;
     private final PlayingHistoryRepository playingHistoryRepository;
+    private final UserInfoService userInfoService;
 
     @Transactional(readOnly = true)
     public HearitDetailResponse getHearitDetail(Long hearitId, UserInfo userInfo) {
@@ -73,8 +75,8 @@ public class HearitService {
     }
 
     private Long calculateLastPlayTime(Hearit hearit, Member member) {
-        Optional<Long> optionalLastPlayTime = playingHistoryRepository.findByHearitIdAndMemberId(hearit.getId(),
-                        member.getId())
+        Optional<Long> optionalLastPlayTime = playingHistoryRepository.findByHearitIdAndUserUuid(hearit.getId(),
+                        member.getUuid())
                 .map(PlayingHistory::getLastPlayTime);
         if (optionalLastPlayTime.isEmpty()) {
             return null;
@@ -95,11 +97,11 @@ public class HearitService {
     @Transactional(readOnly = true)
     public PagedResponse<HearitOverviewResponse> getFilteredHearits(
             Long categoryId, HearitSortRequest sortRequest, UserInfo userInfo, PagingRequest pagingRequest) {
-        Long memberId = (userInfo == null || userInfo.isGuest()) ? null : userInfo.getMemberId();
+        String userUuid = userInfoService.getUuid(userInfo);
         Pageable pageable = PageRequest.of(pagingRequest.page(), pagingRequest.size(), sortRequest.toSort());
         Page<HearitWithPlayTimeProjection> hearitsWithPlayTime = hearitRepository.findWithPlayTimeBy(
                 categoryId,
-                memberId,
+                userUuid,
                 pageable
         );
         List<Long> hearitIds = hearitsWithPlayTime.stream()

--- a/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
@@ -65,9 +65,6 @@ public class PlayingHistoryService {
     }
 
     public void addPlayingHistory(UserInfo userInfo, PlayingHistoryRequest request) {
-        if (userInfo == null || userInfo.isGuest()) {
-            return;
-        }
         Hearit hearit = getHearitById(request.hearitId());
         String userUuid = userInfoService.getUuid(userInfo);
         PlayingHistory history = new PlayingHistory(userUuid, hearit, request.lastPlayTime());

--- a/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
@@ -4,7 +4,7 @@ import com.onair.hearit.app.exception.custom.NotFoundException;
 import com.onair.hearit.app.playinghistory.dto.PlayingHistoryRequest;
 import com.onair.hearit.app.playinghistory.dto.RecentlyPlayedHearitResponse;
 import com.onair.hearit.app.playinghistory.infrastructure.scheduler.PlayingHistoryBuffer;
-import com.onair.hearit.app.userInfo.application.UserInfoService;
+import com.onair.hearit.app.userinfo.application.UserInfoService;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.domain.UserInfo;

--- a/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
@@ -37,7 +37,7 @@ public class PlayingHistoryService {
     }
 
     private List<RecentlyPlayedHearitResponse> toPlayingHistoryResponse(String userUuid) {
-        List<PlayingHistory> histories = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(
+        List<PlayingHistory> histories = playingHistoryRepository.findByUserUuidOrderByUpdatedAtDesc(
                 userUuid, PLAYING_HISTORY_MAX_COUNT);
         Map<Long, Long> lastPlayTimeByHearitId = mapHearitIdToLastPlayTime(histories);
         Map<Long, Hearit> hearitMap = mapHearitIdToHearit(lastPlayTimeByHearitId.keySet());

--- a/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryService.java
@@ -4,12 +4,12 @@ import com.onair.hearit.app.exception.custom.NotFoundException;
 import com.onair.hearit.app.playinghistory.dto.PlayingHistoryRequest;
 import com.onair.hearit.app.playinghistory.dto.RecentlyPlayedHearitResponse;
 import com.onair.hearit.app.playinghistory.infrastructure.scheduler.PlayingHistoryBuffer;
+import com.onair.hearit.app.userInfo.application.UserInfoService;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.domain.UserInfo;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,18 +28,17 @@ public class PlayingHistoryService {
     private final HearitRepository hearitRepository;
     private final PlayingHistoryRepository playingHistoryRepository;
     private final PlayingHistoryBuffer playingHistoryBuffer;
+    private final UserInfoService userInfoService;
 
     @Transactional(readOnly = true)
     public List<RecentlyPlayedHearitResponse> getRecentPlayingHistory(UserInfo userInfo) {
-        if (userInfo == null || userInfo.isGuest()) {
-            return Collections.emptyList();
-        }
-        return toPlayingHistoryResponse(userInfo.getMemberId());
+        String userUuid = userInfoService.getUuid(userInfo);
+        return toPlayingHistoryResponse(userUuid);
     }
 
-    private List<RecentlyPlayedHearitResponse> toPlayingHistoryResponse(Long memberId) {
+    private List<RecentlyPlayedHearitResponse> toPlayingHistoryResponse(String userUuid) {
         List<PlayingHistory> histories = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(
-                memberId, PLAYING_HISTORY_MAX_COUNT);
+                userUuid, PLAYING_HISTORY_MAX_COUNT);
         Map<Long, Long> lastPlayTimeByHearitId = mapHearitIdToLastPlayTime(histories);
         Map<Long, Hearit> hearitMap = mapHearitIdToHearit(lastPlayTimeByHearitId.keySet());
         return lastPlayTimeByHearitId.entrySet().stream()
@@ -70,7 +69,8 @@ public class PlayingHistoryService {
             return;
         }
         Hearit hearit = getHearitById(request.hearitId());
-        PlayingHistory history = new PlayingHistory(userInfo.getMemberId(), hearit, request.lastPlayTime());
+        String userUuid = userInfoService.getUuid(userInfo);
+        PlayingHistory history = new PlayingHistory(userUuid, hearit, request.lastPlayTime());
         playingHistoryBuffer.add(history);
     }
 

--- a/backend/app/src/main/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryController.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryController.java
@@ -23,6 +23,7 @@ public class PlayingHistoryController {
     private final PlayingHistoryService playingHistoryService;
 
     @GetMapping("/hearits")
+    //TODO: 재생기록 개수 파라미터로 받기
     public ResponseEntity<List<RecentlyPlayedHearitResponse>> readPlayingHistories(
             @AuthenticationPrincipal RequestUser requestUser) {
         List<RecentlyPlayedHearitResponse> responses =

--- a/backend/app/src/main/java/com/onair/hearit/app/userInfo/application/UserInfoService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/userInfo/application/UserInfoService.java
@@ -1,0 +1,23 @@
+package com.onair.hearit.app.userInfo.application;
+
+import com.onair.hearit.app.exception.custom.NotFoundException;
+import com.onair.hearit.core.domain.UserInfo;
+import com.onair.hearit.core.infrastructure.jpa.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserInfoService {
+
+    private final MemberRepository memberRepository;
+
+    public String getUuid(UserInfo userInfo) {
+        if (userInfo.isGuest()) {
+            return userInfo.getGuestId();
+        }
+
+        return memberRepository.findUuidById(userInfo.getMemberId())
+                .orElseThrow(() -> new NotFoundException("memberId", userInfo.getMemberId().toString()));
+    }
+}

--- a/backend/app/src/main/java/com/onair/hearit/app/userinfo/application/UserInfoService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/userinfo/application/UserInfoService.java
@@ -1,4 +1,4 @@
-package com.onair.hearit.app.userInfo.application;
+package com.onair.hearit.app.userinfo.application;
 
 import com.onair.hearit.app.exception.custom.NotFoundException;
 import com.onair.hearit.core.domain.UserInfo;

--- a/backend/app/src/test/java/com/onair/hearit/app/bookmark/application/BookmarkServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/bookmark/application/BookmarkServiceTest.java
@@ -91,7 +91,7 @@ class BookmarkServiceTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 1));
+        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 1));
 
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
 
@@ -120,7 +120,7 @@ class BookmarkServiceTest {
         Hearit finished = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark1 = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, finished));
         PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), finished, 500_000L));
+                new PlayingHistory(member.getUuid(), finished, 500_000L));
 
         Hearit unfinished = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark2 = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, unfinished));

--- a/backend/app/src/test/java/com/onair/hearit/app/bookmark/presentation/BookmarkIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/bookmark/presentation/BookmarkIntegrationTest.java
@@ -125,7 +125,7 @@ class BookmarkIntegrationTest extends IntegrationTest {
         Hearit finished = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark1 = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, finished));
         PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), finished, 500_000L));
+                new PlayingHistory(member.getUuid(), finished, 500_000L));
 
         Hearit unfinished = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark2 = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, unfinished));

--- a/backend/app/src/test/java/com/onair/hearit/app/explore/application/HearitExploreServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/explore/application/HearitExploreServiceTest.java
@@ -160,7 +160,7 @@ class HearitExploreServiceTest {
         given(randomNumberGenerator.getDouble()).willReturn(0.1d);
 
         Category category1 = dbHelper.insertCategory(new Category("Java", "#112233"));
-        UserInfo guestInfo = TestFixture.createFixedGuestUserInfo(UUID.randomUUID().toString());
+        UserInfo guestInfo = TestFixture.createGuestUserInfo(UUID.randomUUID().toString());
         LocalDateTime now = LocalDateTime.now();
 
         Hearit hearit1 = dbHelper.insertHearitAt(createHearit(category1), now);

--- a/backend/app/src/test/java/com/onair/hearit/app/fixture/DbHelper.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/fixture/DbHelper.java
@@ -85,4 +85,13 @@ public class DbHelper {
         em.flush();
         return playingHistory;
     }
+
+    public PlayingHistory insertPlayingHistoryAt(PlayingHistory playingHistory, LocalDateTime updatedTime) {
+        try {
+            TestClock.freezeAt(updatedTime);
+            return insertPlayingHistory(playingHistory);
+        } finally {
+            TestClock.unfreeze();
+        }
+    }
 }

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitSearchServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitSearchServiceTest.java
@@ -6,9 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.app.hearit.dto.HearitSearchResponse;
+import com.onair.hearit.app.userInfo.application.UserInfoService;
 import com.onair.hearit.core.config.DataSourceConfig;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.HearitKeyword;
@@ -16,13 +16,10 @@ import com.onair.hearit.core.domain.Keyword;
 import com.onair.hearit.core.domain.Member;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.domain.Source;
-import com.onair.hearit.app.hearit.dto.HearitSearchResponse;
-import com.onair.hearit.core.infrastructure.jpa.HearitKeywordRepository;
-import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
-import com.onair.hearit.core.infrastructure.jpa.MemberRepository;
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,31 +35,18 @@ import org.springframework.test.context.transaction.TestTransaction;
 @Sql("/dbclean.sql")
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class,
+        HearitSearchService.class, UserInfoService.class})
 class HearitSearchServiceTest {
 
     @Autowired
     private DbHelper dbHelper;
 
     @Autowired
-    private HearitRepository hearitRepository;
-
-    @Autowired
-    private HearitKeywordRepository hearitKeywordRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
     private PlayingHistoryRepository playingHistoryRepository;
 
+    @Autowired
     private HearitSearchService hearitSearchService;
-
-    @BeforeEach
-    void setup() {
-        hearitSearchService = new HearitSearchService(hearitRepository, hearitKeywordRepository, memberRepository,
-                playingHistoryRepository);
-    }
 
     @Test
     @DisplayName("검색 시 제목에 검색어가 포함된 히어릿을 반환한다.")
@@ -239,7 +223,7 @@ class HearitSearchServiceTest {
         Hearit hearit = saveHearitWithTitleAndKeyword("spring test title", saveKeyword("keyword"));
 
         PlayingHistory playingHistory = playingHistoryRepository.save(
-                new PlayingHistory(member.getId(), hearit, 10L));
+                new PlayingHistory(member.getUuid(), hearit, 10L));
 
         TestTransaction.flagForCommit();
         TestTransaction.end();

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitSearchServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitSearchServiceTest.java
@@ -7,7 +7,7 @@ import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.fixture.DbHelper;
 import com.onair.hearit.app.hearit.dto.HearitSearchResponse;
-import com.onair.hearit.app.userInfo.application.UserInfoService;
+import com.onair.hearit.app.userinfo.application.UserInfoService;
 import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
@@ -285,7 +285,7 @@ class HearitServiceTest {
 
         @Test
         @DisplayName("모든 카테고리 히어릿을 생성 날짜 오름차순으로 조회한다.")
-        void getHearitsAllCategory() throws InterruptedException {
+        void getHearitsAllCategory() {
             // given
             Category category1 = dbHelper.insertCategory(TestFixture.createFixedCategory());
             Category category2 = dbHelper.insertCategory(TestFixture.createFixedCategory());

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
@@ -13,6 +13,7 @@ import com.onair.hearit.app.hearit.dto.HearitOverviewResponse;
 import com.onair.hearit.app.hearit.dto.HearitSortRequest;
 import com.onair.hearit.app.hearit.dto.param.HearitSortField;
 import com.onair.hearit.app.hearit.dto.param.SortDirection;
+import com.onair.hearit.app.userInfo.application.UserInfoService;
 import com.onair.hearit.core.domain.Bookmark;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
@@ -29,6 +30,7 @@ import com.onair.hearit.core.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.core.infrastructure.jpa.MemberRepository;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -43,7 +45,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("fake-test")
-@Import({DbHelper.class, TestJpaAuditingConfig.class, HearitService.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, HearitService.class, UserInfoService.class})
 class HearitServiceTest {
 
     @Autowired
@@ -124,7 +126,7 @@ class HearitServiceTest {
             Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
             long lastPlayTime = hearit.getPlayTime() * 1000 - remainingSeconds;
-            playingHistoryRepository.save(new PlayingHistory(member.getId(), hearit, lastPlayTime));
+            playingHistoryRepository.save(new PlayingHistory(member.getUuid(), hearit, lastPlayTime));
 
             // when
             HearitDetailResponse response = hearitService.getHearitDetail(
@@ -149,7 +151,7 @@ class HearitServiceTest {
 
             long remainingSeconds = 5001L;
             Long lastPlayTime = hearit.getPlayTime() * 1000 - remainingSeconds;
-            playingHistoryRepository.save(new PlayingHistory(member.getId(), hearit, lastPlayTime));
+            playingHistoryRepository.save(new PlayingHistory(member.getUuid(), hearit, lastPlayTime));
 
             // when
             HearitDetailResponse response = hearitService.getHearitDetail(
@@ -263,7 +265,7 @@ class HearitServiceTest {
             Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                    new PlayingHistory(member.getId(), hearit1, 450));
+                    new PlayingHistory(member.getUuid(), hearit1, 450));
             HearitSortRequest sortRequest = new HearitSortRequest(HearitSortField.CREATED_AT, SortDirection.DESC);
             PagingRequest pagingRequest = new PagingRequest(1, 2);
 
@@ -287,11 +289,9 @@ class HearitServiceTest {
             // given
             Category category1 = dbHelper.insertCategory(TestFixture.createFixedCategory());
             Category category2 = dbHelper.insertCategory(TestFixture.createFixedCategory());
-            Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
-            Thread.sleep(100);
-            Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category1));
-            Thread.sleep(100);
-            Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category2));
+            Hearit hearit1 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category1), LocalDateTime.now().minusMinutes(2));
+            Hearit hearit2 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category1),  LocalDateTime.now().minusMinutes(1));
+            Hearit hearit3 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category2),  LocalDateTime.now());
 
             HearitSortRequest sortRequest = new HearitSortRequest(HearitSortField.CREATED_AT, SortDirection.ASC);
             PagingRequest pagingRequest = new PagingRequest(0, 10);

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
@@ -184,7 +184,7 @@ class HearitServiceTest {
 
             // when
             PagedResponse<HearitOverviewResponse> result = hearitService.getFilteredHearits(category1.getId(),
-                    sortRequest, TestFixture.createFixedGuestUserInfo(UUID.randomUUID().toString()), pagingRequest);
+                    sortRequest, TestFixture.createGuestUserInfo(UUID.randomUUID().toString()), pagingRequest);
 
             // then
             assertAll(() -> {
@@ -210,7 +210,7 @@ class HearitServiceTest {
 
             // when
             PagedResponse<HearitOverviewResponse> result = hearitService.getFilteredHearits(category.getId(),
-                    sortRequest, TestFixture.createFixedGuestUserInfo(UUID.randomUUID().toString()), pagingRequest);
+                    sortRequest, TestFixture.createGuestUserInfo(UUID.randomUUID().toString()), pagingRequest);
 
             // then
             assertAll(() -> {
@@ -234,7 +234,7 @@ class HearitServiceTest {
 
             // when
             PagedResponse<HearitOverviewResponse> result = hearitService.getFilteredHearits(category.getId(),
-                    sortRequest, TestFixture.createFixedGuestUserInfo(UUID.randomUUID().toString()), pagingRequest);
+                    sortRequest, TestFixture.createGuestUserInfo(UUID.randomUUID().toString()), pagingRequest);
 
             // then
             assertAll(() -> {
@@ -300,7 +300,7 @@ class HearitServiceTest {
             PagedResponse<HearitOverviewResponse> result = hearitService.getFilteredHearits(
                     null,
                     sortRequest,
-                    TestFixture.createFixedGuestUserInfo(UUID.randomUUID().toString()),
+                    TestFixture.createGuestUserInfo(UUID.randomUUID().toString()),
                     pagingRequest
             );
 

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
@@ -289,9 +289,10 @@ class HearitServiceTest {
             // given
             Category category1 = dbHelper.insertCategory(TestFixture.createFixedCategory());
             Category category2 = dbHelper.insertCategory(TestFixture.createFixedCategory());
-            Hearit hearit1 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category1), LocalDateTime.now().minusMinutes(2));
-            Hearit hearit2 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category1),  LocalDateTime.now().minusMinutes(1));
-            Hearit hearit3 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category2),  LocalDateTime.now());
+            LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
+            Hearit hearit1 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category1), baseTime.minusMinutes(2));
+            Hearit hearit2 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category1),  baseTime.minusMinutes(1));
+            Hearit hearit3 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category2), baseTime);
 
             HearitSortRequest sortRequest = new HearitSortRequest(HearitSortField.CREATED_AT, SortDirection.ASC);
             PagingRequest pagingRequest = new PagingRequest(0, 10);
@@ -308,6 +309,7 @@ class HearitServiceTest {
             assertAll(
                     () -> assertThat(result.content()).hasSize(3),
                     () -> assertThat(result.content().get(0).id()).isEqualTo(hearit1.getId()),
+                    () -> assertThat(result.content().get(1).id()).isEqualTo(hearit2.getId()),
                     () -> assertThat(result.content().get(2).id()).isEqualTo(hearit3.getId())
             );
         }

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/application/HearitServiceTest.java
@@ -13,7 +13,7 @@ import com.onair.hearit.app.hearit.dto.HearitOverviewResponse;
 import com.onair.hearit.app.hearit.dto.HearitSortRequest;
 import com.onair.hearit.app.hearit.dto.param.HearitSortField;
 import com.onair.hearit.app.hearit.dto.param.SortDirection;
-import com.onair.hearit.app.userInfo.application.UserInfoService;
+import com.onair.hearit.app.userinfo.application.UserInfoService;
 import com.onair.hearit.core.domain.Bookmark;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;

--- a/backend/app/src/test/java/com/onair/hearit/app/hearit/presentation/HearitIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/hearit/presentation/HearitIntegrationTest.java
@@ -38,7 +38,7 @@ class HearitIntegrationTest extends IntegrationTest {
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), hearit, 1_000));
+                new PlayingHistory(member.getUuid(), hearit, 1_000));
         Keyword keyword1 = dbHelper.insertKeyword(new Keyword("Java"));
         Keyword keyword2 = dbHelper.insertKeyword(new Keyword("Spring"));
         dbHelper.insertHearitKeyword(new HearitKeyword(hearit, keyword1));

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
@@ -66,7 +66,7 @@ class PlayingHistoryServiceTest {
 
         @Test
         @DisplayName("회원은 최근 재생 기록을 조회할 수 있다.")
-        void getRecentPlayingHistoryOfMember_whenMember() {
+        void getRecentPlayingHistory_whenMember() {
             // given
             Member member = dbHelper.insertMember(TestFixture.createFixedMember());
             UserInfo memberInfo = RequestUser.member(member.getId()).getUserInfo();
@@ -91,7 +91,7 @@ class PlayingHistoryServiceTest {
 
         @Test
         @DisplayName("비회원은 최근 재생 기록을 조회할 수 있다.")
-        void getRecentPlayingHistoryOfMember_whenGuest() {
+        void getRecentPlayingHistory_whenGuest() {
             // given
             UserInfo guestInfo = new UserInfo(null, UUID.randomUUID().toString());
             Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
@@ -115,65 +115,100 @@ class PlayingHistoryServiceTest {
         }
     }
 
-    @Test
-    @DisplayName("로그인한 회원은 재생기록을 저장할 수 있다.")
-    void addPlayHistory() throws InterruptedException {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+    @Nested
+    @DisplayName("재생 기록 저장")
+    class AddPlayingHistoryTest {
 
-        // when
-        playingHistoryService.addPlayingHistory(TestFixture.createFixedMemberUserInfo(member), request);
-        playingHistoryBuffer.flush();
+        @Test
+        @DisplayName("로그인한 회원은 재생기록을 저장할 수 있다.")
+        void addPlayHistory_Member() {
+            // given
+            Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+            Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+            PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
-        // then
-        List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
-        assertAll(() -> {
-            assertThat(playingHistories.size()).isEqualTo(1);
-            assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(member.getUuid());
-            assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId());
-        });
+            // when
+            playingHistoryService.addPlayingHistory(TestFixture.createFixedMemberUserInfo(member), request);
+            playingHistoryBuffer.flush();
+
+            // then
+            List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
+            assertAll(
+                    () -> assertThat(playingHistories.size()).isEqualTo(1),
+                    () -> assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(member.getUuid()),
+                    () -> assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId())
+            );
+        }
+
+        @Test
+        @DisplayName("비회원은 재생기록을 저장할 수 있다.")
+        void addPlayHistory_Guest() {
+            // given
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+            Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+            PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+
+            // when
+            playingHistoryService.addPlayingHistory(TestFixture.createGuestUserInfo(UUID.randomUUID().toString()),
+                    request);
+            playingHistoryBuffer.flush();
+
+            // then
+            assertThat(playingHistoryRepository.findAll()).hasSize(1);
+        }
     }
 
-    @Test
-    @DisplayName("로그인한 회원은 재생기록을 수정할 수 있다.")
-    void modifyPlayHistory() {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10_000));
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
+    @Nested
+    @DisplayName("재생 기록 저장")
+    class ModifyPlayingHistoryTest {
 
-        // when
-        playingHistoryService.addPlayingHistory(TestFixture.createFixedMemberUserInfo(member), request);
-        playingHistoryBuffer.flush();
+        @Test
+        @DisplayName("로그인한 회원은 재생기록을 수정할 수 있다.")
+        void modifyPlayHistory_Member() {
+            // given
+            Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+            Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+            dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10_000));
+            PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
-        // then
-        List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
-        assertAll(() -> {
-            assertThat(playingHistories.size()).isEqualTo(1);
-            assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(member.getUuid());
-            assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId());
-        });
-    }
+            // when
+            playingHistoryService.addPlayingHistory(TestFixture.createFixedMemberUserInfo(member), request);
+            playingHistoryBuffer.flush();
 
-    @Test
-    @DisplayName("로그인하지 않은 회원은 재생기록을 저장할 수 없다.")
-    void checkMember() {
-        // given
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+            // then
+            List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
+            assertAll(
+                    () -> assertThat(playingHistories.size()).isEqualTo(1),
+                    () -> assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(member.getUuid()),
+                    () -> assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId())
+            );
+        }
 
-        // when
-        playingHistoryService.addPlayingHistory(TestFixture.createFixedGuestUserInfo(UUID.randomUUID().toString()),
-                request);
+        @Test
+        @DisplayName("비회원은 재생기록을 수정할 수 있다.")
+        void modifyPlayHistory_Guest() {
+            // given
+            UserInfo guestUserInfo = TestFixture.createGuestUserInfo(UUID.randomUUID().toString());
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+            Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
+            dbHelper.insertPlayingHistory(new PlayingHistory(guestUserInfo.getGuestId(), hearit, 10_000));
+            PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
-        // then
-        assertThat(playingHistoryRepository.findAll()).hasSize(0);
+            // when
+            playingHistoryService.addPlayingHistory(guestUserInfo, request);
+            playingHistoryBuffer.flush();
+
+            // then
+            List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
+            assertAll(
+                    () -> assertThat(playingHistories.size()).isEqualTo(1),
+                    () -> assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(guestUserInfo.getGuestId()),
+                    () -> assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId())
+            );
+        }
+
     }
 
     @Test

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
@@ -10,7 +10,7 @@ import com.onair.hearit.app.fixture.DbHelper;
 import com.onair.hearit.app.playinghistory.dto.PlayingHistoryRequest;
 import com.onair.hearit.app.playinghistory.dto.RecentlyPlayedHearitResponse;
 import com.onair.hearit.app.playinghistory.infrastructure.scheduler.PlayingHistoryBuffer;
-import com.onair.hearit.app.userInfo.application.UserInfoService;
+import com.onair.hearit.app.userinfo.application.UserInfoService;
 import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
@@ -81,9 +81,10 @@ class PlayingHistoryServiceTest {
             Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
+            LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(member.getUuid(), hearit1, 10),
-                    LocalDateTime.now().minusMinutes(10));
-            dbHelper.insertPlayingHistoryAt(new PlayingHistory(member.getUuid(), hearit2, 20), LocalDateTime.now());
+                    baseTime.minusMinutes(10));
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(member.getUuid(), hearit2, 20), baseTime);
 
             // when
             List<RecentlyPlayedHearitResponse> result = playingHistoryService.getRecentPlayingHistory(memberInfo);
@@ -105,10 +106,11 @@ class PlayingHistoryServiceTest {
             Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
+            LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestInfo.getGuestId(), hearit1, 10),
-                    LocalDateTime.now().minusMinutes(10));
+                    baseTime.minusMinutes(10));
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestInfo.getGuestId(), hearit2, 20),
-                    LocalDateTime.now());
+                    baseTime);
 
             // when
             List<RecentlyPlayedHearitResponse> result = playingHistoryService.getRecentPlayingHistory(guestInfo);
@@ -183,7 +185,6 @@ class PlayingHistoryServiceTest {
             Category category = dbHelper.insertCategory(new Category("name", "#000000"));
             Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
             dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10_000));
-            playingHistoryBuffer.flush();
             PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
             // when
@@ -209,7 +210,6 @@ class PlayingHistoryServiceTest {
             Category category = dbHelper.insertCategory(new Category("name", "#000000"));
             Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
             dbHelper.insertPlayingHistory(new PlayingHistory(guestUserInfo.getGuestId(), hearit, 10_000));
-            playingHistoryBuffer.flush();
             PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
             // when

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
@@ -172,7 +172,7 @@ class PlayingHistoryServiceTest {
     }
 
     @Nested
-    @DisplayName("재생 기록 저장")
+    @DisplayName("재생 기록 수정")
     class ModifyPlayingHistoryTest {
 
         @Test

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
@@ -34,13 +34,17 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.Commit;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @Sql("/dbclean.sql")
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class, PlayingHistoryBuffer.class,
         PlayingHistoryCommandRepository.class, PlayingHistoryService.class, UserInfoService.class})
 class PlayingHistoryServiceTest {
@@ -53,6 +57,9 @@ class PlayingHistoryServiceTest {
 
     @Autowired
     PlayingHistoryBuffer playingHistoryBuffer;
+
+    @Autowired
+    PlayingHistoryCommandRepository playingHistoryCommandRepository;
 
     @Autowired
     HearitRepository hearitRepository;
@@ -176,6 +183,7 @@ class PlayingHistoryServiceTest {
             Category category = dbHelper.insertCategory(new Category("name", "#000000"));
             Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
             dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10_000));
+            playingHistoryBuffer.flush();
             PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
             // when
@@ -187,11 +195,13 @@ class PlayingHistoryServiceTest {
             assertAll(
                     () -> assertThat(playingHistories.size()).isEqualTo(1),
                     () -> assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(member.getUuid()),
-                    () -> assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId())
+                    () -> assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId()),
+                    () -> assertThat(playingHistories.getFirst().getLastPlayTime()).isEqualTo(50_000L)
             );
         }
 
         @Test
+        @Commit
         @DisplayName("비회원은 재생기록을 수정할 수 있다.")
         void modifyPlayHistory_Guest() {
             // given
@@ -199,6 +209,7 @@ class PlayingHistoryServiceTest {
             Category category = dbHelper.insertCategory(new Category("name", "#000000"));
             Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
             dbHelper.insertPlayingHistory(new PlayingHistory(guestUserInfo.getGuestId(), hearit, 10_000));
+            playingHistoryBuffer.flush();
             PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
             // when
@@ -210,10 +221,10 @@ class PlayingHistoryServiceTest {
             assertAll(
                     () -> assertThat(playingHistories.size()).isEqualTo(1),
                     () -> assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(guestUserInfo.getGuestId()),
-                    () -> assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId())
+                    () -> assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId()),
+                    () -> assertThat(playingHistories.getFirst().getLastPlayTime()).isEqualTo(50_000L)
             );
         }
-
     }
 
     @Test

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
@@ -5,27 +5,29 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.auth.domain.RequestUser;
+import com.onair.hearit.app.exception.custom.NotFoundException;
+import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.app.playinghistory.dto.PlayingHistoryRequest;
+import com.onair.hearit.app.playinghistory.dto.RecentlyPlayedHearitResponse;
+import com.onair.hearit.app.playinghistory.infrastructure.scheduler.PlayingHistoryBuffer;
+import com.onair.hearit.app.userInfo.application.UserInfoService;
 import com.onair.hearit.core.config.DataSourceConfig;
-import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.Member;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.domain.Source;
 import com.onair.hearit.core.domain.UserInfo;
-import com.onair.hearit.app.exception.custom.NotFoundException;
-import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import com.onair.hearit.core.infrastructure.jdbc.PlayingHistoryCommandRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
-import com.onair.hearit.app.playinghistory.dto.PlayingHistoryRequest;
-import com.onair.hearit.app.playinghistory.dto.RecentlyPlayedHearitResponse;
-import com.onair.hearit.app.playinghistory.infrastructure.scheduler.PlayingHistoryBuffer;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -39,68 +41,78 @@ import org.springframework.test.context.jdbc.Sql;
 @Sql("/dbclean.sql")
 @ActiveProfiles("integration-test")
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class,
-        PlayingHistoryBuffer.class, PlayingHistoryCommandRepository.class})
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class, PlayingHistoryBuffer.class,
+        PlayingHistoryCommandRepository.class, PlayingHistoryService.class, UserInfoService.class})
 class PlayingHistoryServiceTest {
 
     @Autowired
-    private DbHelper dbHelper;
+    DbHelper dbHelper;
 
     @Autowired
-    private PlayingHistoryRepository playingHistoryRepository;
+    PlayingHistoryRepository playingHistoryRepository;
 
     @Autowired
-    private PlayingHistoryBuffer playingHistoryBuffer;
+    PlayingHistoryBuffer playingHistoryBuffer;
 
     @Autowired
-    private HearitRepository hearitRepository;
+    HearitRepository hearitRepository;
 
-    private PlayingHistoryService playingHistoryService;
+    @Autowired
+    PlayingHistoryService playingHistoryService;
 
-    @BeforeEach
-    void setup() {
-        playingHistoryService = new PlayingHistoryService(
-                hearitRepository,
-                playingHistoryRepository,
-                playingHistoryBuffer);
-    }
+    @Nested
+    @DisplayName("최근 재생 기록 조회")
+    class GetRecentPlayingHistoryTest {
 
-    @Test
-    @DisplayName("회원은 최근 재생 기록을 조회할 수 있다.")
-    void getRecentPlayingHistoryOfMember_whenMember() throws InterruptedException {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        UserInfo memberInfo = RequestUser.member(member.getId()).getUserInfo();
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        @Test
+        @DisplayName("회원은 최근 재생 기록을 조회할 수 있다.")
+        void getRecentPlayingHistoryOfMember_whenMember() {
+            // given
+            Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+            UserInfo memberInfo = RequestUser.member(member.getId()).getUserInfo();
+            Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+            Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-        dbHelper.insertPlayingHistory(new PlayingHistory(memberInfo.getMemberId(), hearit1, 10));
-        Thread.sleep(1000);
-        dbHelper.insertPlayingHistory(new PlayingHistory(memberInfo.getMemberId(), hearit2, 20));
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(member.getUuid(), hearit1, 10),
+                    LocalDateTime.now().minusMinutes(10));
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(member.getUuid(), hearit2, 20), LocalDateTime.now());
 
-        // when
-        List<RecentlyPlayedHearitResponse> result = playingHistoryService.getRecentPlayingHistory(memberInfo);
+            // when
+            List<RecentlyPlayedHearitResponse> result = playingHistoryService.getRecentPlayingHistory(memberInfo);
 
-        // then
-        assertAll(
-                () -> assertThat(result).hasSize(2),
-                () -> assertThat(result.get(0).id()).isEqualTo(hearit2.getId()),
-                () -> assertThat(result.get(1).id()).isEqualTo(hearit1.getId())
-        );
-    }
+            // then
+            assertAll(
+                    () -> assertThat(result).hasSize(2),
+                    () -> assertThat(result.get(0).id()).isEqualTo(hearit2.getId()),
+                    () -> assertThat(result.get(1).id()).isEqualTo(hearit1.getId())
+            );
+        }
 
-    @Test
-    @DisplayName("회원이 아닌 유저는 빈 재생 기록을 반환한다.")
-    void getRecentPlayingHistoryOfMember_whenGuestOrNull_thenReturnEmpty() {
-        // given
-        UserInfo guestInfo = RequestUser.guest(UUID.randomUUID().toString()).getUserInfo();
+        @Test
+        @DisplayName("비회원은 최근 재생 기록을 조회할 수 있다.")
+        void getRecentPlayingHistoryOfMember_whenGuest() {
+            // given
+            UserInfo guestInfo = new UserInfo(null, UUID.randomUUID().toString());
+            Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+            Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-        // when
-        List<RecentlyPlayedHearitResponse> guestResult = playingHistoryService.getRecentPlayingHistory(guestInfo);
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestInfo.getGuestId(), hearit1, 10),
+                    LocalDateTime.now().minusMinutes(10));
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestInfo.getGuestId(), hearit2, 20),
+                    LocalDateTime.now());
 
-        // then
-        assertThat(guestResult).isEmpty();
+            // when
+            List<RecentlyPlayedHearitResponse> result = playingHistoryService.getRecentPlayingHistory(guestInfo);
+
+            // then
+            assertAll(
+                    () -> assertThat(result).hasSize(2),
+                    () -> assertThat(result.get(0).id()).isEqualTo(hearit2.getId()),
+                    () -> assertThat(result.get(1).id()).isEqualTo(hearit1.getId())
+            );
+        }
     }
 
     @Test
@@ -120,20 +132,19 @@ class PlayingHistoryServiceTest {
         List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
         assertAll(() -> {
             assertThat(playingHistories.size()).isEqualTo(1);
-            assertThat(playingHistories.getFirst().getMemberId()).isEqualTo(member.getId());
+            assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(member.getUuid());
             assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId());
         });
     }
 
     @Test
     @DisplayName("로그인한 회원은 재생기록을 수정할 수 있다.")
-    void modifyPlayHistory() throws InterruptedException {
+    void modifyPlayHistory() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
         Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), hearit, 10_000));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10_000));
         PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
         // when
@@ -144,7 +155,7 @@ class PlayingHistoryServiceTest {
         List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
         assertAll(() -> {
             assertThat(playingHistories.size()).isEqualTo(1);
-            assertThat(playingHistories.getFirst().getMemberId()).isEqualTo(member.getId());
+            assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(member.getUuid());
             assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId());
         });
     }

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/application/PlayingHistoryServiceTest.java
@@ -148,14 +148,19 @@ class PlayingHistoryServiceTest {
             Category category = dbHelper.insertCategory(new Category("name", "#000000"));
             Hearit hearit = dbHelper.insertHearit(createHearitWith(100, category));
             PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+            String guestUuid = UUID.randomUUID().toString();
 
             // when
-            playingHistoryService.addPlayingHistory(TestFixture.createGuestUserInfo(UUID.randomUUID().toString()),
-                    request);
+            playingHistoryService.addPlayingHistory(TestFixture.createGuestUserInfo(guestUuid), request);
             playingHistoryBuffer.flush();
 
             // then
-            assertThat(playingHistoryRepository.findAll()).hasSize(1);
+            List<PlayingHistory> playingHistories = playingHistoryRepository.findAll();
+            assertAll(
+                    () -> assertThat(playingHistories.size()).isEqualTo(1),
+                    () -> assertThat(playingHistories.getFirst().getUserUuid()).isEqualTo(guestUuid),
+                    () -> assertThat(playingHistories.getFirst().getHearitId()).isEqualTo(hearit.getId())
+            );
         }
     }
 

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryControllerTest.java
@@ -62,7 +62,7 @@ class PlayingHistoryControllerTest extends ControllerTest {
                                         fieldWithPath("[].title").description("히어릿 제목"),
                                         fieldWithPath("[].playTime").description("히어릿 전체 재생 시간(s)"),
                                         fieldWithPath("[].lastPlayTime").description("사용자가 마지막으로 재생한 시간(ms)"),
-                                        fieldWithPath("[].createdAt").description("히어릿 생성일").optional(),
+                                        fieldWithPath("[].createdAt").description("히어릿 생성일"),
                                         fieldWithPath("[].category.id").description("카테고리 ID"),
                                         fieldWithPath("[].category.name").description("카테고리 이름"),
                                         fieldWithPath("[].category.colorCode").description("카테고리 색상 코드")
@@ -72,22 +72,36 @@ class PlayingHistoryControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("최근 재생 기록 조회 V1 - 게스트 사용자 200 OK 빈 리스트")
+    @DisplayName("최근 재생 기록 조회 V1 - 게스트 사용자 200 OK")
     void getRecentPlayingHistoriesWhenGuestV1_OK() throws Exception {
         // given
+        var responses = List.of(
+                new RecentlyPlayedHearitResponse(1L, "title1", 120, 30L, null,
+                        new RecentlyPlayedHearitResponse.CategoryResponse(1L, "카테고리1", "#000000")),
+                new RecentlyPlayedHearitResponse(2L, "title2", 150, 60L, null,
+                        new RecentlyPlayedHearitResponse.CategoryResponse(2L, "카테고리2", "#111111"))
+        );
         given(jwtTokenProvider.getTokenStatus(isNull())).willReturn(TokenStatus.NOT_EXIST);
-        given(playingHistoryService.getRecentPlayingHistory(any())).willReturn(List.of());
+        given(playingHistoryService.getRecentPlayingHistory(any())).willReturn(responses);
 
         // when & then
-        mockMvc.perform(get("/api/v1/playing-histories/hearits"))
+        mockMvc.perform(get("/api/v1/playing-histories/hearits")
+                        .header("Device-UUID", "00000000-0000-0000-0000-000000000000"))
                 .andExpect(status().isOk())
                 .andDo(document("v1-get-playing-histories-guest-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
                                 .summary("최근 재생 기록 조회 V1")
-                                .description("로그인하지 않은 사용자는 빈 리스트를 반환합니다.")
+                                .description("게스트 사용자는 최근 재생 기록을 최대 10개까지 조회합니다.")
                                 .responseFields(
-                                        fieldWithPath("[]").description("빈 리스트")
+                                        fieldWithPath("[].id").description("히어릿 ID"),
+                                        fieldWithPath("[].title").description("히어릿 제목"),
+                                        fieldWithPath("[].playTime").description("히어릿 전체 재생 시간(s)"),
+                                        fieldWithPath("[].lastPlayTime").description("사용자가 마지막으로 재생한 시간(ms)"),
+                                        fieldWithPath("[].createdAt").description("히어릿 생성일"),
+                                        fieldWithPath("[].category.id").description("카테고리 ID"),
+                                        fieldWithPath("[].category.name").description("카테고리 이름"),
+                                        fieldWithPath("[].category.colorCode").description("카테고리 색상 코드")
                                 )
                                 .build())
                 ));
@@ -133,13 +147,14 @@ class PlayingHistoryControllerTest extends ControllerTest {
         // when & then
         mockMvc.perform(post("/api/v1/playing-histories")
                         .contentType("application/json")
+                        .header("Device-UUID", "00000000-0000-0000-0000-000000000000")
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(document("v1-post-playing-history-guest-ok",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Playing History API")
                                 .summary("재생기록 생성/수정 V1")
-                                .description("로그인하지 않은 사용자는 재생 기록을 저장하지 않습니다.")
+                                .description("로그인하지 않은 사용자는 재생 기록을 생성하거나 업데이트합니다.")
                                 .requestFields(
                                         fieldWithPath("hearitId").description("히어릿 ID"),
                                         fieldWithPath("lastPlayTime").description("마지막 재생 시간(ms)")

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryIntegrationTest.java
@@ -34,7 +34,7 @@ class PlayingHistoryIntegrationTest extends IntegrationTest {
 
         for (int i = 0; i < 12; i++) {
             Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-            dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L * i));
+            dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10L * i));
         }
 
         // when & then
@@ -58,9 +58,9 @@ class PlayingHistoryIntegrationTest extends IntegrationTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit, 10L));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10L));
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit2, 20L));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit2, 20L));
 
         // when & then
         List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
@@ -106,7 +106,7 @@ class PlayingHistoryIntegrationTest extends IntegrationTest {
         Category category = dbHelper.insertCategory(new Category("name", "#000000"));
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), hearit, 20_000));
+                new PlayingHistory(member.getUuid(), hearit, 20_000));
 
         PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryIntegrationTest.java
@@ -1,20 +1,26 @@
 package com.onair.hearit.app.playinghistory.presentation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.app.fixture.IntegrationTest;
 import com.onair.hearit.app.playinghistory.dto.PlayingHistoryRequest;
 import com.onair.hearit.app.playinghistory.dto.RecentlyPlayedHearitResponse;
+import com.onair.hearit.app.playinghistory.infrastructure.scheduler.PlayingHistoryBuffer;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.Member;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
 import java.util.List;
+import java.util.UUID;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -22,122 +28,217 @@ import org.springframework.http.HttpStatus;
 class PlayingHistoryIntegrationTest extends IntegrationTest {
 
     @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    JwtTokenProvider jwtTokenProvider;
 
-    @Test
-    @DisplayName("로그인한 사용자는 최근 재생 기록 최대 10개와 200 OK를 반환한다.")
-    void getRecentPlayingHistories_whenMember() {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+    @Autowired
+    PlayingHistoryRepository playingHistoryRepository;
 
-        for (int i = 0; i < 12; i++) {
-            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-            dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10L * i));
+    @Autowired
+    PlayingHistoryBuffer playingHistoryBuffer;
+
+    @Nested
+    @DisplayName("유저들은 최근 재생기록을 최대 10개 조회할 수 있다.")
+    class GetRecentPlayingHistories {
+
+        @Test
+        @DisplayName("로그인한 사용자는 최근 재생 기록 최대 10개와 200 OK를 반환한다.")
+        void getRecentPlayingHistories_whenMember() {
+            // given
+            Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+            String token = generateToken(member);
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+
+            for (int i = 0; i < 12; i++) {
+                Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+                dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10L * i));
+            }
+
+            // when & then
+            List<RecentlyPlayedHearitResponse> response = RestAssured.given(PlayingHistoryIntegrationTest.this.spec)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType("application/json")
+                    .when()
+                    .get("/api/v1/playing-histories/hearits")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract().as(new TypeRef<>() {
+                    });
+
+            SoftAssertions softly = new SoftAssertions();
+            softly.assertThat(response)
+                    .hasSize(10);
+            List<Long> times = response.stream()
+                    .map(RecentlyPlayedHearitResponse::lastPlayTime)
+                    .toList();
+            softly.assertThat(times)
+                    .as("lastPlayTime 내림차순 정렬 검증")
+                    .isSortedAccordingTo((a, b) -> Long.compare(b, a));
+            softly.assertAll();
         }
 
-        // when & then
-        List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .contentType("application/json")
-                .when()
-                .get("/api/v1/playing-histories/hearits")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(new TypeRef<>() {
-                });
+        @Test
+        @DisplayName("비회원은 최근 재생 기록 최대 10개와 200 OK를 반환한다.")
+        void getRecentPlayingHistories_whenGuest() {
+            // given
+            String guestUuid = UUID.randomUUID().toString();
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
 
-        assertThat(response).hasSize(10);
+            for (int i = 0; i < 12; i++) {
+                Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+                dbHelper.insertPlayingHistory(new PlayingHistory(guestUuid, hearit, 10L * i));
+            }
+
+            // when & then
+            List<RecentlyPlayedHearitResponse> response = RestAssured.given(PlayingHistoryIntegrationTest.this.spec)
+                    .contentType("application/json")
+                    .header("Device-UUID", guestUuid)
+                    .when()
+                    .get("/api/v1/playing-histories/hearits")
+                    .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract().as(new TypeRef<>() {
+                    });
+
+            SoftAssertions softly = new SoftAssertions();
+            softly.assertThat(response)
+                    .hasSize(10);
+            List<Long> times = response.stream()
+                    .map(RecentlyPlayedHearitResponse::lastPlayTime)
+                    .toList();
+            softly.assertThat(times)
+                    .as("lastPlayTime 내림차순 정렬 검증")
+                    .isSortedAccordingTo((a, b) -> Long.compare(b, a));
+            softly.assertAll();
+        }
     }
 
-    @Test
-    @DisplayName("로그인하지 않은 사용자는 최근 재생 기록 조회 시 빈 리스트와 200 OK를 반환한다.")
-    void getRecentPlayingHistories_whenGuest() {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10L));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit2, 20L));
+    @Nested
+    @DisplayName("재생기록 저장 테스트")
+    class CreatePlayingHistory {
 
-        // when & then
-        List<RecentlyPlayedHearitResponse> response = RestAssured.given(this.spec)
-                .contentType("application/json")
-                .when()
-                .get("/api/v1/playing-histories/hearits")
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .extract().as(new TypeRef<>() {
-                });
+        @Test
+        @DisplayName("로그인한 사용자가 재생기록 저장 시, 200 OK를 반환한다.")
+        void createPlayingHistory_member() {
+            // given
+            Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+            String token = generateToken(member);
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-        assertThat(response).isEmpty();
-    }
+            PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
-    @Test
-    @DisplayName("로그인한 사용자가 처음 재생기록 저장 시, 200 OK를 반환한다.")
-    void createPlayingHistory() {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            // when
+            RestAssured.given(PlayingHistoryIntegrationTest.this.spec)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType("application/json")
+                    .body(request)
+                    .when()
+                    .post("/api/v1/playing-histories")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+            playingHistoryBuffer.flush();
 
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+            // then
+            List<PlayingHistory> histories = playingHistoryRepository.findAll();
+            assertAll(
+                    () -> assertThat(histories).hasSize(1),
+                    () -> assertThat(histories.getFirst().getUserUuid()).isEqualTo(member.getUuid()),
+                    () -> assertThat(histories.getFirst().getHearitId()).isEqualTo(hearit.getId()),
+                    () -> assertThat(histories.getFirst().getLastPlayTime()).isEqualTo(100L)
+            );
+        }
 
-        // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .contentType("application/json")
-                .body(request)
-                .when()
-                .post("/api/v1/playing-histories")
-                .then()
-                .statusCode(HttpStatus.OK.value());
-    }
+        @Test
+        @DisplayName("로그인하지 않은 사용자가 재생기록 저장 시, 200 OK를 반환한다.")
+        void createPlayingHistory_guest() {
+            // given
+            String guestUuid = UUID.randomUUID().toString();
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-    @Test
-    @DisplayName("로그인한 사용자가 다시 재생기록 저장 시, 200 OK를 반환한다.")
-    void updatePlayingHistory() {
-        // given
-        Member member = dbHelper.insertMember(TestFixture.createFixedMember());
-        String token = generateToken(member);
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        PlayingHistory playingHistory = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getUuid(), hearit, 20_000));
+            PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
 
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
+            // when
+            RestAssured.given(PlayingHistoryIntegrationTest.this.spec)
+                    .contentType("application/json")
+                    .header("Device-UUID", guestUuid)
+                    .body(request)
+                    .when()
+                    .post("/api/v1/playing-histories")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+            playingHistoryBuffer.flush();
 
-        // when & then
-        RestAssured.given(this.spec)
-                .header("Authorization", "Bearer " + token)
-                .contentType("application/json")
-                .body(request)
-                .when()
-                .post("/api/v1/playing-histories")
-                .then()
-                .statusCode(HttpStatus.OK.value());
-    }
+            // then
+            List<PlayingHistory> histories = playingHistoryRepository.findAll();
+            assertAll(
+                    () -> assertThat(histories).hasSize(1),
+                    () -> assertThat(histories.getFirst().getUserUuid()).isEqualTo(guestUuid),
+                    () -> assertThat(histories.getFirst().getHearitId()).isEqualTo(hearit.getId()),
+                    () -> assertThat(histories.getFirst().getLastPlayTime()).isEqualTo(100L)
+            );
+        }
 
-    @Test
-    @DisplayName("로그인하지 않은 사용자는 재생기록 저장를 저장하지 않고, 200 OK를 반환한다.")
-    void createBookmarkTestWithConflict() {
-        // given
-        Category category = dbHelper.insertCategory(new Category("name", "#000000"));
-        Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        @Test
+        @DisplayName("로그인한 사용자가 다시 재생기록 저장 시, 200 OK를 반환한다.")
+        void updatePlayingHistory_member() {
+            // given
+            Member member = dbHelper.insertMember(TestFixture.createFixedMember());
+            String token = generateToken(member);
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 20_000));
 
-        PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+            PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 50_000L);
 
-        // when & then
-        RestAssured.given(this.spec)
-                .contentType("application/json")
-                .body(request)
-                .when()
-                .post("/api/v1/playing-histories")
-                .then()
-                .statusCode(HttpStatus.OK.value());
+            // when
+            RestAssured.given(PlayingHistoryIntegrationTest.this.spec)
+                    .header("Authorization", "Bearer " + token)
+                    .contentType("application/json")
+                    .body(request)
+                    .when()
+                    .post("/api/v1/playing-histories")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+            playingHistoryBuffer.flush();
+
+            // then
+            List<PlayingHistory> histories = playingHistoryRepository.findAll();
+            assertAll(
+                    () -> assertThat(histories).hasSize(1),
+                    () -> assertThat(histories.getFirst().getLastPlayTime()).isEqualTo(50_000L)
+            );
+        }
+
+        @Test
+        @DisplayName("비회원이 동일한 히어릿에 다시 재생기록 저장 시, 200 OK를 반환한다.")
+        void updatePlayingHistory_guest() {
+            // given
+            String guestUuid = UUID.randomUUID().toString();
+            Category category = dbHelper.insertCategory(new Category("name", "#000000"));
+            Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            dbHelper.insertPlayingHistory(new PlayingHistory(guestUuid, hearit, 20_000));
+
+            PlayingHistoryRequest request = new PlayingHistoryRequest(hearit.getId(), 100L);
+
+            // when
+            RestAssured.given(PlayingHistoryIntegrationTest.this.spec)
+                    .contentType("application/json")
+                    .header("Device-UUID", guestUuid)
+                    .body(request)
+                    .when()
+                    .post("/api/v1/playing-histories")
+                    .then()
+                    .statusCode(HttpStatus.OK.value());
+            playingHistoryBuffer.flush();
+
+            // then
+            List<PlayingHistory> histories = playingHistoryRepository.findAll();
+            assertAll(
+                    () -> assertThat(histories).hasSize(1),
+                    () -> assertThat(histories.getFirst().getLastPlayTime()).isEqualTo(100L)
+            );
+        }
     }
 
     private String generateToken(Member member) {

--- a/backend/core/src/main/java/com/onair/hearit/core/domain/PlayingHistory.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/domain/PlayingHistory.java
@@ -36,8 +36,11 @@ public class PlayingHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "member_id", nullable = false)
+    @Column(name = "member_id", nullable = true)
     private Long memberId;
+
+    @Column(name = "user_uuid", nullable = false, columnDefinition = "CHAR(36)")
+    private String userUuid;
 
     @Column(name = "hearit_id", nullable = false)
     private Long hearitId;
@@ -52,9 +55,9 @@ public class PlayingHistory {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public PlayingHistory(Long memberId, Hearit hearit, long lastPlayTime) {
+    public PlayingHistory(String userUuid, Hearit hearit, long lastPlayTime) {
         validateHearitPlayTime(hearit, lastPlayTime);
-        this.memberId = memberId;
+        this.userUuid = userUuid;
         this.hearitId = hearit.getId();
         this.lastPlayTime = lastPlayTime;
         this.isFinished = checkIsFinished(hearit, lastPlayTime);

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jdbc/PlayingHistoryCommandRepository.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jdbc/PlayingHistoryCommandRepository.java
@@ -18,7 +18,7 @@ public class PlayingHistoryCommandRepository {
     public void bulkInsert(List<PlayingHistory> histories) {
         LocalDateTime nowDateTime = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         String sql = """
-                INSERT INTO playing_history (member_id, hearit_id, last_play_time, is_finished, updated_at)
+                INSERT INTO playing_history (user_uuid, hearit_id, last_play_time, is_finished, updated_at)
                 VALUES (?, ?, ?, ?, ?) AS new_history
                 ON DUPLICATE KEY UPDATE
                     last_play_time = new_history.last_play_time,
@@ -27,7 +27,7 @@ public class PlayingHistoryCommandRepository {
                 """;
 
         jdbcTemplate.batchUpdate(sql, histories, histories.size(), (ps, history) -> {
-            ps.setLong(1, history.getMemberId());
+            ps.setString(1, history.getUserUuid());
             ps.setLong(2, history.getHearitId());
             ps.setLong(3, history.getLastPlayTime());
             ps.setBoolean(4, history.isFinished());

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/BookmarkRepository.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/BookmarkRepository.java
@@ -23,13 +23,13 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
             JOIN FETCH h.category c
             LEFT JOIN PlayingHistory ph
                 ON ph.hearitId = h.id
-                AND ph.memberId = :memberId
-            WHERE b.member.id = :memberId
+                AND ph.userUuid = :userUuid
+            WHERE b.member.uuid = :userUuid
                 AND (:isFinished IS NULL OR
                     (:isFinished = true AND ph.isFinished = :isFinished) OR
                     (:isFinished = false AND (ph.isFinished = false OR ph IS NULL)))
             """)
-    Page<BookmarkWithPlayingHistoryProjection> findFilteredByMember(@Param("memberId") Long memberId,
+    Page<BookmarkWithPlayingHistoryProjection> findFilteredByMember(@Param("userUuid") String userUuid,
                                                                     @Param("isFinished") Boolean isFinished,
                                                                     Pageable pageable);
 

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/HearitRepository.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/HearitRepository.java
@@ -75,13 +75,13 @@ public interface HearitRepository extends JpaRepository<Hearit, Long> {
     @Query("""
             SELECT h AS hearit, ph.lastPlayTime AS lastPlayTime
             FROM Hearit h
-            LEFT JOIN PlayingHistory ph ON h.id = ph.hearitId AND ph.memberId = :memberId
+            LEFT JOIN PlayingHistory ph ON h.id = ph.hearitId AND ph.userUuid = :userUuid
             JOIN FETCH h.category
             WHERE (:categoryId IS NULL OR h.category.id = :categoryId)
             """)
     Page<HearitWithPlayTimeProjection> findWithPlayTimeBy(
             @Param("categoryId") Long categoryId,
-            @Param("memberId") Long memberId,
+            @Param("userUuid") String userUuid,
             Pageable pageable
     );
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/MemberRepository.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/MemberRepository.java
@@ -21,6 +21,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("SELECT m FROM Member m WHERE m.uuid = :uuid AND m.deletedAt IS NULL")
     Optional<Member> findByUuid(String uuid);
 
-    @Query("SELECT m.uuid FROM Member m WHERE m.id = :memberId")
+    @Query("SELECT m.uuid FROM Member m WHERE m.id = :memberId AND m.deletedAt IS NULL")
     Optional<String> findUuidById(@Param("memberId") Long memberId);
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/MemberRepository.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/MemberRepository.java
@@ -5,6 +5,7 @@ import com.onair.hearit.core.domain.OAuthProvider;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -19,4 +20,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m FROM Member m WHERE m.uuid = :uuid AND m.deletedAt IS NULL")
     Optional<Member> findByUuid(String uuid);
+
+    @Query("SELECT m.uuid FROM Member m WHERE m.id = :memberId")
+    Optional<String> findUuidById(@Param("memberId") Long memberId);
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepository.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepository.java
@@ -9,16 +9,16 @@ import org.springframework.data.repository.query.Param;
 
 public interface PlayingHistoryRepository extends JpaRepository<PlayingHistory, Long> {
 
-    Optional<PlayingHistory> findByHearitIdAndMemberId(Long hearitId, Long memberId);
+    Optional<PlayingHistory> findByHearitIdAndUserUuid(Long hearitId, String userUuid);
 
     @Query("""
             SELECT ph
             FROM PlayingHistory ph
-            WHERE ph.memberId = :memberId
+            WHERE ph.userUuid = :userUuid
             ORDER BY ph.updatedAt DESC
             LIMIT :size
             """)
-    List<PlayingHistory> findByMemberIdOrderByUpdatedAtDesc(@Param("memberId") Long memberId, @Param("size") int size);
+    List<PlayingHistory> findByMemberIdOrderByUpdatedAtDesc(@Param("userUuid") String userUuid, @Param("size") int size);
 
-    List<PlayingHistory> findByMemberIdAndHearitIdIn(Long memberId, List<Long> hearitIds);
+    List<PlayingHistory> findByUserUuidAndHearitIdIn(String userUuid, List<Long> hearitIds);
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepository.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepository.java
@@ -18,7 +18,7 @@ public interface PlayingHistoryRepository extends JpaRepository<PlayingHistory, 
             ORDER BY ph.updatedAt DESC
             LIMIT :size
             """)
-    List<PlayingHistory> findByMemberIdOrderByUpdatedAtDesc(@Param("userUuid") String userUuid, @Param("size") int size);
+    List<PlayingHistory> findByUserUuidOrderByUpdatedAtDesc(@Param("userUuid") String userUuid, @Param("size") int size);
 
     List<PlayingHistory> findByUserUuidAndHearitIdIn(String userUuid, List<Long> hearitIds);
 }

--- a/backend/core/src/main/resources/db/migration/V2025120801010__migrate_playing_history_to_uuid.sql
+++ b/backend/core/src/main/resources/db/migration/V2025120801010__migrate_playing_history_to_uuid.sql
@@ -1,0 +1,23 @@
+-- 1. orphan 제거
+DELETE FROM playing_history
+WHERE user_uuid IS NULL;
+
+-- 2. memberId nullable로 변경
+ALTER TABLE playing_history
+    MODIFY COLUMN member_id BIGINT NULL;
+
+-- 3. uuid not null
+ALTER TABLE playing_history
+    MODIFY COLUMN user_uuid CHAR(36) NOT NULL;
+
+-- 4. uuid, hearitId에 유니크 적용
+ALTER TABLE playing_history
+    ADD CONSTRAINT uq_user_hearit UNIQUE (user_uuid, hearit_id);
+
+-- 5. memberId대신 uuid로 새로운 index 추가
+CREATE INDEX idx_user_updated_at
+    ON playing_history (user_uuid, updated_at);
+
+-- 6. memberId 기반 unique, index 제거
+ALTER TABLE playing_history DROP INDEX uq_playing_history_member_hearit;
+ALTER TABLE playing_history DROP INDEX idx_member_updated_at;

--- a/backend/core/src/test/java/com/onair/hearit/core/domain/PlayingHistoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/domain/PlayingHistoryTest.java
@@ -19,7 +19,7 @@ class PlayingHistoryTest {
         Hearit hearit = createHearitWith(playTime);
 
         // when & then
-        assertThatThrownBy(() -> new PlayingHistory(1L, hearit, lastPlayTime));
+        assertThatThrownBy(() -> new PlayingHistory("test-user-Uuid", hearit, lastPlayTime));
     }
 
     @Test
@@ -29,7 +29,7 @@ class PlayingHistoryTest {
         Hearit hearit = createHearitWith(100);
 
         // when
-        PlayingHistory playingHistory = new PlayingHistory(1L, hearit, 90_000);
+        PlayingHistory playingHistory = new PlayingHistory("test-user-Uuid", hearit, 90_000);
 
         // then
         assertThat(playingHistory.isFinished()).isTrue();

--- a/backend/core/src/test/java/com/onair/hearit/core/fixture/DbHelper.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/fixture/DbHelper.java
@@ -1,5 +1,6 @@
 package com.onair.hearit.core.fixture;
 
+import com.onair.hearit.common.TestClock;
 import com.onair.hearit.core.domain.Bookmark;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.ExploreScore;
@@ -11,6 +12,7 @@ import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.domain.RecommendHearit;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +33,15 @@ public class DbHelper {
         em.persist(hearit);
         em.flush();
         return hearit;
+    }
+
+    public Hearit insertHearitAt(Hearit hearit, LocalDateTime creationTime) {
+        try {
+            TestClock.freezeAt(creationTime);
+            return insertHearit(hearit);
+        } finally {
+            TestClock.unfreeze();
+        }
     }
 
     public Category insertCategory(Category category) {
@@ -73,5 +84,14 @@ public class DbHelper {
         em.persist(playingHistory);
         em.flush();
         return playingHistory;
+    }
+
+    public PlayingHistory insertPlayingHistoryAt(PlayingHistory playingHistory, LocalDateTime updatedTime) {
+        try {
+            TestClock.freezeAt(updatedTime);
+            return insertPlayingHistory(playingHistory);
+        } finally {
+            TestClock.unfreeze();
+        }
     }
 }

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/BookmarkRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/BookmarkRepositoryTest.java
@@ -52,7 +52,7 @@ class BookmarkRepositoryTest {
         Sort createdAt = Sort.by(Direction.DESC, "createdAt");
         // when
         Page<BookmarkWithPlayingHistoryProjection> bookmarks = bookmarkRepository.findFilteredByMember(
-                member.getId(),
+                member.getUuid(),
                 null,
                 PageRequest.of(0, 5, createdAt));
 
@@ -81,7 +81,7 @@ class BookmarkRepositoryTest {
         Sort createdAt = Sort.by(Direction.ASC, "createdAt");
         // when
         Page<BookmarkWithPlayingHistoryProjection> bookmarks = bookmarkRepository.findFilteredByMember(
-                member.getId(),
+                member.getUuid(),
                 null,
                 PageRequest.of(0, 5, createdAt));
 
@@ -102,13 +102,13 @@ class BookmarkRepositoryTest {
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Bookmark bookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit));
         PlayingHistory playingHistory = dbHelper.insertPlayingHistory(new PlayingHistory(
-                member.getId(),
+                member.getUuid(),
                 hearit,
                 (hearit.getPlayTime() - 10) * 1000L));
 
         // when
         Page<BookmarkWithPlayingHistoryProjection> bookmarks = bookmarkRepository.findFilteredByMember(
-                member.getId(),
+                member.getUuid(),
                 null,
                 PageRequest.of(0, 5)
         );
@@ -160,17 +160,17 @@ class BookmarkRepositoryTest {
 
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, finished1));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, finished2));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), finished1, 500_000L));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), finished2, 500_000L));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), finished1, 500_000L));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), finished2, 500_000L));
 
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, unfinished1));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), unfinished1, 100L));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), unfinished1, 100L));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, unfinished2));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, unfinished3));
 
         // when
         var unfinishedBookmarks = bookmarkRepository.findFilteredByMember(
-                member.getId(),
+                member.getUuid(),
                 false,
                 PageRequest.of(0, 5));
 
@@ -192,17 +192,17 @@ class BookmarkRepositoryTest {
 
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, finished1));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, finished2));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), finished1, 500_000L));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), finished2, 500_000L));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), finished1, 500_000L));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), finished2, 500_000L));
 
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, unfinished1));
-        dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), unfinished1, 100L));
+        dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), unfinished1, 100L));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, unfinished2));
         dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, unfinished3));
 
         // when
         var finishedBookmarks = bookmarkRepository.findFilteredByMember(
-                member.getId(),
+                member.getUuid(),
                 true,
                 PageRequest.of(0, 5));
 

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositoryTest.java
@@ -127,11 +127,12 @@ class HearitRepositoryTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
+        LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
         Hearit hearit1 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category),
-                LocalDateTime.now().minusMinutes(2));
+                baseTime.minusMinutes(2));
         Hearit hearit2 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category),
-                LocalDateTime.now().minusMinutes(1));
-        Hearit hearit3 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category), LocalDateTime.now());
+                baseTime.minusMinutes(1));
+        Hearit hearit3 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category), baseTime);
 
         PlayingHistory playingHistory1 = dbHelper.insertPlayingHistory(
                 new PlayingHistory(member.getUuid(), hearit1, 14));

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositoryTest.java
@@ -122,7 +122,7 @@ class HearitRepositoryTest {
     @Test
     @Disabled
     @DisplayName("최근 업로드된 히어릿을 마지막 재생시간과 함께 조회한다.")
-    void findTopNHearitWithPlayTimeTest() throws InterruptedException {
+    void findTopNHearitWithPlayTimeTest() {
         // given
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositoryTest.java
@@ -142,7 +142,7 @@ class HearitRepositoryTest {
 
         // when
         Page<HearitWithPlayTimeProjection> result =
-                hearitRepository.findWithPlayTimeBy(null, member.getId(), pageable);
+                hearitRepository.findWithPlayTimeBy(null, member.getUuid(), pageable);
 
         HearitWithPlayTimeProjection projection3 = result.getContent().get(0);
         HearitWithPlayTimeProjection projection2 = result.getContent().get(1);

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/HearitRepositoryTest.java
@@ -11,6 +11,7 @@ import com.onair.hearit.core.fixture.DbHelper;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import com.onair.hearit.core.infrastructure.projection.HearitWithPlayTimeProjection;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -91,15 +92,16 @@ class HearitRepositoryTest {
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-        PlayingHistory playingHistory1 = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit1, 14));
+        PlayingHistory playingHistory1 = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getUuid(), hearit1, 14));
         PlayingHistory playingHistory2 = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), hearit3, 300));
+                new PlayingHistory(member.getUuid(), hearit3, 300));
 
         Pageable pageable = PageRequest.of(0, 10);
 
         // when
         Page<HearitWithPlayTimeProjection> result =
-                hearitRepository.findWithPlayTimeBy(category.getId(), member.getId(), pageable);
+                hearitRepository.findWithPlayTimeBy(category.getId(), member.getUuid(), pageable);
 
         HearitWithPlayTimeProjection projection1 = result.getContent().get(0);
         HearitWithPlayTimeProjection projection2 = result.getContent().get(1);
@@ -125,15 +127,16 @@ class HearitRepositoryTest {
         Member member = dbHelper.insertMember(TestFixture.createFixedMember());
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
 
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Thread.sleep(10);
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Thread.sleep(10);
-        Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+        Hearit hearit1 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category),
+                LocalDateTime.now().minusMinutes(2));
+        Hearit hearit2 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category),
+                LocalDateTime.now().minusMinutes(1));
+        Hearit hearit3 = dbHelper.insertHearitAt(TestFixture.createFixedHearitWith(category), LocalDateTime.now());
 
-        PlayingHistory playingHistory1 = dbHelper.insertPlayingHistory(new PlayingHistory(member.getId(), hearit1, 14));
+        PlayingHistory playingHistory1 = dbHelper.insertPlayingHistory(
+                new PlayingHistory(member.getUuid(), hearit1, 14));
         PlayingHistory playingHistory2 = dbHelper.insertPlayingHistory(
-                new PlayingHistory(member.getId(), hearit3, 300));
+                new PlayingHistory(member.getUuid(), hearit3, 300));
 
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Direction.DESC, "createdAt"));
 

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
@@ -10,6 +10,7 @@ import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.fixture.DbHelper;
 import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,14 +40,12 @@ class PlayingHistoryRepositoryTest {
         Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-        dbHelper.insertPlayingHistory(new PlayingHistory(member1.getId(), hearit1, 10));
-        Thread.sleep(10);
-        dbHelper.insertPlayingHistory(new PlayingHistory(member1.getId(), hearit2, 20));
-        Thread.sleep(10);
-        dbHelper.insertPlayingHistory(new PlayingHistory(member2.getId(), hearit2, 20));
+        dbHelper.insertPlayingHistoryAt(new PlayingHistory(member1.getUuid(), hearit1, 10), LocalDateTime.now().minusMinutes(10));
+        dbHelper.insertPlayingHistoryAt(new PlayingHistory(member1.getUuid(), hearit2, 20), LocalDateTime.now().minusMinutes(1));
+        dbHelper.insertPlayingHistoryAt(new PlayingHistory(member2.getUuid(), hearit2, 20), LocalDateTime.now()); // 업데이트
 
         // when
-        List<PlayingHistory> result = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(member1.getId(), 10);
+        List<PlayingHistory> result = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(member1.getUuid(), 10);
 
         // then
         assertAll(() -> {

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
@@ -32,7 +32,7 @@ class PlayingHistoryRepositoryTest {
 
     @Test
     @DisplayName("회원의 재생 기록을 업데이트 날짜를 기준으로 내림차순 정렬하여 10개 조회한다.")
-    void findByMemberIdOrderByUpdatedAtDesc() throws InterruptedException {
+    void findByMemberIdOrderByUpdatedAtDesc() {
         // given
         Member member1 = dbHelper.insertMember(TestFixture.createFixedMember());
         Member member2 = dbHelper.insertMember(TestFixture.createFixedMember());

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
@@ -45,7 +45,7 @@ class PlayingHistoryRepositoryTest {
         dbHelper.insertPlayingHistoryAt(new PlayingHistory(member2.getUuid(), hearit2, 20), LocalDateTime.now()); // 업데이트
 
         // when
-        List<PlayingHistory> result = playingHistoryRepository.findByMemberIdOrderByUpdatedAtDesc(member1.getUuid(), 10);
+        List<PlayingHistory> result = playingHistoryRepository.findByUserUuidOrderByUpdatedAtDesc(member1.getUuid(), 10);
 
         // then
         assertAll(() -> {

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
@@ -12,7 +12,9 @@ import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -30,28 +32,65 @@ class PlayingHistoryRepositoryTest {
     @Autowired
     private PlayingHistoryRepository playingHistoryRepository;
 
-    @Test
-    @DisplayName("회원의 재생 기록을 업데이트 날짜를 기준으로 내림차순 정렬하여 10개 조회한다.")
-    void findByMemberIdOrderByUpdatedAtDesc() {
-        // given
-        Member member1 = dbHelper.insertMember(TestFixture.createFixedMember());
-        Member member2 = dbHelper.insertMember(TestFixture.createFixedMember());
-        Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
-        Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-        Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+    @Nested
+    @DisplayName("유저의 재생 기록을 원하는 개수만큼 최신순으로 정렬")
+    class findByUserUuidOrderByUpdatedAtDesc {
 
-        dbHelper.insertPlayingHistoryAt(new PlayingHistory(member1.getUuid(), hearit1, 10), LocalDateTime.now().minusMinutes(10));
-        dbHelper.insertPlayingHistoryAt(new PlayingHistory(member1.getUuid(), hearit2, 20), LocalDateTime.now().minusMinutes(1));
-        dbHelper.insertPlayingHistoryAt(new PlayingHistory(member2.getUuid(), hearit2, 20), LocalDateTime.now()); // 업데이트
+        @Test
+        @DisplayName("회원의 재생 기록을 업데이트 날짜를 기준으로 내림차순 정렬하여 10개 조회한다.")
+        void findByUserUuidOrderByUpdatedAtDesc_Member() {
+            // given
+            Member member1 = dbHelper.insertMember(TestFixture.createFixedMember());
+            Member member2 = dbHelper.insertMember(TestFixture.createFixedMember());
+            Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+            Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-        // when
-        List<PlayingHistory> result = playingHistoryRepository.findByUserUuidOrderByUpdatedAtDesc(member1.getUuid(), 10);
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(member1.getUuid(), hearit1, 10),
+                    LocalDateTime.now().minusMinutes(10));
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(member1.getUuid(), hearit2, 20),
+                    LocalDateTime.now().minusMinutes(1));
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(member2.getUuid(), hearit2, 20),
+                    LocalDateTime.now()); // 다른 멤버
 
-        // then
-        assertAll(() -> {
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0).getHearitId()).isEqualTo(hearit2.getId());
-            assertThat(result.get(1).getHearitId()).isEqualTo(hearit1.getId());
-        });
+            // when
+            List<PlayingHistory> result = playingHistoryRepository.findByUserUuidOrderByUpdatedAtDesc(member1.getUuid(),
+                    10);
+
+            // then
+            assertAll(() -> {
+                assertThat(result).hasSize(2);
+                assertThat(result.get(0).getHearitId()).isEqualTo(hearit2.getId());
+                assertThat(result.get(1).getHearitId()).isEqualTo(hearit1.getId());
+            });
+        }
+
+        @Test
+        @DisplayName("회원의 재생 기록을 업데이트 날짜를 기준으로 내림차순 정렬하여 10개 조회한다.")
+        void findByUserUuidOrderByUpdatedAtDesc_Guest() {
+            // given
+            String guestUuid1 = UUID.randomUUID().toString();
+            String guestUuid2 = UUID.randomUUID().toString();
+            Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
+            Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+            Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
+
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestUuid1, hearit1, 10),
+                    LocalDateTime.now().minusMinutes(10));
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestUuid1, hearit2, 20),
+                    LocalDateTime.now().minusMinutes(1));
+            dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestUuid2, hearit2, 20),
+                    LocalDateTime.now()); // 다른 게스트
+
+            // when
+            List<PlayingHistory> result = playingHistoryRepository.findByUserUuidOrderByUpdatedAtDesc(guestUuid1, 10);
+
+            // then
+            assertAll(() -> {
+                assertThat(result).hasSize(2);
+                assertThat(result.get(0).getHearitId()).isEqualTo(hearit2.getId());
+                assertThat(result.get(1).getHearitId()).isEqualTo(hearit1.getId());
+            });
+        }
     }
 }

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/PlayingHistoryRepositoryTest.java
@@ -46,12 +46,13 @@ class PlayingHistoryRepositoryTest {
             Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
+            LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(member1.getUuid(), hearit1, 10),
-                    LocalDateTime.now().minusMinutes(10));
+                    baseTime.minusMinutes(10));
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(member1.getUuid(), hearit2, 20),
-                    LocalDateTime.now().minusMinutes(1));
+                    baseTime.minusMinutes(1));
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(member2.getUuid(), hearit2, 20),
-                    LocalDateTime.now()); // 다른 멤버
+                    baseTime); // 다른 멤버
 
             // when
             List<PlayingHistory> result = playingHistoryRepository.findByUserUuidOrderByUpdatedAtDesc(member1.getUuid(),
@@ -66,7 +67,7 @@ class PlayingHistoryRepositoryTest {
         }
 
         @Test
-        @DisplayName("회원의 재생 기록을 업데이트 날짜를 기준으로 내림차순 정렬하여 10개 조회한다.")
+        @DisplayName("비회원의 재생 기록을 업데이트 날짜를 기준으로 내림차순 정렬하여 10개 조회한다.")
         void findByUserUuidOrderByUpdatedAtDesc_Guest() {
             // given
             String guestUuid1 = UUID.randomUUID().toString();
@@ -75,12 +76,13 @@ class PlayingHistoryRepositoryTest {
             Hearit hearit1 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
             Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
+            LocalDateTime baseTime = LocalDateTime.of(2025, 1, 1, 0, 0);
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestUuid1, hearit1, 10),
-                    LocalDateTime.now().minusMinutes(10));
+                    baseTime.minusMinutes(10));
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestUuid1, hearit2, 20),
-                    LocalDateTime.now().minusMinutes(1));
+                    baseTime.minusMinutes(1));
             dbHelper.insertPlayingHistoryAt(new PlayingHistory(guestUuid2, hearit2, 20),
-                    LocalDateTime.now()); // 다른 게스트
+                    baseTime); // 다른 게스트
 
             // when
             List<PlayingHistory> result = playingHistoryRepository.findByUserUuidOrderByUpdatedAtDesc(guestUuid1, 10);

--- a/backend/core/src/testFixtures/java/com/onair/hearit/core/fixture/TestFixture.java
+++ b/backend/core/src/testFixtures/java/com/onair/hearit/core/fixture/TestFixture.java
@@ -25,7 +25,7 @@ public class TestFixture {
         return new UserInfo(member.getId(), null);
     }
 
-    public static UserInfo createFixedGuestUserInfo(String guestId) {
+    public static UserInfo createGuestUserInfo(String guestId) {
         return new UserInfo(null, guestId);
     }
 


### PR DESCRIPTION
## **📌 변경 내용 & 이유**

- **재생 기록의 식별 기준을 memberId → userUuid로 전면 전환**
    - 회원/비회원 공통으로 동일한 기준에서 재생기록을 관리하기 위해 기존 memberId 기반 로직을 제거하고 userUuid 기반으로 통일
    - 
- **PlayingHistoryService, BookmarkService, HearitSearchService 내부의 조회/업데이트 로직 수정**
    - 각 서비스에서 재생기록 조회 시 userUuid로 일관되게 접근하도록 변경

- **UserInfo → uuid 변환 로직이 각 서비스에 중복되는 문제 해결**
    - 여러 서비스에서 동일하게 아래와 같은 코드가 반복됨

    ```
    if (userInfo.isGuest()) return guestId;
    else return member.uuid;
    ```
  - **중복 제거를 위해 UserInfoService 도입**
      - UserInfoService가 UserInfo → userUuid 변환을 단일 책임으로 수행
      - 모든 서비스가 동일한 방식으로 uuid를 얻을 수 있어 코드 응집력 향상 및 유지보수성 개선

- **테스트에서 sleep 사용 제거**
    - sleep사용 대신 TestClock를 활용한 TestFixture를 사용하도록 변경
    - Disabled되지 않은 모든 테스트에서 sleep을 제거

## **📸 스크린샷 (선택)**

> 없음

## **🧪 테스트 방법 (선택)**

- PlayingHistoryServiceTest
- BookmarkServiceTest
- HearitSearchServiceTest
    
    → uuid 기반으로 기록 조회/업데이트되는지 확인 가능
    

## **📢 논의하고 싶은 내용**

우선 UserInfoService의 위치를 app/userInfo/application으로 두었는데, 도메인 모델(UserInfo)의 해석/변환 로직을 담당하는 역할로 이 위치가 적절한지 의견 필요.. 
core/domain에 두는 게 맞을까여? 사용자의 유즈케이스나 controller에서사용하는 application 로직이라고 하기에는 애매한 거 같음
    

## **🧩 관련 이슈**

close #746 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 사용자 식별을 ID에서 UUID로 전면 전환해 북마크·검색·재생기록의 일관성·안정성 향상
  * 게스트·회원 처리 경로를 통합해 검색·재생기록 동작 단순화 및 결과 일관성 강화
  * 게스트의 재생기록 접근 및 생성/업데이트 흐름 개선(요청에 디바이스 UUID 포함 필요, 응답 필드 보강)

* **테스트**
  * 시간 고정 삽입과 UUID 기반 검증 도입으로 테스트 신뢰성 향상

* **데이터베이스**
  * 재생 기록 테이블 마이그레이션 추가: UUID 제약·유니크 제약·인덱스 도입

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->