### PR TITLE
[BE] refactor: 좋아요 API 비회원 응답 401로 변경

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/reaction/application/ReactionService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/reaction/application/ReactionService.java
@@ -1,7 +1,7 @@
 package com.onair.hearit.app.reaction.application;
 
-import com.onair.hearit.app.exception.custom.ForbiddenException;
 import com.onair.hearit.app.exception.custom.NotFoundException;
+import com.onair.hearit.app.exception.custom.UnauthorizedException;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.Reaction;
 import com.onair.hearit.core.domain.ReactionType;
@@ -25,7 +25,7 @@ public class ReactionService {
     @Transactional
     public void addReaction(UserInfo userInfo, Long hearitId, ReactionType type) {
         if (userInfo == null || userInfo.isGuest()) {
-            throw new ForbiddenException("비회원은 좋아요를 추가할 권한이 없습니다.");
+            throw new UnauthorizedException("비회원은 좋아요를 추가할 권한이 없습니다.");
         }
 
         Hearit hearit = getHearitById(hearitId);
@@ -51,7 +51,7 @@ public class ReactionService {
     @Transactional
     public void removeReaction(UserInfo userInfo, Long hearitId, ReactionType type) {
         if (userInfo == null || userInfo.isGuest()) {
-            throw new ForbiddenException("비회원은 좋아요를 삭제할 권한이 없습니다.");
+            throw new UnauthorizedException("비회원은 좋아요를 삭제할 권한이 없습니다.");
         }
         Hearit hearit = getHearitById(hearitId);
         reactionRepository

--- a/backend/app/src/test/java/com/onair/hearit/app/reaction/application/ReactionServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/reaction/application/ReactionServiceTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.onair.hearit.app.auth.domain.RequestUser;
-import com.onair.hearit.app.exception.custom.ForbiddenException;
 import com.onair.hearit.app.exception.custom.NotFoundException;
+import com.onair.hearit.app.exception.custom.UnauthorizedException;
 import com.onair.hearit.app.fixture.DbHelper;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
@@ -74,7 +74,7 @@ class ReactionServiceTest {
     }
 
     @Test
-    @DisplayName("좋아요 추가 시, 비회원인 경우 ForbiddenException을 던진다.")
+    @DisplayName("좋아요 추가 시, 비회원인 경우 UnauthorizedException을 던진다.")
     void addReaction_GuestTest() {
         // given
         RequestUser guest = RequestUser.guest("00000000-0000-0000-0000-000000000000");
@@ -84,7 +84,7 @@ class ReactionServiceTest {
 
         // when & then
         assertThatThrownBy(() -> reactionService.addReaction(guest.getUserInfo(), hearitId, ReactionType.LIKE))
-                .isInstanceOf(ForbiddenException.class)
+                .isInstanceOf(UnauthorizedException.class)
                 .hasMessageContaining("비회원은 좋아요를 추가할 권한이 없습니다.");
     }
 
@@ -146,7 +146,7 @@ class ReactionServiceTest {
     }
 
     @Test
-    @DisplayName("좋아요 삭제 시, 비회원인 경우 ForbiddenException을 던진다.")
+    @DisplayName("좋아요 삭제 시, 비회원인 경우 UnauthorizedException을 던진다.")
     void removeReaction_GuestTest() {
         // given
         RequestUser guest = RequestUser.guest("00000000-0000-0000-0000-000000000000");
@@ -156,7 +156,7 @@ class ReactionServiceTest {
 
         // when & then
         assertThatThrownBy(() -> reactionService.removeReaction(guest.getUserInfo(), hearitId, ReactionType.LIKE))
-                .isInstanceOf(ForbiddenException.class)
+                .isInstanceOf(UnauthorizedException.class)
                 .hasMessageContaining("비회원은 좋아요를 삭제할 권한이 없습니다.");
     }
 

--- a/backend/app/src/test/java/com/onair/hearit/app/reaction/presentation/LikeIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/reaction/presentation/LikeIntegrationTest.java
@@ -57,7 +57,7 @@ class LikeIntegrationTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("비회원 좋아요 추가 - 403Forbidden")
+    @DisplayName("비회원 좋아요 추가 - 401Unauthorized")
     void createLike_403Forbidden() {
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
@@ -67,11 +67,11 @@ class LikeIntegrationTest extends IntegrationTest {
                 .when()
                 .post("/api/v1/hearits/{hearitId}/likes", hearit.getId())
                 .then()
-                .statusCode(HttpStatus.FORBIDDEN.value());
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
     @Test
-    @DisplayName("비회원 좋아요 삭제 - 403Forbidden")
+    @DisplayName("비회원 좋아요 삭제 - 401Unauthorized")
     void deleteLike_401Unauthorized() {
         Category category = dbHelper.insertCategory(TestFixture.createFixedCategory());
         Hearit hearit = dbHelper.insertHearit(TestFixture.createFixedHearitWith(category));
@@ -81,7 +81,7 @@ class LikeIntegrationTest extends IntegrationTest {
                 .when()
                 .delete("/api/v1/hearits/{hearitId}/likes", hearit.getId())
                 .then()
-                .statusCode(HttpStatus.FORBIDDEN.value());
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
 
     }
 

--- a/backend/app/src/test/java/com/onair/hearit/app/reaction/presentation/ReactionControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/reaction/presentation/ReactionControllerTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.onair.hearit.app.auth.infrastructure.jwt.TokenStatus;
-import com.onair.hearit.app.exception.custom.ForbiddenException;
+import com.onair.hearit.app.exception.custom.UnauthorizedException;
 import com.onair.hearit.app.fixture.ControllerTest;
 import com.onair.hearit.app.reaction.application.ReactionService;
 import org.junit.jupiter.api.DisplayName;
@@ -51,17 +51,17 @@ class ReactionControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("403 Forbidden - 좋아요 삭제 권한 없음")
-    void deleteLike_Forbidden() throws Exception {
+    @DisplayName("401 Unauthorized - 좋아요 삭제 권한 없음")
+    void deleteLike_Unauthorized() throws Exception {
         // given
         var hearitId = 1L;
 
-        willThrow(new ForbiddenException("비회원은 좋아요을 삭제할 권한이 없습니다."))
+        willThrow(new UnauthorizedException("비회원은 좋아요을 삭제할 권한이 없습니다."))
                 .given(reactionService).removeReaction(any(), any(), any());
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/hearits/{hearitId}/likes", hearitId))
-                .andExpect(status().isForbidden())
+                .andExpect(status().isUnauthorized())
                 .andDo(document("v1-delete-like-forbidden",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Like API")
@@ -101,18 +101,18 @@ class ReactionControllerTest extends ControllerTest {
     }
 
     @Test
-    @DisplayName("403 Forbidden - 좋아요 추가 권한 없음")
-    void addLike_Forbidden() throws Exception {
+    @DisplayName("401 Unauthorized - 좋아요 추가 권한 없음")
+    void addLike_Unauthorized() throws Exception {
         // given
         var hearitId = 1L;
 
-        willThrow(new ForbiddenException("비회원은 좋아요을 추가할 권한이 없습니다."))
+        willThrow(new UnauthorizedException("비회원은 좋아요을 추가할 권한이 없습니다."))
                 .given(reactionService).addReaction(any(), any(), any());
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/hearits/{hearitId}/likes", hearitId))
-                .andExpect(status().isForbidden())
-                .andDo(document("v1-post-like-forbidden",
+                .andExpect(status().isUnauthorized())
+                .andDo(document("v1-post-like-aunthorized",
                         resource(ResourceSnippetParameters.builder()
                                 .tag("Like API")
                                 .summary("좋아요 추가 V1")


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
기존에 비회원이 좋아요 추가나 삭제 시 403을 응답했으나,
의미상 401 Unauthorized 가 더 적절하여 401로 수정하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 비회원 사용자가 좋아요를 추가하거나 제거할 때 반환되는 인증 오류 응답이 개선되었습니다. 인증되지 않은 요청에 대해 더 정확한 오류 처리를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->