### PR TITLE
[BE] bug: 어드민 키워드 누락 버그 수정 및 스타일 개선 (#814)

### DIFF
--- a/backend/admin/src/main/resources/static/css/hearit-create.css
+++ b/backend/admin/src/main/resources/static/css/hearit-create.css
@@ -1,0 +1,46 @@
+/* 키워드 컨테이너 커스텀 스타일 */
+#keyword-checkboxes {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); /* 자동 열 맞춤 */
+    gap: 8px;
+    padding: 12px;
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    max-height: 400px; /* 높이를 조금 더 확보 */
+    overflow-y: auto;
+}
+
+/* 체크박스 항목을 버튼/배지 형태로 변경 */
+.keyword-item {
+    display: flex;
+    align-items: center;
+    padding: 6px 10px;
+    background: white;
+    border: 1px solid #e9ecef;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-size: 0.9rem;
+}
+
+.keyword-item:hover {
+    background-color: #e7f1ff;
+    border-color: #0d6efd;
+}
+
+.keyword-item input {
+    margin-right: 8px;
+    cursor: pointer;
+}
+
+/* 선택된 항목 강조 */
+.keyword-item.selected {
+    background-color: #0d6efd;
+    color: white;
+    border-color: #0d6efd;
+}
+
+.keyword-item.selected input {
+    accent-color: white;
+}

--- a/backend/admin/src/main/resources/static/js/hearit-create.js
+++ b/backend/admin/src/main/resources/static/js/hearit-create.js
@@ -166,7 +166,7 @@ class KeywordManager {
         this.searchInput = document.getElementById(searchInputId);
         this.paginationContainer = document.getElementById(paginationId);
         this.countElement = document.getElementById(countId);
-        this.KEYWORDS_PER_PAGE = 20;
+        this.KEYWORDS_PER_PAGE = 50;
         this.allKeywords = [];
         this.filteredKeywords = [];
         this.currentPage = 1;
@@ -195,33 +195,36 @@ class KeywordManager {
     }
 
     createCheckbox(keyword) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'form-check';
+        const isChecked = this.selectedIds.has(keyword.id);
+
+        // 레이블 자체를 컨테이너로 사용하여 클릭 범위를 넓힘
+        const label = document.createElement('label');
+        label.className = `keyword-item ${isChecked ? 'selected' : ''}`;
+        label.setAttribute('for', `keyword-${keyword.id}`);
 
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.className = 'form-check-input';
-        checkbox.name = 'keywordIds';
         checkbox.value = keyword.id;
         checkbox.id = `keyword-${keyword.id}`;
-        checkbox.checked = this.selectedIds.has(keyword.id);
+        checkbox.checked = isChecked;
+
         checkbox.addEventListener('change', (e) => {
             if (e.target.checked) {
                 this.selectedIds.add(keyword.id);
+                label.classList.add('selected');
             } else {
                 this.selectedIds.delete(keyword.id);
+                label.classList.remove('selected');
             }
             this.updateCount();
         });
 
-        const label = document.createElement('label');
-        label.className = 'form-check-label';
-        label.setAttribute('for', `keyword-${keyword.id}`);
-        label.textContent = keyword.name;
+        const text = document.createTextNode(keyword.name);
 
-        wrapper.appendChild(checkbox);
-        wrapper.appendChild(label);
-        return wrapper;
+        label.appendChild(checkbox);
+        label.appendChild(text);
+        return label;
     }
 
     getPagedKeywords() {
@@ -310,6 +313,10 @@ class KeywordManager {
 
     initSearch() {
         this.searchInput.addEventListener('input', (e) => this.handleSearch(e.target.value));
+    }
+
+    getSelectedIds() {
+        return Array.from(this.selectedIds);
     }
 }
 
@@ -612,12 +619,14 @@ class FormSubmitHandler {
         formData.delete('shortAudio');
         formData.delete('script');
 
+        const selectedKeywordIds = window.app.keywordManager.getSelectedIds();
+
         const json = {
             title: formData.get("title"),
             summary: formData.get("summary"),
             playTime: formData.get("playTime"),
             categoryId: formData.get("categoryId"),
-            keywordIds: [...formData.getAll("keywordIds")],
+            keywordIds: selectedKeywordIds,
             sources: extractSources(formData),
             originalAudioKey: presigned.originalAudio.key,
             shortAudioKey: presigned.shortAudio.key,

--- a/backend/admin/src/main/resources/templates/admin/hearit-create.html
+++ b/backend/admin/src/main/resources/templates/admin/hearit-create.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<link rel="stylesheet" th:href="@{/css/hearit-create.css}">
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
@@ -64,15 +65,22 @@
                 </div>
             </div>
             <div class="mb-3">
-                <label class="form-label d-block">키워드</label>
-                <input type="text" class="form-control mb-2" id="keyword-search" placeholder="키워드 검색...">
-                <div id="keyword-checkboxes" class="border rounded p-3"
-                     style="max-height: 200px; overflow-y: auto;"></div>
-                <div class="d-flex justify-content-between align-items-center mt-2">
-                    <small class="text-muted">
-                        선택된 키워드: <span id="selected-keyword-count">0</span>개
+                <div class="d-flex justify-content-between align-items-end mb-2">
+                    <label class="form-label mb-0 fw-bold">키워드 선택</label>
+                    <small class="text-primary fw-bold">
+                        선택됨: <span id="selected-keyword-count">0</span>개
                     </small>
-                    <div id="keyword-pagination" class="btn-group btn-group-sm"></div>
+                </div>
+
+                <div class="input-group mb-2">
+                    <span class="input-group-text bg-white"><i class="bi bi-search"></i></span>
+                    <input type="text" class="form-control" id="keyword-search" placeholder="등록할 키워드를 검색해 보세요...">
+                </div>
+
+                <div id="keyword-checkboxes"></div>
+
+                <div class="d-flex justify-content-center mt-3">
+                    <div id="keyword-pagination" class="btn-group shadow-sm"></div>
                 </div>
             </div>
             <div id="button-container" class="d-flex gap-2">


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

### 키워드 누락 이유
-폼 데이터를 전송할 때 화면에 보이지 않는(렌더링되지 않은) 체크박스들은 전송 대상에서 제외되어서 누락 됨
- 폼에서 불러오지 않고 저장해놨다가 불러오도록 변경

### 스타일 수정
- 키워드를 고르기 위해서 클릭을 많이 해야하는 불편함이 있어서 한번에 50개 불러오기 / 그리드 형식으로 변경
<img width="700" alt="image" src="https://github.com/user-attachments/assets/1dd48828-b169-445e-aa56-8caf94d04201" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 키워드 검색 입력 필드 추가로 빠른 키워드 검색 가능
  * 선택된 키워드 개수를 실시간으로 표시
  * 페이지당 표시 키워드 수 증가 (20개 → 50개)

* **UI 개선**
  * 키워드 선택 인터페이스 완전 리디자인
  * 선택된 키워드에 대한 시각적 피드백 강화 (버튼 스타일 하이라이트)
  * 반응형 그리드 레이아웃으로 더 나은 사용성 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->