### PR TITLE
fix(search): 키워드 없는 히어릿 검색 시 NPE 발생 수정 #812

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitSearchService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/hearit/application/HearitSearchService.java
@@ -12,6 +12,7 @@ import com.onair.hearit.core.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -63,7 +64,7 @@ public class HearitSearchService {
                                 playingHistory -> playingHistory));
         return hearits.map(hearit -> HearitSearchResponse.of(
                 hearit,
-                hearitKeywords.get(hearit.getId()),
+                hearitKeywords.getOrDefault(hearit.getId(), Collections.emptyList()),
                 playingHistories.get(hearit.getId())));
     }
 


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
**문제 상황**
- `GET /api/v1/hearits/search?searchTerm=LLM` API 호출 시 500 에러 발생
- 키워드가 연결되지 않은 Hearit 검색 시 `NullPointerException` 발생
- 에러 발생 위치: `HearitSearchResponse.getKeywordNames():31`

**근본 원인**
- `HearitSearchService`에서 `hearitKeywords.get(hearit.getId())`가 `null` 반환
- Map에 존재하지 않는 키 조회 시 `null`이 DTO로 전달됨

**수정 내용**
- **Service 레벨에서 null 처리** (`HearitSearchService.java`)
   - `hearitKeywords.get()` → `hearitKeywords.getOrDefault(..., Collections.emptyList())`
   - 키워드가 없는 경우 빈 리스트를 DTO에 전달

**효과**
- 키워드 없는 Hearit도 정상적으로 검색 가능
- API 응답: `"keywords": []` (빈 배열)
- HTTP 상태: 500 → 200

## 📸 스크린샷 (선택)
> UI 변경 없음

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
1. 키워드가 없는 Hearit을 DB에 생성
2. `GET /api/v1/hearits/search?searchTerm={해당 제목}` 호출
3. 200 응답과 함께 `keywords: []`가 반환되는지 확인

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #812 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 누락된 키워드가 있는 경우를 더 안정적으로 처리하도록 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->