### PR TITLE
[AN] refactor: kapt -> ksp 변경

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.serialization)
     alias(libs.plugins.kotlin.compose)
+    id("com.google.devtools.ksp")
     id("kotlin-kapt")
     id("com.google.gms.google-services")
     id("org.jlleitschuh.gradle.ktlint")
@@ -201,7 +202,7 @@ dependencies {
 
     // room
     implementation(libs.androidx.room.runtime)
-    kapt(libs.androidx.room.compiler)
+    ksp(libs.androidx.room.compiler)
 
     // coil
     implementation(libs.coil)

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.serialization) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    id("com.google.gms.google-services") version "4.4.3" apply false
+    id("com.google.gms.google-services") version "4.4.4" apply false
     id("org.jlleitschuh.gradle.ktlint") version "13.0.0" apply false
-    id("com.google.firebase.crashlytics") version "3.0.5" apply false
-    id("com.google.android.gms.oss-licenses-plugin") version "0.10.7" apply false
+    id("com.google.firebase.crashlytics") version "3.0.6" apply false
+    id("com.google.android.gms.oss-licenses-plugin") version "0.10.9" apply false
     id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "13.0.0" apply false
     id("com.google.firebase.crashlytics") version "3.0.5" apply false
     id("com.google.android.gms.oss-licenses-plugin") version "0.10.7" apply false
+    id("com.google.devtools.ksp") version "2.0.21-1.0.27" apply false
 }


### PR DESCRIPTION
## 📌 변경 내용 & 이유
- CI 돌릴때와 실행할때 자꾸 경고뜨는 것도 불편하고, 공식문서도 변경을 권장합니다.
- 소소하게 plugin 버전업그레이드도 했습니다

## 📢 논의하고 싶은 내용
- Kapt (Kotlin Annotation Processing Tool)

Kotlin 코드를 Java stub으로 변환한 후 Java annotation processor 실행
느린 빌드 속도 (stub 생성 오버헤드)
Java APT 기반이라 모든 Java annotation processor와 호환

- KSP (Kotlin Symbol Processing)

Kotlin 컴파일러 플러그인으로 직접 Kotlin 코드 분석
최대 2배 빠른 빌드 속도
Kotlin 네이티브 API 제공

- 공식문서도 kapt는 이제 유지보수만 하고 ksp로 이전할 것을 권장합니다. (https://developer.android.com/build/migrate-to-ksp)
- dataBinding은 ksp지원을 안해서 일단 kapt 코드도 남겨는 놨습니다. (viewBinding은 ksp지원함)

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
#739 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 안드로이드 빌드 도구 및 플러그인 버전 업데이트 (Google Services, Firebase Crashlytics, OSS Licenses)
  * KSP 플러그인 추가 및 데이터베이스 컴파일러 설정 개선
  * 빌드 시스템 의존성 현대화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->