### PR TITLE
[AN] feat: 15초 이상 조회수 기능 구현

### DIFF
--- a/android/app/src/main/java/com/onair/hearit/data/api/HearitService.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/api/HearitService.kt
@@ -8,6 +8,7 @@ import com.onair.hearit.data.dto.RecommendationCategoriesResponse
 import com.onair.hearit.data.dto.SearchHearitsResponse
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -43,4 +44,9 @@ interface HearitService {
     suspend fun getHearit(
         @Path("hearitId") hearitId: Long,
     ): Response<HearitResponse>
+
+    @POST("api/v1/hearits/{hearitId}/view")
+    suspend fun postHearitView(
+        @Path("hearitId") hearitId: Long,
+    ): Response<Unit>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSource.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSource.kt
@@ -31,4 +31,6 @@ interface HearitRemoteDataSource {
     ): NetworkResult<HearitsResponse>
 
     suspend fun getRecommendationCategoryHearits(): NetworkResult<List<RecommendationCategoriesResponse>>
+
+    suspend fun postHearitView(hearitId: Long): NetworkResult<Unit>
 }

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.onair.hearit.data.api.HearitService
 import com.onair.hearit.data.datasource.ErrorResponseHandler
 import com.onair.hearit.data.datasource.NetworkResult
 import com.onair.hearit.data.datasource.handleApiCall
+import com.onair.hearit.data.datasource.handleApiCallUnit
 import com.onair.hearit.data.dto.ExploreHearitResponse
 import com.onair.hearit.data.dto.HearitResponse
 import com.onair.hearit.data.dto.HearitsResponse
@@ -70,7 +71,7 @@ class HearitRemoteDataSourceImpl @Inject constructor(
         )
 
     override suspend fun postHearitView(hearitId: Long): NetworkResult<Unit> =
-        handleApiCall(
+        handleApiCallUnit(
             apiCall = { hearitService.postHearitView(hearitId) },
             errorHandler = errorResponseHandler,
         )

--- a/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSourceImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/datasource/remote/HearitRemoteDataSourceImpl.kt
@@ -68,4 +68,10 @@ class HearitRemoteDataSourceImpl @Inject constructor(
             apiCall = { hearitService.getCategoryHearits() },
             errorHandler = errorResponseHandler,
         )
+
+    override suspend fun postHearitView(hearitId: Long): NetworkResult<Unit> =
+        handleApiCall(
+            apiCall = { hearitService.postHearitView(hearitId) },
+            errorHandler = errorResponseHandler,
+        )
 }

--- a/android/app/src/main/java/com/onair/hearit/data/repository/HearitRepositoryImpl.kt
+++ b/android/app/src/main/java/com/onair/hearit/data/repository/HearitRepositoryImpl.kt
@@ -60,4 +60,7 @@ class HearitRepositoryImpl @Inject constructor(
         hearitRemoteDataSource
             .getHearits(null, page, size)
             .toDomainResult { it.toRecentUploadHearit() }
+
+    override suspend fun postHearitView(hearitId: Long): Result<Unit> =
+        hearitRemoteDataSource.postHearitView(hearitId = hearitId).toDomainResult()
 }

--- a/android/app/src/main/java/com/onair/hearit/di/TimeModule.kt
+++ b/android/app/src/main/java/com/onair/hearit/di/TimeModule.kt
@@ -1,11 +1,17 @@
 package com.onair.hearit.di
 
+import android.os.SystemClock
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import java.time.Clock
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ElapsedRealtime
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -13,4 +19,9 @@ class TimeModule {
     @Provides
     @Singleton
     fun provideClock(): Clock = Clock.systemDefaultZone()
+
+    @Provides
+    @Singleton
+    @ElapsedRealtime
+    fun provideElapsedRealtime(): () -> Long = { SystemClock.elapsedRealtime() }
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/repository/HearitRepository.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/repository/HearitRepository.kt
@@ -35,4 +35,6 @@ interface HearitRepository {
         page: Int? = 0,
         size: Int? = 20,
     ): Result<PageResult<RecentUploadHearit>>
+
+    suspend fun postHearitView(hearitId: Long): Result<Unit>
 }

--- a/android/app/src/main/java/com/onair/hearit/domain/usecase/PostHearitViewUseCase.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/usecase/PostHearitViewUseCase.kt
@@ -1,8 +1,6 @@
 package com.onair.hearit.domain.usecase
 
-import com.onair.hearit.domain.model.ExploreHearit
 import com.onair.hearit.domain.repository.HearitRepository
