### PR TITLE
[BE] test: 시간 의존적인 테스트 안정화 - PlayingHistory, Bookmark

### DIFF
--- a/backend/app/src/test/java/com/onair/hearit/app/fixture/DbHelper.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/fixture/DbHelper.java
@@ -58,6 +58,15 @@ public class DbHelper {
         return bookmark;
     }
 
+    public Bookmark insertBookmarkAt(Bookmark bookmark, LocalDateTime creationTime) {
+        try {
+            TestClock.freezeAt(creationTime);
+            return insertBookmark(bookmark);
+        } finally {
+            TestClock.unfreeze();
+        }
+    }
+
     public Keyword insertKeyword(Keyword keyword) {
         em.persist(keyword);
         em.flush();

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/presentation/PlayingHistoryIntegrationTest.java
@@ -16,6 +16,7 @@ import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import io.restassured.RestAssured;
 import io.restassured.common.mapper.TypeRef;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.assertj.core.api.SoftAssertions;
@@ -48,9 +49,11 @@ class PlayingHistoryIntegrationTest extends IntegrationTest {
             String token = generateToken(member);
             Category category = dbHelper.insertCategory(new Category("name", "#000000"));
 
+            LocalDateTime baseTime = LocalDateTime.of(2026, 1, 1, 0, 0);
             for (int i = 0; i < 12; i++) {
                 Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-                dbHelper.insertPlayingHistory(new PlayingHistory(member.getUuid(), hearit, 10L * i));
+                dbHelper.insertPlayingHistoryAt(new PlayingHistory(member.getUuid(), hearit, 10L * i),
+                        baseTime.plusMinutes(i));
             }
 
             // when & then
@@ -83,9 +86,11 @@ class PlayingHistoryIntegrationTest extends IntegrationTest {
             String guestUuid = UUID.randomUUID().toString();
             Category category = dbHelper.insertCategory(new Category("name", "#000000"));
 
+            LocalDateTime baseTime = LocalDateTime.of(2026, 1, 1, 0, 0);
             for (int i = 0; i < 12; i++) {
                 Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
-                dbHelper.insertPlayingHistory(new PlayingHistory(UUID.fromString(guestUuid), hearit, 10L * i));
+                dbHelper.insertPlayingHistoryAt(new PlayingHistory(UUID.fromString(guestUuid), hearit, 10L * i),
+                        baseTime.plusMinutes(i));
             }
 
             // when & then

--- a/backend/core/src/test/java/com/onair/hearit/core/fixture/DbHelper.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/fixture/DbHelper.java
@@ -57,6 +57,15 @@ public class DbHelper {
         return bookmark;
     }
 
+    public Bookmark insertBookmarkAt(Bookmark bookmark, LocalDateTime creationTime) {
+        try {
+            TestClock.freezeAt(creationTime);
+            return insertBookmark(bookmark);
+        } finally {
+            TestClock.unfreeze();
+        }
+    }
+
     public Keyword insertKeyword(Keyword keyword) {
         em.persist(keyword);
         em.flush();

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/BookmarkRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/BookmarkRepositoryTest.java
@@ -50,7 +50,7 @@ class BookmarkRepositoryTest {
         LocalDateTime baseTime = LocalDateTime.of(2026, 1, 1, 0, 0);
         Bookmark oldestBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit1),
                 baseTime);
-        Bookmark mideumBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit2),
+        Bookmark mediumBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit2),
                 baseTime.plusMinutes(1));
         Bookmark newestBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit3),
                 baseTime.plusMinutes(2));
@@ -65,7 +65,7 @@ class BookmarkRepositoryTest {
         // then
         assertAll(() -> {
             assertThat(bookmarks.getContent().get(0).getBookmark().getId()).isEqualTo(newestBookmark.getId());
-            assertThat(bookmarks.getContent().get(1).getBookmark().getId()).isEqualTo(mideumBookmark.getId());
+            assertThat(bookmarks.getContent().get(1).getBookmark().getId()).isEqualTo(mediumBookmark.getId());
             assertThat(bookmarks.getContent().get(2).getBookmark().getId()).isEqualTo(oldestBookmark.getId());
         });
     }
@@ -83,7 +83,7 @@ class BookmarkRepositoryTest {
         LocalDateTime baseTime = LocalDateTime.of(2026, 1, 1, 0, 0);
         Bookmark oldestBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit1),
                 baseTime);
-        Bookmark mideumBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit2),
+        Bookmark mediumBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit2),
                 baseTime.plusMinutes(1));
         Bookmark newestBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit3),
                 baseTime.plusMinutes(2));
