### PR TITLE
[BE] fix: Swagger YAML에 JWT 인증 보안 스키마 자동 추가 #825

### DIFF
--- a/backend/app/build.gradle
+++ b/backend/app/build.gradle
@@ -104,8 +104,42 @@ openapi3 {
     format = "yaml"
 }
 
-tasks.withType(org.hidetake.gradle.swagger.generator.GenerateSwaggerUI).configureEach {
+tasks.register('injectSecurityScheme') {
     dependsOn 'openapi3'
+    doLast {
+        def yamlFile = file("${project.buildDir}/api-spec/openapi3.yaml")
+        if (!yamlFile.exists()) return
+
+        def content = yamlFile.getText('UTF-8')
+
+        // components: 아래에 securitySchemes 추가
+        def securitySchemes = '''\
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: "JWT 인증 토큰 (형식: Bearer {token})"'''
+
+        content = content.replaceFirst(
+                /(?m)^components:\n\s+schemas:/,
+                "components:\n${securitySchemes}\n  schemas:"
+        )
+
+        // 최상위에 글로벌 security 추가 (servers 블록 바로 뒤)
+        if (!content.contains('\nsecurity:')) {
+            content = content.replaceFirst(
+                    /(?m)^tags:/,
+                    "security:\n- BearerAuth: []\ntags:"
+            )
+        }
+
+        yamlFile.write(content, 'UTF-8')
+    }
+}
+
+tasks.withType(org.hidetake.gradle.swagger.generator.GenerateSwaggerUI).configureEach {
+    dependsOn 'injectSecurityScheme'
 }
 
 


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
  - Swagger UI에서 JWT 인증 헤더를 설정할 수 있도록 `injectSecurityScheme` Gradle 태스크를 추가했습니다.
  - `openapi3.yaml` 생성 후 `securitySchemes`(Bearer JWT)와 글로벌 `security` 설정을 자동 주입합니다.

  `app/build.gradle`에 `injectSecurityScheme` 태스크를 등록하고, 기존 빌드 파이프라인에 연결했습니다.

  **빌드 파이프라인 변경:**
  [기존] openapi3 → generateSwaggerUI
  [변경] openapi3 → injectSecurityScheme → generateSwaggerUI

## 📸 스크린샷 (선택)
> UI 변경이 있을 경우 첨부

## 🧪 테스트 방법 (선택)
<!-- 코드 리뷰하는 팀원이 돌려볼 수 있도록 작성해주기 
ex. ReservationTest의 XXXX 테스트메서드로 확인 
ex. 어떤화면의 어떤기능에서 확인 -->
 - ./gradlew :boot:bootJar 후 로컬 실행 시 Swagger UI에 Authorize 버튼 표시 확인
## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
close #825 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* API 명세서에 Bearer 토큰 인증 정보가 자동으로 포함되도록 개선되었습니다.

## 개선 사항
* API 문서 생성 시 보안 인증 설정이 올바르게 적용되어, 개발자가 API 사용 시 필요한 인증 방식을 명확하게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->