### PR TITLE
[IOS] feat: 로그아웃&회원탈퇴 기능 및 비회원 라이브러리 UI 추가

### DIFF
--- a/ios/hearit/lib/core/analytics/analytics_event_names.dart
+++ b/ios/hearit/lib/core/analytics/analytics_event_names.dart
@@ -34,4 +34,10 @@ class AnalyticsEventNames {
   static const detailKakaoShare = 'detail_kakao_share';
   static const exploreToDetail = 'explore_to_detail';
   static const exploreSwipe = 'explore_swipe';
+
+  // Setting screen events
+  static const settingLogoutClicked = 'setting_logout_clicked';
+  static const settingWithdrawClicked = 'setting_withdraw_clicked';
+  static const settingLogoutConfirmed = 'setting_logout_confirmed';
+  static const settingWithdrawConfirmed = 'setting_withdraw_confirmed';
 }

--- a/ios/hearit/lib/features/home/home_screen.dart
+++ b/ios/hearit/lib/features/home/home_screen.dart
@@ -57,7 +57,7 @@ class _HomeScreenState extends State<HomeScreen> {
     if (!mounted) return;
     final authViewModel = context.read<AuthViewModel>();
     authViewModel.clearAuthStatus();
-    Navigator.of(context).pushAndRemoveUntil(
+    Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
       MaterialPageRoute(builder: (_) => const LoginScreen()),
       (route) => false,
     );

--- a/ios/hearit/lib/features/library/library_repository.dart
+++ b/ios/hearit/lib/features/library/library_repository.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../../core/network/api_client.dart';
+import '../../core/network/api_exception.dart';
 import '../auth/services/auth_storage_service.dart';
 import 'library_models.dart';
 
@@ -26,7 +27,7 @@ class LibraryRepository {
       final token = await _authStorageService.getAccessToken();
 
       if (token == null) {
-        throw Exception('로그인이 필요합니다.');
+        throw ApiException.server(401, '로그인이 필요합니다.');
       }
 
       // API 호출
@@ -39,6 +40,8 @@ class LibraryRepository {
 
       // BookmarkListResponse 객체로 변환
       return BookmarkListResponse.fromJson(response);
+    } on ApiException {
+      rethrow; // ApiException은 그대로 전달 (statusCode 보존)
     } catch (error) {
       debugPrint('북마크 목록 조회 실패: $error');
       throw Exception('북마크 목록을 불러올 수 없습니다: $error');
@@ -53,7 +56,7 @@ class LibraryRepository {
       final token = await _authStorageService.getAccessToken();
 
       if (token == null) {
-        throw Exception('로그인이 필요합니다.');
+        throw ApiException.server(401, '로그인이 필요합니다.');
       }
 
       // API 호출
@@ -63,6 +66,8 @@ class LibraryRepository {
       );
 
       debugPrint('북마크 삭제 성공: $bookmarkId');
+    } on ApiException {
+      rethrow; // ApiException은 그대로 전달 (statusCode 보존)
     } catch (error) {
       debugPrint('북마크 삭제 실패: $error');
       throw Exception('북마크를 삭제할 수 없습니다: $error');

--- a/ios/hearit/lib/features/library/library_screen.dart
+++ b/ios/hearit/lib/features/library/library_screen.dart
@@ -6,6 +6,7 @@ import '../../core/analytics/analytics_event_names.dart';
 import '../../core/analytics/analytics_param_keys.dart';
 import '../../core/analytics/analytics_provider.dart';
 import '../../core/audio/hearit_player_controller.dart';
+import '../auth/login_screen.dart';
 import '../detail/hearit_detail.dart' as detail;
 import '../detail/hearit_detail_screen.dart';
 import 'library_models.dart';
@@ -213,6 +214,22 @@ class _LibraryScreenState extends State<LibraryScreen> {
               child: CircularProgressIndicator(color: AppColors.hearitPurple2),
             ),
           )
+        // 게스트 상태 (401/403)
+        else if (_viewModel.isGuest) ...[
+          // 헤더 (기본 프로필)
+          SliverToBoxAdapter(
+            child: LibraryHeader(profile: null, isGuest: true),
+          ),
+          // 북마크 섹션 헤더
+          SliverToBoxAdapter(
+            child: BookmarkSectionHeader(
+              totalCount: 0,
+              onPlayAll: () {}, // No-op for guests
+            ),
+          ),
+          // 게스트 메시지 UI
+          SliverFillRemaining(child: _buildGuestState()),
+        ]
         // 에러 상태 (북마크가 없을 때만)
         else if (_viewModel.error != null && _viewModel.bookmarks.isEmpty)
           SliverFillRemaining(
@@ -249,7 +266,9 @@ class _LibraryScreenState extends State<LibraryScreen> {
         // 정상 상태 (헤더 + 리스트)
         else ...[
           // 헤더 (프로필 + 그라데이션)
-          SliverToBoxAdapter(child: LibraryHeader(profile: _viewModel.profile)),
+          SliverToBoxAdapter(
+            child: LibraryHeader(profile: _viewModel.profile, isGuest: false),
+          ),
           // 북마크 섹션 헤더
           SliverToBoxAdapter(
             child: BookmarkSectionHeader(
@@ -299,8 +318,9 @@ class _LibraryScreenState extends State<LibraryScreen> {
   Widget _buildEmptyState() {
     return Center(
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.start,
         children: [
+          const Spacer(flex: 1), // 상단 여백
           Icon(
             Icons.bookmark_border,
             size: 80,
@@ -310,20 +330,80 @@ class _LibraryScreenState extends State<LibraryScreen> {
           Text(
             '아직 북마크된 팟캐스트가 없습니다',
             style: TextStyle(
-              color: Colors.white.withValues(alpha: 0.7),
+              color: AppColors.gray3,
               fontSize: 16,
               fontWeight: FontWeight.w500,
             ),
           ),
           const SizedBox(height: 8),
           Text(
-            '탐색 탭에서 마음에 드는\n팟캐스트를 북마크해보세요!',
+            '상세화면에서 마음에 드는\n팟캐스트를 북마크해보세요!',
             textAlign: TextAlign.center,
             style: TextStyle(
               color: Colors.white.withValues(alpha: 0.5),
               fontSize: 14,
             ),
           ),
+          const Spacer(flex: 2), // 하단 여백
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGuestState() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Spacer(flex: 1), // 상단 여백
+          RichText(
+            textAlign: TextAlign.center,
+            text: TextSpan(
+              style: const TextStyle(
+                color: AppColors.gray4,
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                height: 1.5,
+              ),
+              children: [
+                TextSpan(
+                  text: '히어릿',
+                  style: TextStyle(
+                    color: AppColors.hearitPurple1,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const TextSpan(text: '을 모아서 듣고 싶다면,\n로그인을 해주세요!'),
+              ],
+            ),
+          ),
+          const SizedBox(height: 32),
+          SizedBox(
+            width: double.infinity,
+            height: 48,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
+                  MaterialPageRoute(builder: (_) => const LoginScreen()),
+                  (route) => false,
+                );
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.hearitPurple3,
+                foregroundColor: AppColors.gray4,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                elevation: 0,
+              ),
+              child: const Text(
+                '로그인 하러가기',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+          const Spacer(flex: 2), // 하단 여백
         ],
       ),
     );

--- a/ios/hearit/lib/features/library/library_screen.dart
+++ b/ios/hearit/lib/features/library/library_screen.dart
@@ -57,7 +57,38 @@ class _LibraryScreenState extends State<LibraryScreen> {
   }
 
   void _onViewModelChanged() {
-    if (mounted) setState(() {});
+    if (mounted) {
+      setState(() {});
+
+      // 무한 스크롤 중 인증 에러 처리
+      if (_viewModel.loadMoreAuthError != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(_viewModel.loadMoreAuthError!),
+                backgroundColor: AppColors.gray2,
+                action: SnackBarAction(
+                  label: '로그인',
+                  textColor: AppColors.hearitPurple3,
+                  onPressed: () {
+                    Navigator.of(
+                      context,
+                      rootNavigator: true,
+                    ).pushAndRemoveUntil(
+                      MaterialPageRoute(builder: (_) => const LoginScreen()),
+                      (route) => false,
+                    );
+                  },
+                ),
+                duration: const Duration(seconds: 3),
+              ),
+            );
+            _viewModel.clearLoadMoreAuthError();
+          }
+        });
+      }
+    }
   }
 
   void _onScroll() {

--- a/ios/hearit/lib/features/library/library_viewmodel.dart
+++ b/ios/hearit/lib/features/library/library_viewmodel.dart
@@ -27,6 +27,7 @@ class LibraryViewModel extends ChangeNotifier {
   int _totalElements = 0;
   bool _hasMore = true;
   bool _isGuest = false;
+  String? _loadMoreAuthError; // 무한 스크롤 중 인증 에러
 
   static const int _pageSize = 20;
 
@@ -40,6 +41,7 @@ class LibraryViewModel extends ChangeNotifier {
   bool get hasMore => _hasMore;
   bool get isEmpty => _bookmarks.isEmpty && !_isLoading;
   bool get isGuest => _isGuest;
+  String? get loadMoreAuthError => _loadMoreAuthError;
 
   /// 초기 데이터 로드 (프로필 + 첫 페이지 북마크)
   Future<void> loadInitialData() async {
@@ -109,15 +111,11 @@ class LibraryViewModel extends ChangeNotifier {
       _hasMore = response.hasMore;
       _totalElements = response.totalElements;
     } on ApiException catch (e) {
-      // 401/403: 세션 만료 또는 인증 실패 → guest 상태로 전환 (Option B)
+      // 401/403: 세션 만료 또는 인증 실패 → 기존 데이터 유지하고 로딩만 중단
       if (e.statusCode == 401 || e.statusCode == 403) {
-        _isGuest = true;
-        _error = null;
-        _bookmarks = []; // 기존 데이터 클리어
-        _totalElements = 0;
         _hasMore = false;
-        _profile = null;
-        debugPrint('추가 북마크 로드 중 인증 실패 (401/403): guest 모드로 전환');
+        _loadMoreAuthError = '로그인이 만료됐습니다. 다시 로그인해주세요';
+        debugPrint('추가 북마크 로드 중 인증 실패 (401/403): 로딩 중단');
       } else {
         // 다른 API 에러: 기존 데이터 유지
         debugPrint('추가 북마크 로드 실패: $e');
@@ -163,5 +161,10 @@ class LibraryViewModel extends ChangeNotifier {
     } catch (e) {
       debugPrint('프로필 재로드 실패: $e');
     }
+  }
+
+  /// 무한 스크롤 인증 에러 소비
+  void clearLoadMoreAuthError() {
+    _loadMoreAuthError = null;
   }
 }

--- a/ios/hearit/lib/features/library/library_viewmodel.dart
+++ b/ios/hearit/lib/features/library/library_viewmodel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../../core/network/api_exception.dart';
 import '../setting/models/member_profile.dart';
 import '../setting/setting_repository.dart';
 import 'library_models.dart';
@@ -25,6 +26,7 @@ class LibraryViewModel extends ChangeNotifier {
   int _currentPage = 0;
   int _totalElements = 0;
   bool _hasMore = true;
+  bool _isGuest = false;
 
   static const int _pageSize = 20;
 
@@ -37,6 +39,7 @@ class LibraryViewModel extends ChangeNotifier {
   int get totalElements => _totalElements;
   bool get hasMore => _hasMore;
   bool get isEmpty => _bookmarks.isEmpty && !_isLoading;
+  bool get isGuest => _isGuest;
 
   /// 초기 데이터 로드 (프로필 + 첫 페이지 북마크)
   Future<void> loadInitialData() async {
@@ -48,6 +51,7 @@ class LibraryViewModel extends ChangeNotifier {
     _totalElements = 0;
     _currentPage = 0;
     _hasMore = true;
+    _isGuest = false; // Reset guest state on reload
     notifyListeners();
 
     try {
@@ -65,10 +69,21 @@ class LibraryViewModel extends ChangeNotifier {
       _hasMore = response.hasMore;
       _currentPage = 0;
       _error = null;
+    } on ApiException catch (e) {
+      // Check for unauthorized (401) or forbidden (403)
+      if (e.statusCode == 401 || e.statusCode == 403) {
+        _isGuest = true;
+        _error = null; // Don't show error UI for guests
+        _profile = null; // Will display default profile
+        debugPrint('초기 데이터 로드 실패 (401/403): guest 모드로 전환');
+      } else {
+        _error = e.toString();
+        debugPrint('초기 데이터 로드 실패: $e');
+      }
     } catch (e) {
+      // Handle non-API errors (generic fallback)
       _error = e.toString();
       debugPrint('초기 데이터 로드 실패: $e');
-      // _bookmarks와 _totalElements는 이미 초기화됨
     } finally {
       _isLoading = false;
       notifyListeners();
@@ -93,9 +108,23 @@ class LibraryViewModel extends ChangeNotifier {
       _currentPage = nextPage;
       _hasMore = response.hasMore;
       _totalElements = response.totalElements;
+    } on ApiException catch (e) {
+      // 401/403: 세션 만료 또는 인증 실패 → guest 상태로 전환 (Option B)
+      if (e.statusCode == 401 || e.statusCode == 403) {
+        _isGuest = true;
+        _error = null;
+        _bookmarks = []; // 기존 데이터 클리어
+        _totalElements = 0;
+        _hasMore = false;
+        _profile = null;
+        debugPrint('추가 북마크 로드 중 인증 실패 (401/403): guest 모드로 전환');
+      } else {
+        // 다른 API 에러: 기존 데이터 유지
+        debugPrint('추가 북마크 로드 실패: $e');
+      }
     } catch (e) {
+      // 다른 에러: 기존 데이터 유지
       debugPrint('추가 북마크 로드 실패: $e');
-      // 에러가 발생해도 기존 데이터는 유지
     } finally {
       _isLoadingMore = false;
       notifyListeners();

--- a/ios/hearit/lib/features/library/widgets/bookmark_section_header.dart
+++ b/ios/hearit/lib/features/library/widgets/bookmark_section_header.dart
@@ -16,6 +16,7 @@ class BookmarkSectionHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final hasBookmarks = totalCount > 0;
+    final showPlayButton = onPlayAll != null; // onPlayAll이 null이 아니면 버튼 표시
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -46,8 +47,8 @@ class BookmarkSectionHeader extends StatelessWidget {
               ],
             ),
           ),
-          // 오른쪽: 전체재생 버튼
-          if (hasBookmarks)
+          // 오른쪽: 전체재생 버튼 (onPlayAll이 있으면 표시)
+          if (showPlayButton)
             GestureDetector(
               onTap: onPlayAll,
               child: Container(

--- a/ios/hearit/lib/features/library/widgets/bookmark_section_header.dart
+++ b/ios/hearit/lib/features/library/widgets/bookmark_section_header.dart
@@ -19,7 +19,7 @@ class BookmarkSectionHeader extends StatelessWidget {
     final showPlayButton = onPlayAll != null; // onPlayAll이 null이 아니면 버튼 표시
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
       child: Row(
         children: [
           // 왼쪽: 타이틀 + 개수

--- a/ios/hearit/lib/features/library/widgets/library_header.dart
+++ b/ios/hearit/lib/features/library/widgets/library_header.dart
@@ -7,9 +7,10 @@ import '../../setting/setting_screen.dart';
 /// 라이브러리 화면 상단 프로필 헤더
 /// 프로필 이미지 + 닉네임 + 그라데이션 배경 + 설정 버튼
 class LibraryHeader extends StatelessWidget {
-  const LibraryHeader({super.key, required this.profile});
+  const LibraryHeader({super.key, required this.profile, this.isGuest = false});
 
   final MemberProfile? profile;
+  final bool isGuest;
 
   void _navigateToSettings(BuildContext context) {
     Navigator.of(
@@ -73,7 +74,7 @@ class LibraryHeader extends StatelessWidget {
                   // 닉네임
                   Expanded(
                     child: Text(
-                      profile?.nickname ?? '사용자',
+                      isGuest ? 'hEARit' : (profile?.nickname ?? '사용자'),
                       style: const TextStyle(
                         color: Colors.white,
                         fontSize: 22,
@@ -93,6 +94,36 @@ class LibraryHeader extends StatelessWidget {
   }
 
   Widget _buildProfileImage() {
+    // Guest users always see 'H' initial on HearitPurple3 background
+    if (isGuest) {
+      return Container(
+        width: 48,
+        height: 48,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: AppColors.hearitPurple3,
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.2),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Center(
+          child: Text(
+            'H',
+            style: const TextStyle(
+              color: AppColors.gray4,
+              fontSize: 28,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Logged-in users: existing logic
     final hasImage = profile?.hasProfileImage ?? false;
 
     return Container(

--- a/ios/hearit/lib/features/library/widgets/library_header.dart
+++ b/ios/hearit/lib/features/library/widgets/library_header.dart
@@ -40,30 +40,14 @@ class LibraryHeader extends StatelessWidget {
       ),
       child: SafeArea(
         bottom: false,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
+        child: Stack(
           children: [
-            // 설정 아이콘 (상단에 배치)
-            Align(
-              alignment: Alignment.topRight,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 8, top: 4),
-                child: IconButton(
-                  icon: const Icon(
-                    Icons.settings,
-                    color: Colors.white,
-                    size: 28,
-                  ),
-                  onPressed: () => _navigateToSettings(context),
-                ),
-              ),
-            ),
-            // 프로필 영역 (위로 올림)
+            // 프로필 영역
             Padding(
               padding: const EdgeInsets.only(
                 left: 20,
                 right: 20,
-                top: 0,
+                top: 12,
                 bottom: 28,
               ),
               child: Row(
@@ -85,6 +69,15 @@ class LibraryHeader extends StatelessWidget {
                     ),
                   ),
                 ],
+              ),
+            ),
+            // 설정 아이콘 (우측 상단에 배치)
+            Positioned(
+              top: 4,
+              right: 8,
+              child: IconButton(
+                icon: const Icon(Icons.settings, color: Colors.white, size: 28),
+                onPressed: () => _navigateToSettings(context),
               ),
             ),
           ],
@@ -115,8 +108,8 @@ class LibraryHeader extends StatelessWidget {
             'H',
             style: const TextStyle(
               color: AppColors.gray4,
-              fontSize: 28,
-              fontWeight: FontWeight.w700,
+              fontSize: 22,
+              fontWeight: FontWeight.w500,
             ),
           ),
         ),

--- a/ios/hearit/lib/features/setting/setting_repository.dart
+++ b/ios/hearit/lib/features/setting/setting_repository.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import '../../core/network/api_client.dart';
+import '../../core/network/api_exception.dart';
 import '../auth/services/auth_storage_service.dart';
 import 'models/member_profile.dart';
 
@@ -22,7 +23,7 @@ class SettingRepository {
       final token = await _authStorageService.getAccessToken();
 
       if (token == null) {
-        throw Exception('로그인이 필요합니다.');
+        throw ApiException.server(401, '로그인이 필요합니다.');
       }
 
       // 2. API 호출
@@ -34,6 +35,8 @@ class SettingRepository {
 
       // 3. MemberProfile 객체로 변환
       return MemberProfile.fromJson(response);
+    } on ApiException {
+      rethrow; // ApiException은 그대로 전달 (statusCode 보존)
     } catch (error) {
       debugPrint('프로필 조회 실패: $error');
       throw Exception('프로필 정보를 불러올 수 없습니다: $error');
@@ -48,13 +51,15 @@ class SettingRepository {
       final token = await _authStorageService.getAccessToken();
 
       if (token == null) {
-        throw Exception('로그인이 필요합니다.');
+        throw ApiException.server(401, '로그인이 필요합니다.');
       }
 
       await _apiClient.delete<void>(
         '/api/v1/auth/withdraw',
         headers: {'Authorization': 'Bearer $token'},
       );
+    } on ApiException {
+      rethrow; // ApiException은 그대로 전달 (statusCode 보존)
     } catch (error) {
       debugPrint('회원탈퇴 API 실패: $error');
       throw Exception('회원탈퇴에 실패했습니다.');

--- a/ios/hearit/lib/features/setting/setting_repository.dart
+++ b/ios/hearit/lib/features/setting/setting_repository.dart
@@ -39,4 +39,25 @@ class SettingRepository {
       throw Exception('프로필 정보를 불러올 수 없습니다: $error');
     }
   }
+
+  /// 회원탈퇴
+  /// DELETE /api/v1/auth/withdraw
+  /// Headers: Authorization (Bearer token), UUID (자동 추가됨)
+  Future<void> withdrawAccount() async {
+    try {
+      final token = await _authStorageService.getAccessToken();
+
+      if (token == null) {
+        throw Exception('로그인이 필요합니다.');
+      }
+
+      await _apiClient.delete<void>(
+        '/api/v1/auth/withdraw',
+        headers: {'Authorization': 'Bearer $token'},
+      );
+    } catch (error) {
+      debugPrint('회원탈퇴 API 실패: $error');
+      throw Exception('회원탈퇴에 실패했습니다.');
+    }
+  }
 }

--- a/ios/hearit/lib/features/setting/setting_screen.dart
+++ b/ios/hearit/lib/features/setting/setting_screen.dart
@@ -3,9 +3,15 @@ import 'package:hearit/core/theme/app_colors.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../core/analytics/analytics_provider.dart';
+import '../../core/analytics/analytics_event_names.dart';
 import '../auth/auth_viewmodel.dart';
+import '../auth/login_screen.dart';
 import 'my_profile_screen.dart';
 import 'oss_licenses_page.dart';
+import 'setting_viewmodel.dart';
+import 'widgets/logout_confirm_dialog.dart';
+import 'widgets/withdraw_confirm_dialog.dart';
 
 class SettingScreen extends StatelessWidget {
   const SettingScreen({super.key, this.onBackToHome});
@@ -52,6 +58,106 @@ class SettingScreen extends StatelessWidget {
     Navigator.of(
       context,
     ).push(MaterialPageRoute(builder: (_) => const MyProfileScreen()));
+  }
+
+  /// 로그아웃 처리
+  Future<void> _handleLogout(BuildContext context) async {
+    // Analytics: 로그아웃 버튼 클릭
+    await AnalyticsProvider.logger.logEvent(
+      AnalyticsEventNames.settingLogoutClicked,
+    );
+
+    // 확인 다이얼로그
+    final confirmed = await LogoutConfirmDialog.show(context);
+    if (!confirmed || !context.mounted) return;
+
+    final settingViewModel = context.read<SettingViewModel>();
+
+    try {
+      // 로그아웃 실행
+      await settingViewModel.logout();
+
+      if (!context.mounted) return;
+
+      // 성공 메시지 Toast
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('로그아웃이 완료되었습니다.'),
+          backgroundColor: AppColors.hearitPurple2,
+          duration: Duration(seconds: 2),
+        ),
+      );
+
+      // 로그인 화면으로 이동 (루트 네비게이터 사용하여 모든 스택 제거)
+      Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => const LoginScreen()),
+        (route) => false,
+      );
+    } catch (error) {
+      if (!context.mounted) return;
+
+      // 실패 메시지
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(error.toString().replaceAll('Exception: ', '')),
+          backgroundColor: AppColors.error,
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  /// 회원탈퇴 처리
+  Future<void> _handleWithdraw(BuildContext context) async {
+    // Analytics: 회원탈퇴 버튼 클릭
+    await AnalyticsProvider.logger.logEvent(
+      AnalyticsEventNames.settingWithdrawClicked,
+    );
+
+    // 경고 다이얼로그
+    final confirmed = await WithdrawConfirmDialog.show(context);
+    if (!confirmed || !context.mounted) return;
+
+    final settingViewModel = context.read<SettingViewModel>();
+
+    try {
+      // 회원탈퇴 실행
+      await settingViewModel.withdraw();
+
+      if (!context.mounted) return;
+
+      // 성공 메시지 Toast
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('회원탈퇴가 완료되었습니다.'),
+          backgroundColor: AppColors.hearitPurple2,
+          duration: Duration(seconds: 2),
+        ),
+      );
+
+      // 로그인 화면으로 이동 (루트 네비게이터 사용하여 모든 스택 제거)
+      Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => const LoginScreen()),
+        (route) => false,
+      );
+    } catch (error) {
+      if (!context.mounted) return;
+
+      // 실패 메시지 (API 실패해도 로컬 토큰은 이미 삭제됨)
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('회원탈퇴에 실패했습니다. 다시 로그인해주세요.'),
+          backgroundColor: AppColors.error,
+          duration: Duration(seconds: 2),
+        ),
+      );
+
+      // API 실패해도 로그인 화면으로 이동 (루트 네비게이터 사용하여 모든 스택 제거)
+      Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => const LoginScreen()),
+        (route) => false,
+      );
+    }
   }
 
   @override
@@ -110,6 +216,37 @@ class SettingScreen extends StatelessWidget {
                     label: '오픈 라이선스',
                     onTap: () => _openLicenses(context),
                   ),
+                  const SizedBox(height: 20),
+
+                  // 로그인 상태일 때만 로그아웃/회원탈퇴 표시
+                  if (isLoggedIn) ...[
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 12),
+                      child: Divider(
+                        color: AppColors.gray2,
+                        thickness: 1,
+                        height: 1,
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    _SettingItem(
+                      label: '로그아웃',
+                      onTap: () => _handleLogout(context),
+                      textStyle: _itemTextStyle.copyWith(
+                        color: AppColors.gray4,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    _SettingItem(
+                      label: '회원탈퇴',
+                      onTap: () => _handleWithdraw(context),
+                      textStyle: _itemTextStyle.copyWith(
+                        color: AppColors.error,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
                   const Spacer(),
                   Center(
                     child: Padding(

--- a/ios/hearit/lib/features/setting/setting_screen.dart
+++ b/ios/hearit/lib/features/setting/setting_screen.dart
@@ -19,7 +19,7 @@ class SettingScreen extends StatelessWidget {
   final VoidCallback? onBackToHome;
   static const Color _backgroundColor = AppColors.hearitBlack;
   static const TextStyle _itemTextStyle = TextStyle(
-    color: Colors.white70,
+    color: AppColors.gray4,
     fontSize: 16,
     fontWeight: FontWeight.w500,
   );
@@ -182,92 +182,140 @@ class SettingScreen extends StatelessWidget {
         ),
       ),
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          child: Consumer<AuthViewModel>(
-            builder: (context, authViewModel, _) {
-              final isLoggedIn = authViewModel.isLoggedIn;
+        child: Consumer<AuthViewModel>(
+          builder: (context, authViewModel, _) {
+            final isLoggedIn = authViewModel.isLoggedIn;
 
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(height: 12),
+
+                      // 로그인 상태일 때만 "내 정보" 표시
+                      if (isLoggedIn) ...[
+                        _SettingItem(
+                          label: '내 정보',
+                          onTap: () => _openMyProfile(context),
+                        ),
+                        const SizedBox(height: 20),
+                      ],
+
+                      _SettingItem(
+                        label: '개인정보처리방침',
+                        onTap: () =>
+                            _openExternalUrl(context, _privacyPolicyUrl),
+                      ),
+                      const SizedBox(height: 20),
+                      _SettingItem(
+                        label: '이용 약관',
+                        onTap: () => _openExternalUrl(context, _termsUrl),
+                      ),
+                      const SizedBox(height: 20),
+                      _SettingItem(
+                        label: '오픈 라이선스',
+                        onTap: () => _openLicenses(context),
+                      ),
+                      const SizedBox(height: 20),
+                    ],
+                  ),
+                ),
+
+                // 로그인 상태일 때만 로그아웃/회원탈퇴 표시
+                if (isLoggedIn) ...[
                   const SizedBox(height: 12),
-
-                  // 로그인 상태일 때만 "내 정보" 표시
-                  if (isLoggedIn) ...[
-                    _SettingItem(
-                      label: '내 정보',
-                      onTap: () => _openMyProfile(context),
-                    ),
-                    const SizedBox(height: 20),
-                  ],
-
-                  _SettingItem(
-                    label: '개인정보처리방침',
-                    onTap: () => _openExternalUrl(context, _privacyPolicyUrl),
+                  Container(
+                    width: double.infinity,
+                    height: 1,
+                    color: AppColors.darkGray,
                   ),
-                  const SizedBox(height: 20),
-                  _SettingItem(
-                    label: '이용 약관',
-                    onTap: () => _openExternalUrl(context, _termsUrl),
-                  ),
-                  const SizedBox(height: 20),
-                  _SettingItem(
-                    label: '오픈 라이선스',
-                    onTap: () => _openLicenses(context),
-                  ),
-                  const SizedBox(height: 20),
-
-                  // 로그인 상태일 때만 로그아웃/회원탈퇴 표시
-                  if (isLoggedIn) ...[
-                    const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 12),
-                      child: Divider(
-                        color: AppColors.gray2,
-                        thickness: 1,
-                        height: 1,
-                      ),
-                    ),
-                    const SizedBox(height: 20),
-                    _SettingItem(
-                      label: '로그아웃',
-                      onTap: () => _handleLogout(context),
-                      textStyle: _itemTextStyle.copyWith(
-                        color: AppColors.gray4,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                    const SizedBox(height: 20),
-                    _SettingItem(
-                      label: '회원탈퇴',
-                      onTap: () => _handleWithdraw(context),
-                      textStyle: _itemTextStyle.copyWith(
-                        color: AppColors.error,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ],
-                  const Spacer(),
-                  Center(
-                    child: Padding(
-                      padding: const EdgeInsets.only(bottom: 24),
-                      child: _SettingItem(
-                        label: '피드백 및 문의하기',
-                        onTap: () => _openExternalUrl(
-                          context,
-                          'https://forms.gle/KGjHNi9ASdN3jR5v6',
+                  const SizedBox(height: 12),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(height: 20),
+                        _SettingItem(
+                          label: '로그아웃',
+                          onTap: () => _handleLogout(context),
+                          textStyle: _itemTextStyle.copyWith(
+                            color: AppColors.gray4,
+                            fontWeight: FontWeight.w500,
+                          ),
                         ),
-                        textStyle: _itemTextStyle.copyWith(
-                          color: Colors.white,
-                          fontWeight: FontWeight.w600,
+                        const SizedBox(height: 20),
+                        _SettingItem(
+                          label: '회원탈퇴',
+                          onTap: () => _handleWithdraw(context),
+                          textStyle: _itemTextStyle.copyWith(
+                            color: AppColors.error,
+                            fontWeight: FontWeight.w500,
+                          ),
                         ),
-                      ),
+                      ],
+                    ),
+                  ),
+                ] else ...[
+                  const SizedBox(height: 12),
+                  Container(
+                    width: double.infinity,
+                    height: 1,
+                    color: AppColors.darkGray,
+                  ),
+                  const SizedBox(height: 12),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const SizedBox(height: 20),
+                        _SettingItem(
+                          label: '로그인 하러가기',
+                          onTap: () {
+                            Navigator.of(
+                              context,
+                              rootNavigator: true,
+                            ).pushAndRemoveUntil(
+                              MaterialPageRoute(
+                                builder: (_) => const LoginScreen(),
+                              ),
+                              (route) => false,
+                            );
+                          },
+                          textStyle: _itemTextStyle.copyWith(
+                            color: AppColors.gray4,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ],
-              );
-            },
-          ),
+                const Spacer(),
+                Center(
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 24),
+                    child: _SettingItem(
+                      label: '피드백 및 문의하기',
+                      onTap: () => _openExternalUrl(
+                        context,
+                        'https://forms.gle/KGjHNi9ASdN3jR5v6',
+                      ),
+                      textStyle: _itemTextStyle.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/ios/hearit/lib/features/setting/setting_viewmodel.dart
+++ b/ios/hearit/lib/features/setting/setting_viewmodel.dart
@@ -1,13 +1,20 @@
 import 'package:flutter/foundation.dart';
 
+import '../../core/analytics/analytics_provider.dart';
+import '../../core/analytics/analytics_event_names.dart';
+import '../auth/auth_viewmodel.dart';
 import 'models/member_profile.dart';
 import 'setting_repository.dart';
 
 class SettingViewModel extends ChangeNotifier {
-  SettingViewModel({SettingRepository? repository})
-    : _repository = repository ?? SettingRepository();
+  SettingViewModel({
+    SettingRepository? repository,
+    required AuthViewModel authViewModel,
+  }) : _repository = repository ?? SettingRepository(),
+       _authViewModel = authViewModel;
 
   final SettingRepository _repository;
+  final AuthViewModel _authViewModel;
 
   MemberProfile? _profile;
   bool _isLoading = false;
@@ -47,5 +54,54 @@ class SettingViewModel extends ChangeNotifier {
   void clearError() {
     _errorMessage = null;
     notifyListeners();
+  }
+
+  /// 로그아웃
+  Future<void> logout() async {
+    _setLoading(true);
+    _errorMessage = null;
+
+    try {
+      // Analytics 기록
+      await AnalyticsProvider.logger.logEvent(
+        AnalyticsEventNames.settingLogoutConfirmed,
+      );
+
+      // AuthViewModel의 logout 호출 (카카오 로그아웃 + 토큰 삭제)
+      await _authViewModel.logout();
+
+      _setLoading(false);
+    } catch (error) {
+      _errorMessage = '로그아웃에 실패했습니다.';
+      _setLoading(false);
+      debugPrint('로그아웃 실패: $error');
+      rethrow;
+    }
+  }
+
+  /// 회원탈퇴
+  Future<void> withdraw() async {
+    _setLoading(true);
+    _errorMessage = null;
+
+    try {
+      // Analytics 기록
+      await AnalyticsProvider.logger.logEvent(
+        AnalyticsEventNames.settingWithdrawConfirmed,
+      );
+
+      // 회원탈퇴 API 호출
+      await _repository.withdrawAccount();
+
+      _setLoading(false);
+    } catch (error) {
+      _errorMessage = '회원탈퇴에 실패했습니다.';
+      _setLoading(false);
+      debugPrint('회원탈퇴 실패: $error');
+      // API 실패해도 아래 finally에서 토큰 삭제됨
+    } finally {
+      // API 성공/실패 무관하게 로컬 토큰 삭제 및 인증 상태 초기화
+      await _authViewModel.clearAuthStatus();
+    }
   }
 }

--- a/ios/hearit/lib/features/setting/widgets/logout_confirm_dialog.dart
+++ b/ios/hearit/lib/features/setting/widgets/logout_confirm_dialog.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:hearit/core/theme/app_colors.dart';
+
+/// 로그아웃 확인 다이얼로그
+class LogoutConfirmDialog {
+  /// 로그아웃 확인 다이얼로그 표시
+  static Future<bool> show(BuildContext context) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.gray1,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: const Text(
+          '로그아웃',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 20,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        content: Text(
+          '정말 로그아웃 하시겠습니까?',
+          style: TextStyle(color: Colors.white.withOpacity(0.8), fontSize: 16),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(
+              '취소',
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.7),
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text(
+              '로그아웃',
+              style: TextStyle(
+                color: AppColors.hearitPurple2,
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return result ?? false;
+  }
+}

--- a/ios/hearit/lib/features/setting/widgets/withdraw_confirm_dialog.dart
+++ b/ios/hearit/lib/features/setting/widgets/withdraw_confirm_dialog.dart
@@ -37,7 +37,7 @@ class WithdrawConfirmDialog {
                 borderRadius: BorderRadius.circular(8),
               ),
               child: const Text(
-                '⚠️ 탈퇴 시 모든 데이터가 삭제되며\n복구할 수 없습니다.',
+                '⚠️ 탈퇴 시 모든 데이터가 삭제됩니다.',
                 style: TextStyle(
                   color: AppColors.error,
                   fontSize: 14,

--- a/ios/hearit/lib/features/setting/widgets/withdraw_confirm_dialog.dart
+++ b/ios/hearit/lib/features/setting/widgets/withdraw_confirm_dialog.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:hearit/core/theme/app_colors.dart';
+
+/// 회원탈퇴 확인 다이얼로그
+class WithdrawConfirmDialog {
+  /// 회원탈퇴 확인 다이얼로그 표시
+  static Future<bool> show(BuildContext context) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.gray1,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        title: const Text(
+          '회원탈퇴',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: 20,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '정말 탈퇴하시겠습니까?',
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.8),
+                fontSize: 16,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: AppColors.hearitBlack,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Text(
+                '⚠️ 탈퇴 시 모든 데이터가 삭제되며\n복구할 수 없습니다.',
+                style: TextStyle(
+                  color: AppColors.error,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(
+              '취소',
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.7),
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text(
+              '탈퇴',
+              style: TextStyle(
+                color: AppColors.error,
+                fontSize: 16,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    return result ?? false;
+  }
+}

--- a/ios/hearit/lib/main.dart
+++ b/ios/hearit/lib/main.dart
@@ -62,7 +62,12 @@ Future<void> main() async {
           ),
         ),
         ChangeNotifierProvider(create: (_) => AuthViewModel()),
-        ChangeNotifierProvider(create: (_) => SettingViewModel()),
+        ChangeNotifierProxyProvider<AuthViewModel, SettingViewModel>(
+          create: (context) =>
+              SettingViewModel(authViewModel: context.read<AuthViewModel>()),
+          update: (context, authViewModel, previous) =>
+              previous ?? SettingViewModel(authViewModel: authViewModel),
+        ),
       ],
       child: const MyApp(),
     ),


### PR DESCRIPTION
## 📌 변경 내용 & 이유
1. 로그아웃 & 회원탈퇴 기능 구현
- 설정 화면 개선 (setting_screen.dart)
  - 로그인/비로그인 상태에 따른 UI 분기 처리
  - 로그인 상태: "로그아웃", "회원탈퇴" 메뉴 표시
  - 비로그인 상태: "로그인 하러가기" 메뉴 표시
  
2. 비회원 사용자 라이브러리 화면 UI 추가
- 게스트 모드 지원 (library_viewmodel.dart)
  - API 호출 시 401/403 에러 발생 시 isGuest 상태로 전환
  - 기존 데이터 보존하면서 인증 에러만 별도 처리
  - 무한 스크롤 중 인증 만료 시 loadMoreAuthError 상태 관리
- 게스트 전용 UI (library_screen.dart)
  - 비로그인 상태 전용 안내 화면 추가
    - "로그인 하러가기" 버튼으로 즉시 로그인 화면 이동

3. 라이브러리 화면 무한 스크롤 중 인증 만료 처리
  - 스크롤 중 401/403 에러 발생 시 SnackBar로 안내
  - "로그인이 만료됐습니다. 다시 로그인해주세요" 메시지
  - SnackBar에 "로그인" 액션 버튼 제공 (즉시 로그인 화면 이동)

4. 에러 처리 강화
- ApiException 전파 (library_repository.dart, setting_repository.dart)
  - 기존 Exception 대신 ApiException 사용으로 statusCode 보존
  - ViewModel에서 HTTP 상태 코드 기반 정확한 에러 분기 가능
  - 401/403 에러를 게스트 모드로 처리하기 위한 기반 작업

---
## 📸 스크린샷

**로그인 상태**

<img width="200" height="2556" alt="simulator_screenshot_D76FD0F7-5F10-4C82-B0A4-F0E6E09F70FD" src="https://github.com/user-attachments/assets/75327780-38d8-4b7c-9bdf-b6c8dff29639" />
<img width="200" height="2556" alt="simulator_screenshot_1A807983-1FBF-4B2F-A882-DF16984AB1C8" src="https://github.com/user-attachments/assets/bd5bdaf3-81ac-4b9e-9655-9088d68438ba" />
<img width="200" height="2556" alt="simulator_screenshot_9A20283B-22E0-4425-BE13-26885C319E04" src="https://github.com/user-attachments/assets/5fcba581-d693-4488-a174-571e8c4379e4" />

**비회원 상태**

<img width="200" height="2556" alt="simulator_screenshot_531C233B-B85D-4225-BA89-5272CFD8B494" src="https://github.com/user-attachments/assets/23444531-ae2c-40df-b0d9-30f5ca562453" />
<img width="200" height="2556" alt="simulator_screenshot_986A7B36-02F0-4C7B-9A1E-07032CB28678" src="https://github.com/user-attachments/assets/563cbc19-88ee-4e8e-bcc1-6829b951f31e" />

---
## 🧪 테스트 방법
- 설정 화면 - 로그인 상태 (로그아웃/회원탈퇴 메뉴)
- 설정 화면 - 비로그인 상태 (로그인 하러가기 메뉴)
- 라이브러리 화면 - 게스트 모드 (로그인 안내)
- 라이브러리 화면 - 무한 스크롤 중 인증 만료 SnackBar

---
## 🧩 관련 이슈
close #792