-import com.onair.hearit.domain.repository.MediaFileRepository
 import javax.inject.Inject
 
 class PostHearitViewUseCase @Inject constructor(

--- a/android/app/src/main/java/com/onair/hearit/domain/usecase/PostHearitViewUseCase.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/usecase/PostHearitViewUseCase.kt
@@ -1,0 +1,15 @@
+package com.onair.hearit.domain.usecase
+
+import com.onair.hearit.domain.model.ExploreHearit
+import com.onair.hearit.domain.repository.HearitRepository
+import com.onair.hearit.domain.repository.MediaFileRepository
+import javax.inject.Inject
+
+class PostHearitViewUseCase @Inject constructor(
+    private val hearitRepository: HearitRepository,
+) {
+    suspend operator fun invoke(hearitId: Long): Result<Unit> =
+        runCatching {
+            hearitRepository.postHearitView(hearitId)
+        }
+}

--- a/android/app/src/main/java/com/onair/hearit/domain/usecase/PostHearitViewUseCase.kt
+++ b/android/app/src/main/java/com/onair/hearit/domain/usecase/PostHearitViewUseCase.kt
@@ -6,8 +6,5 @@ import javax.inject.Inject
 class PostHearitViewUseCase @Inject constructor(
     private val hearitRepository: HearitRepository,
 ) {
-    suspend operator fun invoke(hearitId: Long): Result<Unit> =
-        runCatching {
-            hearitRepository.postHearitView(hearitId)
-        }
+    suspend operator fun invoke(hearitId: Long): Result<Unit> = hearitRepository.postHearitView(hearitId)
 }

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
@@ -23,66 +23,57 @@ class PlaybackDurationTracker @Inject constructor(
 ) : Player.Listener {
     private var player: Player? = null
     private var trackingJob: Job? = null
-    private var viewHistoryJob: Job? = null
-    private var currentMediaId: String? = null
 
-    private var accumulatedMs = 0L
-    private var isHistorySent = false
-    private var lastCheckTime = 0L
+    private data class TrackingState(
+        val mediaId: String?,
+        var accumulatedMs: Long = 0L,
+        var isHistorySent: Boolean = false,
+    )
 
-    private val targetMs = 15_000L
-    private val checkInterval = 1_000L
+    private var currentState: TrackingState? = null
 
     fun attach(player: Player) {
         this.player = player
-        this.currentMediaId = player.currentMediaItem?.mediaId
+        this.currentState = TrackingState(player.currentMediaItem?.mediaId)
         player.addListener(this)
         updateTrackingState()
     }
 
     fun detach() {
         stopTracking()
-        viewHistoryJob?.cancel()
-        viewHistoryJob = null
         player?.removeListener(this)
         player = null
-        currentMediaId = null
-        accumulatedMs = 0L
-        isHistorySent = false
+        currentState = null
     }
 
     private fun updateTrackingState() {
-        val player = this.player ?: return
-        val isPlaying = player.isPlaying
-        val hasValidMedia = player.currentMediaItem != null
+        val state = currentState ?: return
+        val player = player ?: return
 
-        if (isPlaying && !isHistorySent && hasValidMedia) {
-            startTracking()
-        } else {
-            stopTracking()
+        with(player) {
+            if (isPlaying && !state.isHistorySent && currentMediaItem != null) {
+                startTracking()
+            } else {
+                stopTracking()
+            }
         }
     }
 
     private fun startTracking() {
         if (trackingJob?.isActive == true) return
 
-        lastCheckTime = System.currentTimeMillis()
-
         trackingJob =
             scope.launch {
                 while (isActive) {
-                    delay(checkInterval)
+                    delay(CHECK_INTERVAL_MS)
 
-                    val now = System.currentTimeMillis()
-                    val actualElapsed = now - lastCheckTime
-                    lastCheckTime = now
+                    currentState?.let { state ->
+                        state.accumulatedMs += CHECK_INTERVAL_MS
 
-                    accumulatedMs += actualElapsed
-
-                    if (accumulatedMs >= targetMs) {
-                        sendViewHistory()
-                        stopTracking()
-                        break
+                        if (state.accumulatedMs >= TARGET_DURATION_MS) {
+                            sendViewHistory(state)
+                            stopTracking()
+                        }
                     }
                 }
             }
@@ -94,26 +85,25 @@ class PlaybackDurationTracker @Inject constructor(
     }
 
     @OptIn(UnstableApi::class)
-    private fun sendViewHistory() {
+    private fun sendViewHistory(state: TrackingState) {
         val hearitId =
             player
                 ?.currentMediaItem
                 ?.requestMetadata
                 ?.extras
-                ?.getLong(EXTRA_HEARIT_ID, -1L) ?: return
+                ?.getLong(EXTRA_HEARIT_ID, -1L)
+                ?.takeIf { it != -1L } ?: return
 
-        isHistorySent = true
+        state.isHistorySent = true
 
-        viewHistoryJob?.cancel()
-        viewHistoryJob =
-            scope.launch {
-                runCatching {
-                    postHearitView(hearitId)
-                }.onFailure { e ->
-                    Timber.d("hearit 조회수 전송에 실패했습니다")
-                    isHistorySent = false
-                }
+        scope.launch {
+            runCatching {
+                postHearitView(hearitId)
+            }.onFailure { e ->
+                Timber.d("hearit 조회수 전송에 실패했습니다")
+                state.isHistorySent = false
             }
+        }
     }
 
     override fun onIsPlayingChanged(isPlaying: Boolean) {
@@ -124,12 +114,14 @@ class PlaybackDurationTracker @Inject constructor(
         mediaItem: MediaItem?,
         reason: Int,
     ) {
-        val newId = mediaItem?.mediaId
-        if (currentMediaId != newId) {
-            currentMediaId = newId
-            accumulatedMs = 0L
-            isHistorySent = false
-            updateTrackingState()
-        }
+        // 곡이 바뀌면 상태를 새 객체로 교체하여 시간과 전송 여부를 초기화
+        currentState = TrackingState(mediaItem?.mediaId)
+        stopTracking()
+        updateTrackingState()
+    }
+
+    companion object {
+        private const val TARGET_DURATION_MS = 15_000L
+        private const val CHECK_INTERVAL_MS = 1_000L
     }
 }

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
@@ -74,6 +74,7 @@ class PlaybackDurationTracker @Inject constructor(
                             sendViewHistory(state) {
                                 stopTracking()
                             }
+                            return@launch
                         }
                     }
                 }

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
@@ -71,8 +71,9 @@ class PlaybackDurationTracker @Inject constructor(
                         state.accumulatedMs += CHECK_INTERVAL_MS
 
                         if (state.accumulatedMs >= TARGET_DURATION_MS) {
-                            sendViewHistory(state)
-                            stopTracking()
+                            sendViewHistory(state) {
+                                stopTracking()
+                            }
                         }
                     }
                 }
@@ -85,7 +86,10 @@ class PlaybackDurationTracker @Inject constructor(
     }
 
     @OptIn(UnstableApi::class)
-    private fun sendViewHistory(state: TrackingState) {
+    private fun sendViewHistory(
+        state: TrackingState,
+        onSuccess: () -> Unit,
+    ) {
         val hearitId =
             player
                 ?.currentMediaItem
@@ -94,13 +98,16 @@ class PlaybackDurationTracker @Inject constructor(
                 ?.getLong(EXTRA_HEARIT_ID, -1L)
                 ?.takeIf { it != -1L } ?: return
 
+        // 전송 시작 시 true로 설정하여 중복 전송 방지
         state.isHistorySent = true
 
         scope.launch {
             runCatching {
                 postHearitView(hearitId)
+            }.onSuccess {
+                onSuccess()
             }.onFailure { e ->
-                Timber.d("hearit 조회수 전송에 실패했습니다")
+                Timber.d("hearit 조회수 전송 실패: ${e.message}")
                 state.isHistorySent = false
             }
         }

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
@@ -4,6 +4,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import com.onair.hearit.di.ElapsedRealtime
 import com.onair.hearit.di.ServiceCoroutineScope
 import com.onair.hearit.domain.usecase.PostHearitViewUseCase
 import com.onair.hearit.service.PlaybackMediaItemManager.Companion.EXTRA_HEARIT_ID
@@ -19,6 +20,7 @@ import javax.inject.Inject
 @ServiceScoped
 class PlaybackDurationTracker @Inject constructor(
     private val postHearitView: PostHearitViewUseCase,
+    @ElapsedRealtime private val elapsedRealtime: () -> Long,
     @ServiceCoroutineScope private val scope: CoroutineScope,
 ) : Player.Listener {
     private var player: Player? = null
@@ -64,16 +66,22 @@ class PlaybackDurationTracker @Inject constructor(
 
         trackingJob =
             scope.launch {
+                var lastTickTime = elapsedRealtime()
+
                 while (isActive) {
                     delay(CHECK_INTERVAL_MS)
 
+                    val currentTickTime = elapsedRealtime()
+                    val actualDiff = currentTickTime - lastTickTime
+                    lastTickTime = currentTickTime
+
                     currentState?.let { state ->
-                        state.accumulatedMs += CHECK_INTERVAL_MS
+                        if (player?.isPlaying == true) {
+                            state.accumulatedMs += actualDiff
+                        }
 
                         if (state.accumulatedMs >= TARGET_DURATION_MS) {
-                            sendViewHistory(state) {
-                                stopTracking()
-                            }
+                            sendViewHistory(state) { stopTracking() }
                             return@launch
                         }
                     }

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackDurationTracker.kt
@@ -1,0 +1,135 @@
+package com.onair.hearit.service
+
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import com.onair.hearit.di.ServiceCoroutineScope
+import com.onair.hearit.domain.usecase.PostHearitViewUseCase
+import com.onair.hearit.service.PlaybackMediaItemManager.Companion.EXTRA_HEARIT_ID
+import dagger.hilt.android.scopes.ServiceScoped
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@ServiceScoped
+class PlaybackDurationTracker @Inject constructor(
+    private val postHearitView: PostHearitViewUseCase,
+    @ServiceCoroutineScope private val scope: CoroutineScope,
+) : Player.Listener {
+    private var player: Player? = null
+    private var trackingJob: Job? = null
+    private var viewHistoryJob: Job? = null
+    private var currentMediaId: String? = null
+
+    private var accumulatedMs = 0L
+    private var isHistorySent = false
+    private var lastCheckTime = 0L
+
+    private val targetMs = 15_000L
+    private val checkInterval = 1_000L
+
+    fun attach(player: Player) {
+        this.player = player
+        this.currentMediaId = player.currentMediaItem?.mediaId
+        player.addListener(this)
+        updateTrackingState()
+    }
+
+    fun detach() {
+        stopTracking()
+        viewHistoryJob?.cancel()
+        viewHistoryJob = null
+        player?.removeListener(this)
+        player = null
+        currentMediaId = null
+        accumulatedMs = 0L
+        isHistorySent = false
+    }
+
+    private fun updateTrackingState() {
+        val player = this.player ?: return
+        val isPlaying = player.isPlaying
+        val hasValidMedia = player.currentMediaItem != null
+
+        if (isPlaying && !isHistorySent && hasValidMedia) {
+            startTracking()
+        } else {
+            stopTracking()
+        }
+    }
+
+    private fun startTracking() {
+        if (trackingJob?.isActive == true) return
+
+        lastCheckTime = System.currentTimeMillis()
+
+        trackingJob =
+            scope.launch {
+                while (isActive) {
+                    delay(checkInterval)
+
+                    val now = System.currentTimeMillis()
+                    val actualElapsed = now - lastCheckTime
+                    lastCheckTime = now
+
+                    accumulatedMs += actualElapsed
+
+                    if (accumulatedMs >= targetMs) {
+                        sendViewHistory()
+                        stopTracking()
+                        break
+                    }
+                }
+            }
+    }
+
+    private fun stopTracking() {
+        trackingJob?.cancel()
+        trackingJob = null
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun sendViewHistory() {
+        val hearitId =
+            player
+                ?.currentMediaItem
+                ?.requestMetadata
+                ?.extras
+                ?.getLong(EXTRA_HEARIT_ID, -1L) ?: return
+
+        isHistorySent = true
+
+        viewHistoryJob?.cancel()
+        viewHistoryJob =
+            scope.launch {
+                runCatching {
+                    postHearitView(hearitId)
+                }.onFailure { e ->
+                    Timber.d("hearit 조회수 전송에 실패했습니다")
+                    isHistorySent = false
+                }
+            }
+    }
+
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        updateTrackingState()
+    }
+
+    override fun onMediaItemTransition(
+        mediaItem: MediaItem?,
+        reason: Int,
+    ) {
+        val newId = mediaItem?.mediaId
+        if (currentMediaId != newId) {
+            currentMediaId = newId
+            accumulatedMs = 0L
+            isHistorySent = false
+            updateTrackingState()
+        }
+    }
+}

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackMediaItemManager.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackMediaItemManager.kt
@@ -25,15 +25,24 @@ class PlaybackMediaItemManager @Inject constructor(
     ): MediaItem {
         val extras =
             createExtras(
+                hearitId = info.hearitId,
                 bookmarkId = bookmarkId,
                 playbackMode = playbackMode,
                 lastPosition = info.lastPosition,
             )
+
+        val requestMetadata =
+            MediaItem.RequestMetadata
+                .Builder()
+                .setExtras(extras) // 여기에 extras 주입
+                .build()
+
         return MediaItem
             .Builder()
             .setUri(info.audioUrl.toUri())
             .setMediaId(info.hearitId.toString())
             .setMediaMetadata(createMediaMetadata(info, extras))
+            .setRequestMetadata(requestMetadata)
             .setTag(playbackMode)
             .build()
     }
@@ -83,11 +92,13 @@ class PlaybackMediaItemManager @Inject constructor(
     }
 
     private fun createExtras(
+        hearitId: Long?,
         bookmarkId: Long?,
         playbackMode: String?,
         lastPosition: Long?,
     ): Bundle =
         Bundle().apply {
+            hearitId?.let { putLong(EXTRA_HEARIT_ID, it) }
             bookmarkId?.let { putLong(EXTRA_BOOKMARK_ID, it) }
             playbackMode?.let { putString(EXTRA_PLAYBACK_MODE, it) }
             lastPosition?.let { putLong(EXTRA_LAST_POSITION_MS, it) }
@@ -105,6 +116,7 @@ class PlaybackMediaItemManager @Inject constructor(
             .build()
 
     companion object {
+        const val EXTRA_HEARIT_ID = "HEARIT_ID"
         const val EXTRA_PLAYBACK_MODE = "PLAYBACK_MODE"
         const val EXTRA_BOOKMARK_ID = "BOOKMARK_ID"
         const val EXTRA_LAST_POSITION_MS = "LAST_POSITION_MS"

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackMediaItemManager.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackMediaItemManager.kt
@@ -34,7 +34,7 @@ class PlaybackMediaItemManager @Inject constructor(
         val requestMetadata =
             MediaItem.RequestMetadata
                 .Builder()
-                .setExtras(extras) // 여기에 extras 주입
+                .setExtras(extras)
                 .build()
 
         return MediaItem

--- a/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
+++ b/android/app/src/main/java/com/onair/hearit/service/PlaybackService.kt
@@ -48,11 +48,21 @@ class PlaybackService : MediaSessionService() {
     @Inject
     lateinit var sessionCallback: PlaybackSessionCallback
 
+    @Inject
+    lateinit var durationTracker: PlaybackDurationTracker
+
     private lateinit var playbackPositionListener: PlaybackPositionListener
 
     private lateinit var mediaSession: MediaSession
 
     private var notificationController: PlayerNotificationController? = null
+
+    private val errorListener =
+        object : Player.Listener {
+            override fun onPlayerError(error: PlaybackException) {
+                player.pause()
+            }
+        }
 
     override fun onCreate() {
         super.onCreate()
@@ -65,9 +75,10 @@ class PlaybackService : MediaSessionService() {
         playbackPositionListener.attach()
         sessionCallback.setPlaybackPositionListener(playbackPositionListener)
 
+        durationTracker.attach(player)
+
         initializeMediaSession()
 
-        // 2) 알림 + 포그라운드 제어는 컨트롤러에 위임
         notificationController =
             PlayerNotificationController(
                 service = this,
@@ -76,13 +87,7 @@ class PlaybackService : MediaSessionService() {
                 notificationId = NOTIFICATION_ID,
             ).also { it.attach(player) }
 
-        player.addListener(
-            object : Player.Listener {
-                override fun onPlayerError(error: PlaybackException) {
-                    player.pause()
-                }
-            },
-        )
+        player.addListener(errorListener)
     }
 
     override fun onStartCommand(
@@ -140,11 +145,13 @@ class PlaybackService : MediaSessionService() {
 
     override fun onDestroy() {
         super.onDestroy()
+        player.removeListener(errorListener)
+        player.removeListener(stateSaver.listener)
         notificationController?.detach()
+        playbackPositionListener.detach()
+        durationTracker.detach()
         stateSaver.release()
         mediaSession.release()
-        player.removeListener(stateSaver.listener)
-        playbackPositionListener.detach()
         player.release()
     }
 


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- 15초 이상 히어릿을 들은 경우에 조회수를 서버로 전송할 수 있도록 함
- isHistorySent를 한번 하고 나면 A->B->A인 경우에는 다시 전송할 수 있습니다

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

<img width="1341" height="576" alt="image" src="https://github.com/user-attachments/assets/e3dc42ea-e6ae-4bbf-85cd-2e284dd82b6f" />
-> 오디오를 불러오고나서, 15초 후에 view가 찍히는 것 확인 가능합니다.

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
Resolve #816 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 재생이 15초 이상 지속되면 자동으로 조회 이력이 서버로 전송됩니다.
  * 재생 중 미디어 전환 및 재생 상태 변화를 감지해 조회 추적을 관리합니다.
  * 재생 항목에 식별자(hearitId)를 포함해 조회 전송에 사용합니다.
  * 플레이어 오류 발생 시 자동으로 재생을 일시 중지하고 안정적으로 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->