### PR TITLE
[BE] test: RedisContainer를 사용하는 DataJpaTest 환경 통합 #840

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/config/RedissonConfig.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/config/RedissonConfig.java
@@ -6,6 +6,7 @@ import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.util.StringUtils;
 
 @Configuration
@@ -35,6 +36,7 @@ public class RedissonConfig {
     private static final String REDIS_URL_PREFIX = "redis://";
 
     @Bean
+    @Lazy
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()

--- a/backend/app/src/test/java/com/onair/hearit/app/fixture/RedisContainerTestSupport.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/fixture/RedisContainerTestSupport.java
@@ -61,7 +61,7 @@ import org.testcontainers.utility.DockerImageName;
         TestCircuitBreakerConfig.class,
         CircuitBreakerConfig.class
 })
-public abstract class RedisIntegrationTestSupport {
+public abstract class RedisContainerTestSupport {
 
     @Container
     protected static final GenericContainer<?> REDIS_CONTAINER =

--- a/backend/app/src/test/java/com/onair/hearit/app/fixture/RedisIntegrationTestSupport.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/fixture/RedisIntegrationTestSupport.java
@@ -70,6 +70,7 @@ public abstract class RedisIntegrationTestSupport {
 
     protected static RedisTemplate<String, String> redisTemplate;
     protected static RedissonClient redissonClient;
+    private static LettuceConnectionFactory connectionFactory;
 
     /**
      * Redis 객체 초기화
@@ -83,7 +84,7 @@ public abstract class RedisIntegrationTestSupport {
         config.setHostName(REDIS_CONTAINER.getHost());
         config.setPort(REDIS_CONTAINER.getFirstMappedPort());
 
-        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(config);
+        connectionFactory = new LettuceConnectionFactory(config);
         connectionFactory.afterPropertiesSet();
 
         redisTemplate = new RedisTemplate<>();
@@ -116,6 +117,9 @@ public abstract class RedisIntegrationTestSupport {
     static void cleanupRedis() {
         if (redissonClient != null && !redissonClient.isShutdown()) {
             redissonClient.shutdown();
+        }
+        if (connectionFactory != null) {
+            connectionFactory.destroy();
         }
     }
 

--- a/backend/app/src/test/java/com/onair/hearit/app/fixture/RedisIntegrationTestSupport.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/fixture/RedisIntegrationTestSupport.java
@@ -66,8 +66,7 @@ public abstract class RedisIntegrationTestSupport {
     @Container
     protected static final GenericContainer<?> REDIS_CONTAINER =
             new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine"))
-                    .withExposedPorts(6379)
-                    .withReuse(true);
+                    .withExposedPorts(6379);
 
     protected static RedisTemplate<String, String> redisTemplate;
     protected static RedissonClient redissonClient;

--- a/backend/app/src/test/java/com/onair/hearit/app/fixture/RedisIntegrationTestSupport.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/fixture/RedisIntegrationTestSupport.java
@@ -1,0 +1,164 @@
+package com.onair.hearit.app.fixture;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.onair.hearit.app.playinghistory.infrastructure.buffer.PlayingHistoryMapBuffer;
+import com.onair.hearit.app.playinghistory.infrastructure.buffer.TestCircuitBreakerConfig;
+import com.onair.hearit.app.playinghistory.infrastructure.buffer.config.CircuitBreakerConfig;
+import com.onair.hearit.app.playinghistory.infrastructure.converter.PlayingHistoryConverter;
+import com.onair.hearit.core.config.DataSourceConfig;
+import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
+import com.onair.hearit.core.infrastructure.jdbc.PlayingHistoryCommandRepository;
+import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
+import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Redis + DB 통합 테스트를 위한 DataJpaTest 기반 공통 클래스
+ *
+ * <p>주요 특징:
+ * <ul>
+ *   <li>@DataJpaTest: 필요한 Bean만 로딩, 빠른 초기화</li>
+ *   <li>Singleton Redis 컨테이너: @Container로 JUnit이 lifecycle 관리</li>
+ *   <li>Static Redis 객체: @BeforeAll에서 초기화, @AfterAll에서 정리</li>
+ *   <li>@Sql 기반 DB 초기화: 각 테스트 메서드마다 dbclean.sql 실행</li>
+ *   <li>컨텍스트 재사용: 모든 테스트가 동일한 @Import로 단일 컨텍스트 공유</li>
+ *   <li>안전한 Redis flush: @BeforeEach에서 execute() 방식 사용</li>
+ * </ul>
+ */
+@DataJpaTest
+@Sql("/dbclean.sql")
+@ActiveProfiles("integration-test")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Testcontainers
+@Import({
+        DbHelper.class,
+        TestJpaAuditingConfig.class,
+        DataSourceConfig.class,
+        PlayingHistoryCommandRepository.class,
+        PlayingHistoryConverter.class,
+        PlayingHistoryMapBuffer.class,
+        TestCircuitBreakerConfig.class,
+        CircuitBreakerConfig.class
+})
+public abstract class RedisIntegrationTestSupport {
+
+    @Container
+    protected static final GenericContainer<?> REDIS_CONTAINER =
+            new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine"))
+                    .withExposedPorts(6379)
+                    .withReuse(true);
+
+    protected static RedisTemplate<String, String> redisTemplate;
+    protected static RedissonClient redissonClient;
+
+    /**
+     * Redis 객체 초기화
+     * - @Container가 컨테이너를 시작한 후 실행됨 (JUnit이 보장)
+     * - static 초기화로 모든 테스트가 동일한 인스턴스 공유
+     */
+    @BeforeAll
+    static void initializeRedis() {
+        // RedisTemplate 설정
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(REDIS_CONTAINER.getHost());
+        config.setPort(REDIS_CONTAINER.getFirstMappedPort());
+
+        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(config);
+        connectionFactory.afterPropertiesSet();
+
+        redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        redisTemplate.setKeySerializer(serializer);
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashKeySerializer(serializer);
+        redisTemplate.setHashValueSerializer(serializer);
+        redisTemplate.afterPropertiesSet();
+
+        // Redisson 설정 (테스트 환경 최적화: pool 10→2, idle 1→0)
+        Config redissonConfig = new Config();
+        redissonConfig.useSingleServer()
+                .setAddress("redis://" + REDIS_CONTAINER.getHost() + ":" + REDIS_CONTAINER.getFirstMappedPort())
+                .setConnectionPoolSize(2)           // 테스트용 축소
+                .setConnectionMinimumIdleSize(0)    // 테스트용 축소
+                .setConnectTimeout(3000)
+                .setTimeout(500)
+                .setRetryAttempts(1)
+                .setRetryInterval(100);
+        redissonClient = Redisson.create(redissonConfig);
+    }
+
+    /**
+     * Redis 리소스 정리
+     * - Redisson shutdown으로 커넥션 정리
+     */
+    @AfterAll
+    static void cleanupRedis() {
+        if (redissonClient != null && !redissonClient.isShutdown()) {
+            redissonClient.shutdown();
+        }
+    }
+
+    // ========================================
+    // 공통 Autowired Bean들
+    // ========================================
+
+    @Autowired
+    protected DbHelper dbHelper;
+
+    @Autowired
+    protected HearitRepository hearitRepository;
+
+    @Autowired
+    protected PlayingHistoryRepository playingHistoryRepository;
+
+    @Autowired
+    protected PlayingHistoryCommandRepository commandRepository;
+
+    @Autowired
+    protected PlayingHistoryConverter converter;
+
+    @Autowired
+    protected PlayingHistoryMapBuffer mapBuffer;
+
+    @Autowired
+    protected CircuitBreakerRegistry circuitBreakerRegistry;
+
+    /** ObjectMapper (RedisBuffer 생성용) */
+    protected final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 각 테스트 실행 전 Redis 데이터 초기화
+     * - DB는 @Sql이 자동 정리
+     * - Redis는 수동으로 flushAll 필요
+     * - execute() 방식으로 connection을 안전하게 관리
+     */
+    @BeforeEach
+    protected void clearRedis() {
+        redisTemplate.execute((org.springframework.data.redis.core.RedisCallback<Void>) connection -> {
+            connection.serverCommands().flushAll();
+            return null;
+        });
+    }
+}

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryBufferFacadeTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryBufferFacadeTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onair.hearit.app.exception.custom.RedisBufferException;
-import com.onair.hearit.app.fixture.RedisIntegrationTestSupport;
+import com.onair.hearit.app.fixture.RedisContainerTestSupport;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.Member;
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class PlayingHistoryBufferFacadeTest extends RedisIntegrationTestSupport {
+class PlayingHistoryBufferFacadeTest extends RedisContainerTestSupport {
 
     private PlayingHistoryRedisBuffer redisBuffer;
     private PlayingHistoryRedisBufferWithCircuitBreaker circuitWrappedRedisBuffer;

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryBufferFacadeTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryBufferFacadeTest.java
@@ -9,142 +9,32 @@ import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onair.hearit.app.exception.custom.RedisBufferException;
-import com.onair.hearit.app.fixture.DbHelper;
-import com.onair.hearit.app.playinghistory.infrastructure.buffer.config.CircuitBreakerConfig;
-import com.onair.hearit.app.playinghistory.infrastructure.converter.PlayingHistoryConverter;
-import com.onair.hearit.core.config.DataSourceConfig;
+import com.onair.hearit.app.fixture.RedisIntegrationTestSupport;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.Member;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
-import com.onair.hearit.core.infrastructure.jdbc.PlayingHistoryCommandRepository;
-import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
-import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.redisson.Redisson;
-import org.redisson.api.RedissonClient;
-import org.redisson.config.Config;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.utility.DockerImageName;
 
-@DataJpaTest
-@Sql("/dbclean.sql")
-@ActiveProfiles("integration-test")
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({
-        DbHelper.class,
-        TestJpaAuditingConfig.class,
-        DataSourceConfig.class,
-        PlayingHistoryCommandRepository.class,
-        PlayingHistoryConverter.class,
-        PlayingHistoryMapBuffer.class,
-        TestCircuitBreakerConfig.class,
-        CircuitBreakerConfig.class
-})
-class PlayingHistoryBufferFacadeTest {
+class PlayingHistoryBufferFacadeTest extends RedisIntegrationTestSupport {
 
-    static GenericContainer<?> redisContainer;
-    static RedisTemplate<String, String> redisTemplate;
-    static RedissonClient redissonClient;
-
-    @Autowired
-    DbHelper dbHelper;
-
-    @Autowired
-    HearitRepository hearitRepository;
-
-    @Autowired
-    PlayingHistoryRepository playingHistoryRepository;
-
-    @Autowired
-    PlayingHistoryCommandRepository commandRepository;
-
-    @Autowired
-    PlayingHistoryConverter converter;
-
-    @Autowired
-    CircuitBreakerRegistry circuitBreakerRegistry;
-
-    @Autowired
-    PlayingHistoryMapBuffer mapBuffer;
-
-    PlayingHistoryRedisBuffer redisBuffer;
-    PlayingHistoryRedisBufferWithCircuitBreaker circuitWrappedRedisBuffer;
-    PlayingHistoryBufferFacade facade;
-    CircuitBreaker circuitBreaker;
-
-    @BeforeAll
-    static void startRedis() {
-        redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine"))
-                .withExposedPorts(6379);
-        redisContainer.start();
-
-        // RedisTemplate 설정
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(redisContainer.getHost());
-        config.setPort(redisContainer.getFirstMappedPort());
-
-        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(config);
-        connectionFactory.afterPropertiesSet();
-
-        redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(connectionFactory);
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
-        redisTemplate.afterPropertiesSet();
-
-        // Redisson 설정
-        Config redissonConfig = new Config();
-        redissonConfig.useSingleServer()
-                .setAddress("redis://" + redisContainer.getHost() + ":" + redisContainer.getFirstMappedPort());
-        redissonClient = Redisson.create(redissonConfig);
-    }
-
-    @AfterAll
-    static void stopRedis() {
-        if (redissonClient != null) {
-            redissonClient.shutdown();
-        }
-        if (redisTemplate != null) {
-            redisTemplate.getConnectionFactory().getConnection().close();
-        }
-        if (redisContainer != null) {
-            redisContainer.stop();
-        }
-    }
+    private PlayingHistoryRedisBuffer redisBuffer;
+    private PlayingHistoryRedisBufferWithCircuitBreaker circuitWrappedRedisBuffer;
+    private PlayingHistoryBufferFacade testFacade;
+    private CircuitBreaker circuitBreaker;
 
     @BeforeEach
     void setup() {
-        // Redis 초기화
-        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
-
         mapBuffer.clear();
 
         circuitBreaker = circuitBreakerRegistry.circuitBreaker("redisBuffer");
-        circuitBreaker.reset(); // CLOSED 상태로 초기화
+        circuitBreaker.reset();
 
         redisBuffer = new PlayingHistoryRedisBuffer(
                 redisTemplate,
@@ -156,15 +46,12 @@ class PlayingHistoryBufferFacadeTest {
                 3000L   // lockLeaseTime
         );
         circuitWrappedRedisBuffer = new PlayingHistoryRedisBufferWithCircuitBreaker(redisBuffer, circuitBreaker);
-        facade = new PlayingHistoryBufferFacade(circuitWrappedRedisBuffer, mapBuffer);
+        testFacade = new PlayingHistoryBufferFacade(circuitWrappedRedisBuffer, mapBuffer);
     }
 
     @AfterEach
-    void ensureRedisRunning() throws InterruptedException {
-        if (!redisContainer.isRunning()) {
-            redisContainer.start();
-            waitForRedis();
-        }
+    void cleanupAfterTest() {
+        mapBuffer.clear();
     }
 
     private void waitForRedis() throws InterruptedException {
@@ -193,7 +80,7 @@ class PlayingHistoryBufferFacadeTest {
             assertThat(circuitBreaker.getState()).isEqualTo(CircuitBreaker.State.CLOSED);
 
             // when
-            facade.add(history, 1000L);
+            testFacade.add(history, 1000L);
 
             // then
             assertAll(
@@ -219,7 +106,7 @@ class PlayingHistoryBufferFacadeTest {
                 Hearit hearit = dbHelper.insertHearit(
                         TestFixture.createFixedHearitWith(category)
                 );
-                facade.add(
+                testFacade.add(
                         new PlayingHistory(member.getUuid(), hearit, 1000L + i),
                         1000L + i
                 );
@@ -251,7 +138,7 @@ class PlayingHistoryBufferFacadeTest {
             circuitBreaker.transitionToOpenState();
 
             // when
-            facade.add(history, 1000L);
+            testFacade.add(history, 1000L);
 
             // then
             assertAll(
@@ -276,7 +163,7 @@ class PlayingHistoryBufferFacadeTest {
                 Hearit hearit = dbHelper.insertHearit(
                         TestFixture.createFixedHearitWith(category)
                 );
-                facade.add(
+                testFacade.add(
                         new PlayingHistory(member.getUuid(), hearit, 1000L + i),
                         1000L + i
                 );

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryBufferFacadeTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryBufferFacadeTest.java
@@ -54,17 +54,6 @@ class PlayingHistoryBufferFacadeTest extends RedisIntegrationTestSupport {
         mapBuffer.clear();
     }
 
-    private void waitForRedis() throws InterruptedException {
-        for (int i = 0; i < 10; i++) {
-            try {
-                redisTemplate.getConnectionFactory().getConnection().ping();
-                break;
-            } catch (Exception e) {
-                Thread.sleep(300);
-            }
-        }
-    }
-
     @Nested
     @DisplayName("정상 상태 동작 (CLOSED)")
     class NormalOperation {

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryMapBufferTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryMapBufferTest.java
@@ -6,19 +6,49 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
-import com.onair.hearit.app.fixture.RedisIntegrationTestSupport;
+import com.onair.hearit.app.fixture.DbHelper;
+import com.onair.hearit.app.playinghistory.infrastructure.converter.PlayingHistoryConverter;
+import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.Member;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.fixture.TestFixture;
+import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
+import com.onair.hearit.core.infrastructure.jdbc.PlayingHistoryCommandRepository;
+import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 
-class PlayingHistoryMapBufferTest extends RedisIntegrationTestSupport {
+@DataJpaTest
+@Sql("/dbclean.sql")
+@ActiveProfiles("integration-test")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class,
+        PlayingHistoryCommandRepository.class, PlayingHistoryConverter.class})
+class PlayingHistoryMapBufferTest {
 
-    private PlayingHistoryMapBuffer buffer;
+    @Autowired
+    DbHelper dbHelper;
+
+    @Autowired
+    PlayingHistoryCommandRepository commandRepository;
+
+    @Autowired
+    PlayingHistoryConverter converter;
+
+    @Autowired
+    PlayingHistoryRepository playingHistoryRepository;
+
+    PlayingHistoryMapBuffer buffer;
 
     @BeforeEach
     void setup() {

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryMapBufferTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryMapBufferTest.java
@@ -6,54 +6,22 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
-import com.onair.hearit.app.fixture.DbHelper;
-import com.onair.hearit.app.playinghistory.infrastructure.converter.PlayingHistoryConverter;
-import com.onair.hearit.core.config.DataSourceConfig;
+import com.onair.hearit.app.fixture.RedisIntegrationTestSupport;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.Member;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
-import com.onair.hearit.core.infrastructure.jdbc.PlayingHistoryCommandRepository;
-import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
-import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
 
-@DataJpaTest
-@Sql("/dbclean.sql")
-@ActiveProfiles("integration-test")
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({DbHelper.class, TestJpaAuditingConfig.class, DataSourceConfig.class, PlayingHistoryCommandRepository.class})
-class PlayingHistoryMapBufferTest {
+class PlayingHistoryMapBufferTest extends RedisIntegrationTestSupport {
 
-    @Autowired
-    DbHelper dbHelper;
-
-    @Autowired
-    PlayingHistoryCommandRepository commandRepository;
-
-    @Autowired
-    HearitRepository hearitRepository;
-
-    @Autowired
-    PlayingHistoryRepository playingHistoryRepository;
-
-    PlayingHistoryMapBuffer buffer;
-    PlayingHistoryConverter converter;
+    private PlayingHistoryMapBuffer buffer;
 
     @BeforeEach
     void setup() {
-        converter = new PlayingHistoryConverter(hearitRepository);
         buffer = new PlayingHistoryMapBuffer(commandRepository, converter);
     }
 
@@ -117,7 +85,7 @@ class PlayingHistoryMapBufferTest {
         buffer.add(history2, 2_000L);
 
         // spy repository로 bulkInsert에서 예외 발생
-        PlayingHistoryCommandRepository spyRepo = spy(commandRepository);
+        var spyRepo = spy(commandRepository);
         doThrow(new RuntimeException("DB error")).when(spyRepo).bulkInsert(anyList());
         PlayingHistoryMapBuffer failingBuffer = new PlayingHistoryMapBuffer(spyRepo, converter);
 

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryRedisBufferTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryRedisBufferTest.java
@@ -3,7 +3,6 @@ package com.onair.hearit.app.playinghistory.infrastructure.buffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.onair.hearit.app.fixture.RedisIntegrationTestSupport;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 class PlayingHistoryRedisBufferTest extends RedisIntegrationTestSupport {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private PlayingHistoryRedisBuffer storage;
 
     @BeforeEach

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryRedisBufferTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryRedisBufferTest.java
@@ -4,120 +4,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.onair.hearit.app.fixture.DbHelper;
-import com.onair.hearit.app.playinghistory.infrastructure.converter.PlayingHistoryConverter;
-import com.onair.hearit.core.config.DataSourceConfig;
+import com.onair.hearit.app.fixture.RedisIntegrationTestSupport;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.PlayingHistory;
 import com.onair.hearit.core.fixture.TestFixture;
-import com.onair.hearit.core.fixture.TestJpaAuditingConfig;
-import com.onair.hearit.core.infrastructure.jdbc.PlayingHistoryCommandRepository;
-import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
-import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
 import java.util.UUID;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.redisson.Redisson;
-import org.redisson.api.RedissonClient;
-import org.redisson.config.Config;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.utility.DockerImageName;
 
-@DataJpaTest
-@Sql("/dbclean.sql")
-@ActiveProfiles("integration-test")
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-@Import({
-        DbHelper.class,
-        TestJpaAuditingConfig.class,
-        DataSourceConfig.class,
-        PlayingHistoryCommandRepository.class,
-        PlayingHistoryConverter.class
-})
-class PlayingHistoryRedisBufferTest {
+class PlayingHistoryRedisBufferTest extends RedisIntegrationTestSupport {
 
-    static GenericContainer<?> redisContainer;
-    static RedisTemplate<String, String> redisTemplate;
-    static RedissonClient redissonClient;
-
-    @Autowired
-    DbHelper dbHelper;
-
-    @Autowired
-    HearitRepository hearitRepository;
-
-    @Autowired
-    PlayingHistoryCommandRepository commandRepository;
-
-    @Autowired
-    PlayingHistoryRepository playingHistoryRepository;
-
-    @Autowired
-    PlayingHistoryConverter converter;
-
-    ObjectMapper objectMapper = new ObjectMapper();
-    PlayingHistoryRedisBuffer storage;
-
-    @BeforeAll
-    static void startRedis() {
-        redisContainer = new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine"))
-                .withExposedPorts(6379);
-        redisContainer.start();
-
-        // RedisTemplate 설정
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(redisContainer.getHost());
-        config.setPort(redisContainer.getFirstMappedPort());
-
-        LettuceConnectionFactory connectionFactory = new LettuceConnectionFactory(config);
-        connectionFactory.afterPropertiesSet();
-
-        redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(connectionFactory);
-        StringRedisSerializer serializer = new StringRedisSerializer();
-        redisTemplate.setKeySerializer(serializer);
-        redisTemplate.setValueSerializer(serializer);
-        redisTemplate.setHashKeySerializer(serializer);
-        redisTemplate.setHashValueSerializer(serializer);
-        redisTemplate.afterPropertiesSet();
-
-        // Redisson 설정
-        Config redissonConfig = new Config();
-        redissonConfig.useSingleServer()
-                .setAddress("redis://" + redisContainer.getHost() + ":" + redisContainer.getFirstMappedPort());
-        redissonClient = Redisson.create(redissonConfig);
-    }
-
-    @AfterAll
-    static void stopRedis() {
-        if (redissonClient != null) {
-            redissonClient.shutdown();
-        }
-        if (redisContainer != null) {
-            redisContainer.stop();
-        }
-    }
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private PlayingHistoryRedisBuffer storage;
 
     @BeforeEach
     void setup() {
-        // Redis 데이터 초기화
-        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
-
         storage = new PlayingHistoryRedisBuffer(
                 redisTemplate,
                 redissonClient,

--- a/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryRedisBufferTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/playinghistory/infrastructure/buffer/PlayingHistoryRedisBufferTest.java
@@ -3,7 +3,7 @@ package com.onair.hearit.app.playinghistory.infrastructure.buffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.onair.hearit.app.fixture.RedisIntegrationTestSupport;
+import com.onair.hearit.app.fixture.RedisContainerTestSupport;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.PlayingHistory;
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class PlayingHistoryRedisBufferTest extends RedisIntegrationTestSupport {
+class PlayingHistoryRedisBufferTest extends RedisContainerTestSupport {
 
     private PlayingHistoryRedisBuffer storage;
 

--- a/backend/core/src/testFixtures/resources/application-integration-test.properties
+++ b/backend/core/src/testFixtures/resources/application-integration-test.properties
@@ -99,3 +99,20 @@ ai.max-file-size-mb=25
 
 # S3 임시 경로
 aws.s3.temp.prefix=hearit/temp/
+
+# HikariCP Test Optimization
+# -------- Master DataSource --------
+spring.datasource.master.hikari.minimum-idle=0
+spring.datasource.master.hikari.maximum-pool-size=2
+spring.datasource.master.hikari.connection-timeout=3000
+spring.datasource.master.hikari.validation-timeout=1000
+spring.datasource.master.hikari.idle-timeout=10000
+spring.datasource.master.hikari.max-lifetime=30000
+
+# -------- Replica DataSource --------
+spring.datasource.replica.hikari.minimum-idle=0
+spring.datasource.replica.hikari.maximum-pool-size=2
+spring.datasource.replica.hikari.connection-timeout=3000
+spring.datasource.replica.hikari.validation-timeout=1000
+spring.datasource.replica.hikari.idle-timeout=10000
+spring.datasource.replica.hikari.max-lifetime=30000


### PR DESCRIPTION
## **📌 변경 내용 & 이유**

### 1. Redis 통합 테스트 Base 클래스 도입
- RedisContainerTestSupport 생성 (@DataJpaTest + @Testcontainers 기반)
- 공통 Redis 컨테이너 (@Container static 관리)
- 공통 DB 초기화 (@Sql)
- Redis flushAll() 공통 처리 (RedisCallback 방식)
- LettuceConnectionFactory / RedissonClient 리소스 정리 (@AfterAll)
- RedisBufferTest, BufferFacadeTest → Base 클래스 상속으로 전환
- 테스트 중복 코드 약 250줄 제거

**이유**
- 3개 테스트에 산재하던 Redis 컨테이너/Template/Redisson 설정 코드 중복 제거
- 동일한 @Import 구성으로 Spring 컨텍스트 공유 (컨텍스트 수 감소)
- 신규 Redis 통합 테스트 추가 시 extends 한 줄로 인프라 설정 완료

 ### 2. MapBufferTest 독립 분리
- Redis를 사용하지 않는 테스트에서 불필요한 Redis 컨테이너 의존 제거

**이유**
- MapBufferTest는 Redis를 사용하지 않으므로 컨테이너 오버헤드 불필요
- 테스트가 실제 의존하는 인프라만 로딩하도록 정확한 범위 설정

### 3. HikariCP 테스트 전용 설정 최적화
- maximum-pool-size=2, minimum-idle=0
- validation-timeout=1000
- connection-timeout=3000, idle-timeout=10000, max-lifetime=30000
- Master / Replica 양쪽 동일 적용

**이유**
- 다중 컨텍스트 환경에서 MySQL Too many connections 방지
- CI 환경에서 커넥션 스파이크 제거
- 테스트 종료 시 빠른 리소스 반환

### 4. Redisson 초기화 안정화
- RedissonConfig에 @Lazy 적용
- 테스트 종료 시 shutdown() 처리 유지

**이유**
- @DataJpaTest 컨텍스트 초기화 시점에 아직 뜨지 않은 Redis로의 연결 시도 방지
- Netty thread leak 및 CI hang 방지

## **📸 스크린샷 (선택)**

N/A

## **🧪 테스트 방법**

### **1. 개별 테스트 실행**

```
./gradlew :app:test --tests PlayingHistoryMapBufferTest
./gradlew :app:test --tests PlayingHistoryRedisBufferTest
./gradlew :app:test --tests PlayingHistoryBufferFacadeTest
```

### **2. 전체 Buffer 테스트 실행**

```
./gradlew :app:test --tests "*Buffer*Test"
```

### **3. 전체 테스트 실행**

```
./gradlew :app:test
```

### **확인 포인트**

- RedisCommandTimeoutException 발생하지 않음
- MySQL “Too many connections” 오류 없음
- Redis 컨테이너 1개만 생성됨
- Hikari pool 생성 로그 master/replica 각각 1개만 생성됨
- 테스트 종료 시 hanging 없음

## **📢 논의하고 싶은 내용**

테스트 컨텍스트가 1개 뜨도록 수정하는 과정에서, RedisMapBufferTest와 BufferFacadeTest의 Import를 RedisContainerTestSupport에 통합했습니다. 현재는 이렇게 유지하고, 나중에 테스트 개수가 늘어나서 불필요한 Import가 많아지면 분리하는 방향으로 생각하고 있습니다만, 혹시 Import를 fixture에 통합하는 방향에 대해서 어떻게 생각하시나요...

## **🧩 관련 이슈**

close #840 

### **요약**

- MySQL 커넥션 고갈 문제 해결
- Redis 초기화 타이밍 이슈 해결
- 테스트 구조 안정화
- 중복 코드 제거 및 유지보수성 향상

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 테스트 인프라 개선으로 Redis 기반 통합 테스트 설정이 단순화되었습니다.
  * 테스트 코드 가독성 및 유지보수성이 향상되었습니다.

* **Chores**
  * 데이터베이스 연결 풀 설정이 최적화되었습니다.
  * 불필요한 테스트 의존성이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->