@@ -98,7 +98,7 @@ class BookmarkRepositoryTest {
         // then
         assertAll(() -> {
             assertThat(bookmarks.getContent().get(2).getBookmark().getId()).isEqualTo(newestBookmark.getId());
-            assertThat(bookmarks.getContent().get(1).getBookmark().getId()).isEqualTo(mideumBookmark.getId());
+            assertThat(bookmarks.getContent().get(1).getBookmark().getId()).isEqualTo(mediumBookmark.getId());
             assertThat(bookmarks.getContent().get(0).getBookmark().getId()).isEqualTo(oldestBookmark.getId());
         });
     }

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/BookmarkRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/jpa/BookmarkRepositoryTest.java
@@ -13,6 +13,7 @@ import com.onair.hearit.core.fixture.TestFixture;
 import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
 import com.onair.hearit.core.infrastructure.projection.BookmarkWithPlayingHistoryProjection;
 import com.onair.hearit.core.infrastructure.projection.CategoryBookmarkCount;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,9 +47,13 @@ class BookmarkRepositoryTest {
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-        Bookmark oldestBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit1));
-        Bookmark mideumBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit2));
-        Bookmark newestBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit3));
+        LocalDateTime baseTime = LocalDateTime.of(2026, 1, 1, 0, 0);
+        Bookmark oldestBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit1),
+                baseTime);
+        Bookmark mideumBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit2),
+                baseTime.plusMinutes(1));
+        Bookmark newestBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit3),
+                baseTime.plusMinutes(2));
 
         Sort createdAt = Sort.by(Direction.DESC, "createdAt");
         // when
@@ -75,9 +80,13 @@ class BookmarkRepositoryTest {
         Hearit hearit2 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
         Hearit hearit3 = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
 
-        Bookmark oldestBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit1));
-        Bookmark mideumBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit2));
-        Bookmark newestBookmark = dbHelper.insertBookmark(TestFixture.createFixedBookmark(member, hearit3));
+        LocalDateTime baseTime = LocalDateTime.of(2026, 1, 1, 0, 0);
+        Bookmark oldestBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit1),
+                baseTime);
+        Bookmark mideumBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit2),
+                baseTime.plusMinutes(1));
+        Bookmark newestBookmark = dbHelper.insertBookmarkAt(TestFixture.createFixedBookmark(member, hearit3),
+                baseTime.plusMinutes(2));
 
         Sort createdAt = Sort.by(Direction.ASC, "createdAt");
         // when


### PR DESCRIPTION
## 📌 변경 내용 & 이유

**문제 상황**
- 테스트 실행 환경이 느린 경우, 엔티티를 순차적으로 생성할 때 `createdAt` 필드의 밀리초 차이로 인해 순서가 예상과 달라져 테스트가 실패할 수 있음
- `@CreatedDate`를 사용하는 엔티티들이 시간순으로 정렬되는 테스트에서 불안정한 결과 발생 가능

 **변경 내용**
1. **DbHelper에 시간 제어 메서드 추가**
   - `insertBookmarkAt(Bookmark, LocalDateTime)` 메서드 추가 (app, core 모듈)
   - TestClock을 활용하여 특정 시점에 엔티티 생성 가능
2. **PlayingHistoryIntegrationTest 수정**
   - 12개의 PlayingHistory를 순차 생성 시 `insertPlayingHistoryAt()` 사용
   - 고정된 baseTime(`2026-01-01 00:00`)부터 1분씩 증가시켜 명확한 순서 보장
3. **BookmarkRepositoryTest 수정**
   - `findAllByMemberOrderByRecentTest()`: 최신순 정렬 테스트
   - `findAllByMemberOrderByOldestTest()`: 오래된순 정렬 테스트
   - 고정된 baseTime부터 1분씩 증가시켜 생성 순서 보장
  
 **기대 효과**
- CI/CD 환경, 느린 테스트 환경에서도 테스트 결과가 일관되게 유지됨
- 테스트 실패로 인한 불필요한 재실행 감소
##  🧪 테스트 방법
**수정된 테스트 실행**
`./gradlew :core:test --tests BookmarkRepositoryTest`
`./gradlew :app:test --tests PlayingHistoryIntegrationTest`
**전체 테스트로 검증**
`./gradlew test`

## 📢 논의하고 싶은 내용
- 앞으로 시간순으로 머 확인하고싶으면 TestFixture쓰기~

## 🧩 관련 이슈
close #835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 유틸리티에 특정 생성 시점을 지정해 데이터 삽입할 수 있는 기능 추가(북마크·재생기록).  
  * 타임스탬프 기반 데이터 시드로 시간 순서 검증의 결정론성 및 테스트 신뢰성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->