### PR TITLE
[IOS] fix: refreshToken을 활용한 자동 토큰 갱신 및 로그인 유지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # AI Agent Configuration
 AGENTS.md
 .gstack/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # AI Agent Configuration
 AGENTS.md
+.gstack/

--- a/ios/hearit/.claude/settings.local.json
+++ b/ios/hearit/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Skill(browse)",
+      "Bash(flutter analyze:*)"
+    ]
+  }
+}

--- a/ios/hearit/.claude/settings.local.json
+++ b/ios/hearit/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Skill(browse)",
-      "Bash(flutter analyze:*)"
-    ]
-  }
-}

--- a/ios/hearit/docs/token_refresh_implementation.md
+++ b/ios/hearit/docs/token_refresh_implementation.md
@@ -1,0 +1,361 @@
+# Token Refresh 구현 LLD
+
+## 1. 배경 및 문제 정의
+
+### 문제
+앱이 accessToken만으로 인증을 처리하고 있었으며, 토큰 만료 시 refreshToken을 사용하지 않고 즉시 로그아웃 처리.
+결과적으로 로그인 상태가 유지되지 않아 사용자가 자주 재로그인해야 하는 UX 문제 발생.
+
+### 근본 원인
+1. **`auth_viewmodel.dart`** — 앱 시작 시 `checkAuthStatus()`에서 accessToken 유효성 실패 시 refresh 시도 없이 바로 `clearTokens()` 호출
+2. **`api_client.dart`** — 앱 사용 중 401 응답 처리 인터셉터 없음
+3. **`auth_repository.dart`** — refreshToken을 사용하는 API 호출 메서드 없음
+
+---
+
+## 2. Refresh API 스펙
+
+```
+POST /api/v1/auth/token/refresh
+Content-Type: application/json
+
+Request Body:
+{
+  "refreshToken": "string"
+}
+
+Response 200:
+{
+  "accessToken": "string"
+}
+```
+
+> **주의:** 응답은 새 accessToken만 포함. refreshToken은 갱신되지 않으며 기존 값을 계속 사용.
+
+---
+
+## 3. 아키텍처 설계
+
+### 순환 참조 문제
+`AuthInterceptor`가 토큰 갱신 실패 시 `AuthViewModel`의 `clearAuthStatus()`를 직접 호출하면 순환 import 발생.
+
+```
+AuthViewModel → AuthRepository → ApiClient → AuthInterceptor → AuthViewModel (순환!)
+```
+
+### 해결: Stream 이벤트 방식
+
+`AuthViewModel`이 `StreamController<AuthEvent>`를 소유하고 `ApiClient` → `AuthInterceptor`에 주입.
+`AuthInterceptor`는 `AuthViewModel`을 전혀 모르고, Stream에 이벤트만 push.
+
+```
+AuthViewModel (StreamController 소유 + stream 구독)
+     ↓ eventController 주입
+ApiClient
+     ↓ eventController 주입
+AuthInterceptor → StreamController.add(tokenRefreshFailed)
+                                ↑
+              AuthViewModel이 listen하여 clearAuthStatus() 호출
+```
+
+### 의존성 방향 (순환 없음)
+
+```
+auth_event.dart
+      ↑
+auth_interceptor.dart      (auth_viewmodel 미참조)
+      ↑
+api_client.dart
+      ↑
+auth_repository.dart
+      ↑
+auth_viewmodel.dart        (Stream 구독으로 interceptor 이벤트 수신)
+```
+
+---
+
+## 4. 토큰 갱신 시나리오
+
+### 시나리오 A: 앱 시작 시 (Splash Screen)
+
+```
+앱 시작
+  └─ checkAuthStatus()
+       ├─ 저장된 토큰 없음 → unauthenticated
+       └─ 저장된 토큰 있음
+            ├─ GET /api/v1/auth/check (accessToken)
+            │    ├─ 200 OK → authenticated ✓
+            │    └─ 실패 (만료)
+            │         ├─ POST /api/v1/auth/token/refresh (refreshToken)
+            │         │    ├─ 200 OK → 새 accessToken 저장 → authenticated ✓
+            │         │    └─ 실패 → clearTokens() → unauthenticated
+            │         └─ 네트워크 오류 → unauthenticated
+            └─ 예외 → unauthenticated
+```
+
+### 시나리오 B: 앱 사용 중 API 호출 시 (AuthInterceptor)
+
+```
+API 요청
+  └─ 401 응답 수신
+       └─ AuthInterceptor.onError()
+            ├─ _isRefreshing == true → 갱신 중복 방지, 에러 그대로 전달
+            └─ _isRefreshing == false
+                 ├─ 저장된 토큰 없음 → Stream.add(tokenRefreshFailed)
+                 └─ refreshToken 존재
+                      ├─ POST /api/v1/auth/token/refresh
+                      │    ├─ 200 OK → 새 accessToken 저장
+                      │    │         → 원래 요청 재시도 (새 accessToken 헤더 교체)
+                      │    │         → handler.resolve(retryResponse) ✓
+                      │    └─ 실패 → Stream.add(tokenRefreshFailed)
+                      └─ Stream 이벤트 수신
+                           └─ AuthViewModel.clearAuthStatus()
+                                └─ clearTokens() → unauthenticated → 로그인 화면
+```
+
+---
+
+## 5. 변경 파일 상세
+
+### 5-1. `lib/features/auth/models/auth_event.dart` (신규)
+
+인터셉터와 ViewModel 간 통신에 사용되는 이벤트 타입.
+
+```dart
+enum AuthEvent {
+  tokenRefreshFailed,
+}
+```
+
+---
+
+### 5-2. `lib/core/network/interceptors/auth_interceptor.dart` (신규)
+
+401 에러 자동 처리 인터셉터. `AuthViewModel`에 대한 의존성 없음.
+
+**주요 설계 결정:**
+- refresh 호출에 **별도 `Dio` 인스턴스** 사용 → 동일 `ApiClient`의 인터셉터 루프 방지
+- `_isRefreshing` 플래그로 중복 refresh 요청 방지
+- refresh 성공 시 `err.requestOptions`의 Authorization 헤더를 교체 후 `Dio().fetch()`로 원래 요청 재시도
+
+```dart
+class AuthInterceptor extends Interceptor {
+  AuthInterceptor({
+    required AuthStorageService storageService,
+    required StreamController<AuthEvent> eventController,
+  })  : _storageService = storageService,
+        _eventController = eventController;
+
+  final AuthStorageService _storageService;
+  final StreamController<AuthEvent> _eventController;
+  bool _isRefreshing = false;
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) async {
+    if (err.response?.statusCode != 401 || _isRefreshing) {
+      return handler.next(err);
+    }
+
+    _isRefreshing = true;
+    try {
+      final tokens = await _storageService.getTokens();
+      if (tokens == null) {
+        _eventController.add(AuthEvent.tokenRefreshFailed);
+        return handler.next(err);
+      }
+
+      // 별도 Dio 인스턴스로 refresh (인터셉터 루프 방지)
+      final refreshDio = Dio();
+      final response = await refreshDio.post(
+        '${ApiConfig.defaultBaseUrl}/api/v1/auth/token/refresh',
+        data: {'refreshToken': tokens.refreshToken},
+      );
+      final newAccessToken = response.data['accessToken'] as String;
+
+      await _storageService.saveTokens(
+        AuthTokens(
+          accessToken: newAccessToken,
+          refreshToken: tokens.refreshToken, // refreshToken은 그대로 유지
+        ),
+      );
+
+      // 원래 요청 재시도
+      final retryOptions = err.requestOptions;
+      retryOptions.headers['Authorization'] = 'Bearer $newAccessToken';
+      final retryResponse = await Dio().fetch(retryOptions);
+      return handler.resolve(retryResponse);
+    } catch (e) {
+      _eventController.add(AuthEvent.tokenRefreshFailed);
+      return handler.next(err);
+    } finally {
+      _isRefreshing = false;
+    }
+  }
+}
+```
+
+---
+
+### 5-3. `lib/core/network/api_client.dart` (수정)
+
+`AuthInterceptor` 등록을 위한 파라미터 추가. 두 파라미터 모두 제공될 때만 인터셉터 활성화.
+인터셉터 등록 순서: `AuthInterceptor` → `DeviceUUIDInterceptor` → `DebugLoggingInterceptor`.
+
+**변경 전:**
+```dart
+ApiClient({
+  ApiConfig config = const ApiConfig(),
+  Duration connectTimeout = ...,
+  Duration sendTimeout = ...,
+  Duration receiveTimeout = ...,
+  Dio? dio,
+})
+```
+
+**변경 후:**
+```dart
+ApiClient({
+  ApiConfig config = const ApiConfig(),
+  Duration connectTimeout = ...,
+  Duration sendTimeout = ...,
+  Duration receiveTimeout = ...,
+  Dio? dio,
+  AuthStorageService? storageService,                    // 추가
+  StreamController<AuthEvent>? authEventController,      // 추가
+}) {
+  if (storageService != null && authEventController != null) {
+    _dio.interceptors.add(
+      AuthInterceptor(
+        storageService: storageService,
+        eventController: authEventController,
+      ),
+    );
+  }
+  _dio.interceptors.add(DeviceUUIDInterceptor());
+  ...
+}
+```
+
+---
+
+### 5-4. `lib/features/auth/auth_repository.dart` (수정)
+
+앱 시작 시 `checkAuthStatus()`에서 사용하는 refresh 메서드 추가.
+
+```dart
+/// refreshToken으로 새 accessToken 발급
+Future<String> refreshAccessToken(String refreshToken) async {
+  try {
+    final response = await _apiClient.post<Map<String, dynamic>>(
+      '/api/v1/auth/token/refresh',
+      body: {'refreshToken': refreshToken},
+      parser: (data) => data as Map<String, dynamic>,
+    );
+    return response['accessToken'] as String;
+  } catch (error) {
+    throw Exception('토큰 갱신 실패: $error');
+  }
+}
+```
+
+---
+
+### 5-5. `lib/features/auth/auth_viewmodel.dart` (수정)
+
+**생성자 변경:**
+`StreamController` 소유 및 `AuthRepository`에 auth-aware `ApiClient` 주입.
+
+```dart
+AuthViewModel({
+  AuthRepository? repository,
+  AuthStorageService? storageService,
+}) : _storageService = storageService ?? AuthStorageService() {
+  _authEventController = StreamController<AuthEvent>.broadcast();
+  _repository = repository ??
+      AuthRepository(
+        apiClient: ApiClient(
+          storageService: _storageService,
+          authEventController: _authEventController,
+        ),
+      );
+  _authEventSubscription = _authEventController.stream.listen((event) {
+    if (event == AuthEvent.tokenRefreshFailed) {
+      clearAuthStatus();
+    }
+  });
+}
+```
+
+**필드 추가:**
+```dart
+late final AuthRepository _repository;
+late final StreamController<AuthEvent> _authEventController;
+late final StreamSubscription<AuthEvent> _authEventSubscription;
+```
+
+**`checkAuthStatus()` 변경 — else 블록:**
+
+```dart
+// 변경 전
+} else {
+  await _storageService.clearTokens();
+  _status = AuthStatus.unauthenticated;
+}
+
+// 변경 후
+} else {
+  try {
+    final newAccessToken =
+        await _repository.refreshAccessToken(tokens.refreshToken);
+    await _storageService.saveTokens(
+      AuthTokens(
+        accessToken: newAccessToken,
+        refreshToken: tokens.refreshToken,
+      ),
+    );
+    _status = AuthStatus.authenticated;
+    try {
+      _user = await _repository.getKakaoUserInfo();
+    } catch (e) {
+      debugPrint('사용자 정보 조회 실패: $e');
+    }
+  } catch (e) {
+    debugPrint('토큰 갱신 실패, 로그아웃 처리: $e');
+    await _storageService.clearTokens();
+    _status = AuthStatus.unauthenticated;
+  }
+}
+```
+
+**`dispose()` 추가:**
+```dart
+@override
+void dispose() {
+  _authEventSubscription.cancel();
+  _authEventController.close();
+  super.dispose();
+}
+```
+
+---
+
+## 6. 변경 파일 요약
+
+| 파일 | 변경 유형 | 핵심 변경 내용 |
+|------|-----------|--------------|
+| `features/auth/models/auth_event.dart` | 신규 | `AuthEvent` enum 정의 |
+| `core/network/interceptors/auth_interceptor.dart` | 신규 | 401 자동 갱신 인터셉터 |
+| `core/network/api_client.dart` | 수정 | `storageService`, `authEventController` 파라미터 추가 및 `AuthInterceptor` 등록 |
+| `features/auth/auth_repository.dart` | 수정 | `refreshAccessToken()` 메서드 추가 |
+| `features/auth/auth_viewmodel.dart` | 수정 | `StreamController` 소유, Stream 구독, `checkAuthStatus()` refresh 로직, `dispose()` |
+
+---
+
+## 7. 제약 및 한계
+
+| 항목 | 내용 |
+|------|------|
+| 동시 401 처리 | `_isRefreshing` 플래그로 중복 refresh 방지. 첫 번째 요청만 refresh 시도, 나머지는 401 에러 그대로 전달됨. 앱 규모상 허용 수준으로 판단. |
+| refreshToken 만료 주기 | 서버 정책에 따름. 현재 클라이언트는 refresh 실패 시 재로그인 유도로 처리. |
+| 토큰 저장소 | `FlutterSecureStorage` 사용. OS 키체인/키스토어 기반으로 암호화 저장됨. |
+| refreshToken 갱신 없음 | 백엔드 API가 refresh 응답에 새 refreshToken을 포함하지 않으므로 기존 refreshToken을 계속 사용. 서버 정책 변경 시 `AuthTokens` 저장 로직 수정 필요. |

--- a/ios/hearit/lib/core/network/api_client.dart
+++ b/ios/hearit/lib/core/network/api_client.dart
@@ -1,10 +1,14 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../features/auth/models/auth_event.dart';
+import '../../features/auth/services/auth_storage_service.dart';
 import 'api_config.dart';
 import 'api_exception.dart';
+import 'interceptors/auth_interceptor.dart';
 import 'interceptors/debug_logging_interceptor.dart';
 import 'interceptors/device_uuid_interceptor.dart';
 
@@ -15,6 +19,8 @@ class ApiClient {
     Duration sendTimeout = const Duration(seconds: 10),
     Duration receiveTimeout = const Duration(seconds: 15),
     Dio? dio,
+    AuthStorageService? storageService,
+    StreamController<AuthEvent>? authEventController,
   }) : _config = config,
        _dio =
            dio ??
@@ -28,6 +34,14 @@ class ApiClient {
                responseType: ResponseType.json,
              ),
            ) {
+    if (storageService != null && authEventController != null) {
+      _dio.interceptors.add(
+        AuthInterceptor(
+          storageService: storageService,
+          eventController: authEventController,
+        ),
+      );
+    }
     _dio.interceptors.add(DeviceUUIDInterceptor());
     if (!kReleaseMode) {
       _dio.interceptors.add(DebugLoggingInterceptor());

--- a/ios/hearit/lib/core/network/interceptors/auth_interceptor.dart
+++ b/ios/hearit/lib/core/network/interceptors/auth_interceptor.dart
@@ -18,6 +18,12 @@ class AuthInterceptor extends Interceptor {
   final StreamController<AuthEvent> _eventController;
   bool _isRefreshing = false;
 
+  void _emitRefreshFailed() {
+    if (!_eventController.isClosed) {
+      _eventController.add(AuthEvent.tokenRefreshFailed);
+    }
+  }
+
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
     if (err.response?.statusCode != 401 || _isRefreshing) {
@@ -28,14 +34,24 @@ class AuthInterceptor extends Interceptor {
     try {
       final tokens = await _storageService.getTokens();
       if (tokens == null) {
-        _eventController.add(AuthEvent.tokenRefreshFailed);
+        _emitRefreshFailed();
         return handler.next(err);
       }
 
-      // 별도 Dio 인스턴스로 refresh 호출 (인터셉터 루프 방지)
-      final refreshDio = Dio();
+      // refresh 요청: 별도 Dio 인스턴스로 인터셉터 루프 방지
+      // baseUrl은 원래 요청의 baseUrl을 따라 환경(스테이징/프로덕션)을 존중
+      final baseUrl = err.requestOptions.baseUrl.isNotEmpty
+          ? err.requestOptions.baseUrl
+          : ApiConfig.defaultBaseUrl;
+      final refreshDio = Dio(
+        BaseOptions(
+          connectTimeout: err.requestOptions.connectTimeout,
+          receiveTimeout: err.requestOptions.receiveTimeout,
+          sendTimeout: err.requestOptions.sendTimeout,
+        ),
+      );
       final response = await refreshDio.post(
-        '${ApiConfig.defaultBaseUrl}/api/v1/auth/token/refresh',
+        '${baseUrl}api/v1/auth/token/refresh',
         data: {'refreshToken': tokens.refreshToken},
       );
       final newAccessToken = response.data['accessToken'] as String;
@@ -51,10 +67,24 @@ class AuthInterceptor extends Interceptor {
       // 원래 요청을 새 accessToken으로 재시도
       final retryOptions = err.requestOptions;
       retryOptions.headers['Authorization'] = 'Bearer $newAccessToken';
-      final retryResponse = await Dio().fetch(retryOptions);
+      final retryDio = Dio(
+        BaseOptions(
+          baseUrl: retryOptions.baseUrl,
+          connectTimeout: retryOptions.connectTimeout,
+          receiveTimeout: retryOptions.receiveTimeout,
+          sendTimeout: retryOptions.sendTimeout,
+          responseType: retryOptions.responseType,
+          contentType: retryOptions.contentType,
+          followRedirects: retryOptions.followRedirects,
+          validateStatus: retryOptions.validateStatus,
+          receiveDataWhenStatusError: retryOptions.receiveDataWhenStatusError,
+          headers: retryOptions.headers,
+        ),
+      );
+      final retryResponse = await retryDio.fetch(retryOptions);
       return handler.resolve(retryResponse);
     } catch (e) {
-      _eventController.add(AuthEvent.tokenRefreshFailed);
+      _emitRefreshFailed();
       return handler.next(err);
     } finally {
       _isRefreshing = false;

--- a/ios/hearit/lib/core/network/interceptors/auth_interceptor.dart
+++ b/ios/hearit/lib/core/network/interceptors/auth_interceptor.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+
+import '../../../features/auth/models/auth_event.dart';
+import '../../../features/auth/models/auth_tokens.dart';
+import '../../../features/auth/services/auth_storage_service.dart';
+import '../api_config.dart';
+
+class AuthInterceptor extends Interceptor {
+  AuthInterceptor({
+    required AuthStorageService storageService,
+    required StreamController<AuthEvent> eventController,
+  })  : _storageService = storageService,
+        _eventController = eventController;
+
+  final AuthStorageService _storageService;
+  final StreamController<AuthEvent> _eventController;
+  bool _isRefreshing = false;
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) async {
+    if (err.response?.statusCode != 401 || _isRefreshing) {
+      return handler.next(err);
+    }
+
+    _isRefreshing = true;
+    try {
+      final tokens = await _storageService.getTokens();
+      if (tokens == null) {
+        _eventController.add(AuthEvent.tokenRefreshFailed);
+        return handler.next(err);
+      }
+
+      // 별도 Dio 인스턴스로 refresh 호출 (인터셉터 루프 방지)
+      final refreshDio = Dio();
+      final response = await refreshDio.post(
+        '${ApiConfig.defaultBaseUrl}/api/v1/auth/token/refresh',
+        data: {'refreshToken': tokens.refreshToken},
+      );
+      final newAccessToken = response.data['accessToken'] as String;
+
+      // 새 accessToken 저장 (refreshToken은 그대로 유지)
+      await _storageService.saveTokens(
+        AuthTokens(
+          accessToken: newAccessToken,
+          refreshToken: tokens.refreshToken,
+        ),
+      );
+
+      // 원래 요청을 새 accessToken으로 재시도
+      final retryOptions = err.requestOptions;
+      retryOptions.headers['Authorization'] = 'Bearer $newAccessToken';
+      final retryResponse = await Dio().fetch(retryOptions);
+      return handler.resolve(retryResponse);
+    } catch (e) {
+      _eventController.add(AuthEvent.tokenRefreshFailed);
+      return handler.next(err);
+    } finally {
+      _isRefreshing = false;
+    }
+  }
+}

--- a/ios/hearit/lib/core/network/interceptors/auth_interceptor.dart
+++ b/ios/hearit/lib/core/network/interceptors/auth_interceptor.dart
@@ -57,7 +57,7 @@ class AuthInterceptor extends Interceptor {
         ),
       );
       final response = await refreshDio.post(
-        '${baseUrl}api/v1/auth/token/refresh',
+        '$baseUrl/api/v1/auth/token/refresh',
         data: {'refreshToken': tokens.refreshToken},
       );
       final newAccessToken = response.data['accessToken'] as String;
@@ -85,6 +85,8 @@ class AuthInterceptor extends Interceptor {
           validateStatus: retryOptions.validateStatus,
           receiveDataWhenStatusError: retryOptions.receiveDataWhenStatusError,
           headers: retryOptions.headers,
+          extra: retryOptions.extra,
+          method: retryOptions.method,
         ),
       );
       final retryResponse = await retryDio.fetch(retryOptions);

--- a/ios/hearit/lib/core/network/interceptors/auth_interceptor.dart
+++ b/ios/hearit/lib/core/network/interceptors/auth_interceptor.dart
@@ -26,7 +26,13 @@ class AuthInterceptor extends Interceptor {
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) async {
-    if (err.response?.statusCode != 401 || _isRefreshing) {
+    // refresh 엔드포인트 자체가 401을 반환할 경우 재진입 방지
+    const refreshPath = '/api/v1/auth/token/refresh';
+    final requestPath = err.requestOptions.path;
+    final isRefreshRequest =
+        requestPath == refreshPath || requestPath.endsWith(refreshPath);
+
+    if (err.response?.statusCode != 401 || _isRefreshing || isRefreshRequest) {
       return handler.next(err);
     }
 

--- a/ios/hearit/lib/features/auth/auth_repository.dart
+++ b/ios/hearit/lib/features/auth/auth_repository.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
 import '../../core/network/api_client.dart';
+import '../../core/network/api_exception.dart';
 import 'models/auth_tokens.dart';
 import 'models/kakao_user.dart';
 
@@ -79,16 +80,21 @@ class AuthRepository {
   }
 
   /// 백엔드 인증 상태 체크 (/api/v1/auth/check)
+  /// - 200 OK → true
+  /// - 401 → false (토큰 만료, refresh 시도 대상)
+  /// - 네트워크 오류 / 타임아웃 / 5xx → rethrow (refresh 시도 없이 처리)
   Future<bool> checkAuthStatus(String accessToken) async {
     try {
       await _apiClient.get<void>(
         '/api/v1/auth/check',
         headers: {'Authorization': 'Bearer $accessToken'},
       );
-      return true; // 200 OK
-    } catch (error) {
-      debugPrint('인증 체크 실패: $error');
-      return false; // 401 또는 기타 에러
+      return true;
+    } on ApiException catch (e) {
+      if (e.statusCode == 401) {
+        return false;
+      }
+      rethrow;
     }
   }
 
@@ -99,7 +105,11 @@ class AuthRepository {
       body: {'refreshToken': refreshToken},
       parser: (data) => data as Map<String, dynamic>,
     );
-    return response['accessToken'] as String;
+    final accessToken = response['accessToken'];
+    if (accessToken is! String || accessToken.isEmpty) {
+      throw ApiException.unexpected('응답에 유효한 accessToken이 없습니다.');
+    }
+    return accessToken;
   }
 
   /// 카카오 로그아웃

--- a/ios/hearit/lib/features/auth/auth_repository.dart
+++ b/ios/hearit/lib/features/auth/auth_repository.dart
@@ -92,6 +92,20 @@ class AuthRepository {
     }
   }
 
+  /// refreshToken으로 새 accessToken 발급
+  Future<String> refreshAccessToken(String refreshToken) async {
+    try {
+      final response = await _apiClient.post<Map<String, dynamic>>(
+        '/api/v1/auth/token/refresh',
+        body: {'refreshToken': refreshToken},
+        parser: (data) => data as Map<String, dynamic>,
+      );
+      return response['accessToken'] as String;
+    } catch (error) {
+      throw Exception('토큰 갱신 실패: $error');
+    }
+  }
+
   /// 카카오 로그아웃
   Future<void> logoutFromKakao() async {
     try {

--- a/ios/hearit/lib/features/auth/auth_repository.dart
+++ b/ios/hearit/lib/features/auth/auth_repository.dart
@@ -94,16 +94,12 @@ class AuthRepository {
 
   /// refreshToken으로 새 accessToken 발급
   Future<String> refreshAccessToken(String refreshToken) async {
-    try {
-      final response = await _apiClient.post<Map<String, dynamic>>(
-        '/api/v1/auth/token/refresh',
-        body: {'refreshToken': refreshToken},
-        parser: (data) => data as Map<String, dynamic>,
-      );
-      return response['accessToken'] as String;
-    } catch (error) {
-      throw Exception('토큰 갱신 실패: $error');
-    }
+    final response = await _apiClient.post<Map<String, dynamic>>(
+      '/api/v1/auth/token/refresh',
+      body: {'refreshToken': refreshToken},
+      parser: (data) => data as Map<String, dynamic>,
+    );
+    return response['accessToken'] as String;
   }
 
   /// 카카오 로그아웃

--- a/ios/hearit/lib/features/auth/auth_viewmodel.dart
+++ b/ios/hearit/lib/features/auth/auth_viewmodel.dart
@@ -1,6 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
+import '../../core/network/api_client.dart';
 import 'auth_repository.dart';
+import 'models/auth_event.dart';
+import 'models/auth_tokens.dart';
 import 'models/kakao_user.dart';
 import 'services/auth_storage_service.dart';
 
@@ -16,11 +21,26 @@ class AuthViewModel extends ChangeNotifier {
   AuthViewModel({
     AuthRepository? repository,
     AuthStorageService? storageService,
-  }) : _repository = repository ?? AuthRepository(),
-       _storageService = storageService ?? AuthStorageService();
+  }) : _storageService = storageService ?? AuthStorageService() {
+    _authEventController = StreamController<AuthEvent>.broadcast();
+    _repository = repository ??
+        AuthRepository(
+          apiClient: ApiClient(
+            storageService: _storageService,
+            authEventController: _authEventController,
+          ),
+        );
+    _authEventSubscription = _authEventController.stream.listen((event) {
+      if (event == AuthEvent.tokenRefreshFailed) {
+        clearAuthStatus();
+      }
+    });
+  }
 
-  final AuthRepository _repository;
+  late final AuthRepository _repository;
   final AuthStorageService _storageService;
+  late final StreamController<AuthEvent> _authEventController;
+  late final StreamSubscription<AuthEvent> _authEventSubscription;
 
   AuthStatus _status = AuthStatus.initial;
   bool _isLoading = false;
@@ -59,9 +79,28 @@ class AuthViewModel extends ChangeNotifier {
           debugPrint('사용자 정보 조회 실패: $e');
         }
       } else {
-        // 토큰 만료 등 -> 로그인 필요
-        await _storageService.clearTokens();
-        _status = AuthStatus.unauthenticated;
+        // accessToken 만료 -> refreshToken으로 갱신 시도
+        try {
+          final newAccessToken =
+              await _repository.refreshAccessToken(tokens.refreshToken);
+          await _storageService.saveTokens(
+            AuthTokens(
+              accessToken: newAccessToken,
+              refreshToken: tokens.refreshToken,
+            ),
+          );
+          _status = AuthStatus.authenticated;
+          try {
+            _user = await _repository.getKakaoUserInfo();
+          } catch (e) {
+            debugPrint('사용자 정보 조회 실패: $e');
+          }
+        } catch (e) {
+          // refreshToken도 만료 -> 로그아웃
+          debugPrint('토큰 갱신 실패, 로그아웃 처리: $e');
+          await _storageService.clearTokens();
+          _status = AuthStatus.unauthenticated;
+        }
       }
     } catch (error) {
       debugPrint('인증 체크 오류: $error');
@@ -143,5 +182,12 @@ class AuthViewModel extends ChangeNotifier {
   void _setLoading(bool value) {
     _isLoading = value;
     notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _authEventSubscription.cancel();
+    _authEventController.close();
+    super.dispose();
   }
 }

--- a/ios/hearit/lib/features/auth/auth_viewmodel.dart
+++ b/ios/hearit/lib/features/auth/auth_viewmodel.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 
 import '../../core/network/api_client.dart';
 import 'auth_repository.dart';
@@ -21,8 +22,10 @@ class AuthViewModel extends ChangeNotifier {
   AuthViewModel({
     AuthRepository? repository,
     AuthStorageService? storageService,
+    StreamController<AuthEvent>? authEventController,
   }) : _storageService = storageService ?? AuthStorageService() {
-    _authEventController = StreamController<AuthEvent>.broadcast();
+    _authEventController =
+        authEventController ?? StreamController<AuthEvent>.broadcast();
     _repository = repository ??
         AuthRepository(
           apiClient: ApiClient(
@@ -32,7 +35,7 @@ class AuthViewModel extends ChangeNotifier {
         );
     _authEventSubscription = _authEventController.stream.listen((event) {
       if (event == AuthEvent.tokenRefreshFailed) {
-        clearAuthStatus();
+        unawaited(clearAuthStatus());
       }
     });
   }

--- a/ios/hearit/lib/features/auth/auth_viewmodel.dart
+++ b/ios/hearit/lib/features/auth/auth_viewmodel.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 
 import '../../core/network/api_client.dart';
 import 'auth_repository.dart';
@@ -24,6 +23,8 @@ class AuthViewModel extends ChangeNotifier {
     AuthStorageService? storageService,
     StreamController<AuthEvent>? authEventController,
   }) : _storageService = storageService ?? AuthStorageService() {
+    // 외부에서 주입된 controller는 소유하지 않음 → dispose 시 close 하지 않음
+    _ownsEventController = authEventController == null;
     _authEventController =
         authEventController ?? StreamController<AuthEvent>.broadcast();
     _repository = repository ??
@@ -44,6 +45,7 @@ class AuthViewModel extends ChangeNotifier {
   final AuthStorageService _storageService;
   late final StreamController<AuthEvent> _authEventController;
   late final StreamSubscription<AuthEvent> _authEventSubscription;
+  late final bool _ownsEventController;
 
   AuthStatus _status = AuthStatus.initial;
   bool _isLoading = false;
@@ -190,7 +192,8 @@ class AuthViewModel extends ChangeNotifier {
   @override
   void dispose() {
     _authEventSubscription.cancel();
-    _authEventController.close();
+    // 외부에서 주입된 controller는 소유자(main.dart)가 관리하므로 close 하지 않음
+    if (_ownsEventController) _authEventController.close();
     super.dispose();
   }
 }

--- a/ios/hearit/lib/features/auth/models/auth_event.dart
+++ b/ios/hearit/lib/features/auth/models/auth_event.dart
@@ -1,0 +1,3 @@
+enum AuthEvent {
+  tokenRefreshFailed,
+}

--- a/ios/hearit/lib/features/detail/hearit_detail_screen.dart
+++ b/ios/hearit/lib/features/detail/hearit_detail_screen.dart
@@ -6,6 +6,8 @@ import '../../core/analytics/analytics_param_keys.dart';
 import '../../core/analytics/analytics_provider.dart';
 
 import '../../core/audio/hearit_player_controller.dart';
+import '../../core/network/api_client.dart';
+import 'detail_repository.dart';
 import '../../core/presentation/widgets/script_view.dart';
 import '../../core/theme/app_colors.dart';
 import 'hearit_detail.dart';
@@ -42,7 +44,8 @@ class _HearitDetailScreenState extends State<HearitDetailScreen> {
     _viewModel = HearitDetailViewModel(
       detail: widget.detail,
       playerController: context.read<HearitPlayerController>(),
-      fromPlaylist: widget.fromPlaylist, // 재생목록 진입 여부 전달
+      fromPlaylist: widget.fromPlaylist,
+      repository: DetailRepository(apiClient: context.read<ApiClient>()),
     )..addListener(_onViewModelUpdated);
     _viewModel.loadAll();
     WidgetsBinding.instance.addPostFrameCallback((_) => _logScreenView());

--- a/ios/hearit/lib/features/explore/explore_screen.dart
+++ b/ios/hearit/lib/features/explore/explore_screen.dart
@@ -9,6 +9,8 @@ import '../../core/analytics/analytics_param_keys.dart';
 import '../../core/analytics/analytics_provider.dart';
 
 import '../../core/audio/hearit_player_controller.dart';
+import '../../core/network/api_client.dart';
+import 'explore_repository.dart';
 import '../../core/theme/app_colors.dart';
 import '../detail/hearit_detail.dart';
 import '../detail/hearit_detail_screen.dart';
@@ -40,6 +42,7 @@ class ExploreScreenState extends State<ExploreScreen> {
     _titleNotifier = ValueNotifier<String?>(null);
     _viewModel = ExploreViewModel(
       controller: context.read<HearitPlayerController>(),
+      repository: ExploreRepository(apiClient: context.read<ApiClient>()),
     )..addListener(_onViewModelUpdated);
     _viewModel.setOnCompleted(_handleCompleted);
     _viewModel.loadInitial();

--- a/ios/hearit/lib/features/home/home_screen.dart
+++ b/ios/hearit/lib/features/home/home_screen.dart
@@ -5,8 +5,10 @@ import 'package:hearit/core/analytics/analytics_provider.dart';
 import 'package:hearit/core/theme/app_colors.dart';
 import 'package:provider/provider.dart';
 
+import '../../core/network/api_client.dart';
 import '../auth/auth_viewmodel.dart';
 import '../auth/login_screen.dart';
+import 'home_repository.dart';
 import '../detail/hearit_detail.dart';
 import '../detail/hearit_detail_screen.dart';
 import 'home_models.dart';
@@ -40,6 +42,7 @@ class _HomeScreenState extends State<HomeScreen> {
     final authViewModel = context.read<AuthViewModel>();
     _viewModel = HomeViewModel(
       authViewModel: authViewModel,
+      repository: HomeRepository(apiClient: context.read<ApiClient>()),
       onUnauthorized: _handleUnauthorized,
     )..addListener(_onViewModelUpdated);
     _viewModel.loadHome();

--- a/ios/hearit/lib/features/library/library_screen.dart
+++ b/ios/hearit/lib/features/library/library_screen.dart
@@ -3,6 +3,9 @@ import 'package:hearit/core/theme/app_colors.dart';
 import 'package:provider/provider.dart';
 
 import '../../core/analytics/analytics_event_names.dart';
+import '../../core/network/api_client.dart';
+import '../setting/setting_repository.dart';
+import 'library_repository.dart';
 import '../../core/analytics/analytics_param_keys.dart';
 import '../../core/analytics/analytics_provider.dart';
 import '../../core/audio/hearit_player_controller.dart';
@@ -33,7 +36,11 @@ class _LibraryScreenState extends State<LibraryScreen> {
   @override
   void initState() {
     super.initState();
-    _viewModel = LibraryViewModel()..addListener(_onViewModelChanged);
+    final apiClient = context.read<ApiClient>();
+    _viewModel = LibraryViewModel(
+      libraryRepository: LibraryRepository(apiClient: apiClient),
+      settingRepository: SettingRepository(apiClient: apiClient),
+    )..addListener(_onViewModelChanged);
     _viewModel.loadInitialData();
     _scrollController.addListener(_onScroll);
 

--- a/ios/hearit/lib/features/search/search_screen.dart
+++ b/ios/hearit/lib/features/search/search_screen.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:hearit/core/analytics/analytics_event_names.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/network/api_client.dart';
+import 'search_repository.dart';
 import 'package:hearit/core/analytics/analytics_param_keys.dart';
 import 'package:hearit/core/analytics/analytics_provider.dart';
 import 'package:hearit/core/theme/app_colors.dart';
@@ -27,7 +31,9 @@ class _SearchScreenState extends State<SearchScreen> {
   @override
   void initState() {
     super.initState();
-    _viewModel = SearchViewModel()..addListener(_onViewModelUpdated);
+    _viewModel = SearchViewModel(
+      repository: SearchRepository(apiClient: context.read<ApiClient>()),
+    )..addListener(_onViewModelUpdated);
     WidgetsBinding.instance.addPostFrameCallback((_) => _logScreenView());
   }
 

--- a/ios/hearit/lib/main.dart
+++ b/ios/hearit/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:audio_service/audio_service.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -11,7 +13,12 @@ import 'core/analytics/analytics_provider.dart';
 import 'core/audio/audio_handler.dart';
 import 'core/audio/hearit_player_controller.dart';
 import 'core/device/device_uuid_service.dart';
+import 'core/network/api_client.dart';
+import 'features/auth/auth_repository.dart';
+import 'features/auth/models/auth_event.dart';
+import 'features/auth/services/auth_storage_service.dart';
 import 'features/library/library_repository.dart';
+import 'features/setting/setting_repository.dart';
 import 'firebase_options.dart';
 import 'core/theme/app_colors.dart';
 import 'features/auth/auth_viewmodel.dart';
@@ -52,21 +59,45 @@ Future<void> main() async {
       androidNotificationOngoing: true,
     ),
   );
+
+  // 앱 전역에서 공유되는 인증 인프라 인스턴스
+  // AuthInterceptor가 401 갱신 실패 이벤트를 Stream으로 push하고,
+  // AuthViewModel이 구독하여 로그아웃 처리함 (순환 참조 없음)
+  final authStorageService = AuthStorageService();
+  final authEventController = StreamController<AuthEvent>.broadcast();
+  final sharedApiClient = ApiClient(
+    storageService: authStorageService,
+    authEventController: authEventController,
+  );
+
   runApp(
     MultiProvider(
       providers: [
+        Provider<ApiClient>(create: (_) => sharedApiClient),
         ChangeNotifierProvider(
           create: (_) => HearitPlayerController(
             audioHandler: audioHandler,
-            libraryRepository: LibraryRepository(),
+            libraryRepository: LibraryRepository(apiClient: sharedApiClient),
           ),
         ),
-        ChangeNotifierProvider(create: (_) => AuthViewModel()),
+        ChangeNotifierProvider(
+          create: (_) => AuthViewModel(
+            storageService: authStorageService,
+            authEventController: authEventController,
+            repository: AuthRepository(apiClient: sharedApiClient),
+          ),
+        ),
         ChangeNotifierProxyProvider<AuthViewModel, SettingViewModel>(
-          create: (context) =>
-              SettingViewModel(authViewModel: context.read<AuthViewModel>()),
+          create: (context) => SettingViewModel(
+            authViewModel: context.read<AuthViewModel>(),
+            repository: SettingRepository(apiClient: sharedApiClient),
+          ),
           update: (context, authViewModel, previous) =>
-              previous ?? SettingViewModel(authViewModel: authViewModel),
+              previous ??
+              SettingViewModel(
+                authViewModel: authViewModel,
+                repository: SettingRepository(apiClient: sharedApiClient),
+              ),
         ),
       ],
       child: const MyApp(),


### PR DESCRIPTION
## 📌 변경 내용 & 이유

- **문제**: accessToken 만료 시 refreshToken이 있어도 갱신 시도 없이 바로 로그아웃 처리되어 로그인 유지가 안 되는 문제
- `POST /api/v1/auth/token/refresh` API를 활용한 자동 토큰 갱신 로직 추가

### 변경 사항

- **`auth_event.dart` (신규)**: 인터셉터 → ViewModel 간 통신용 `AuthEvent` enum 추가
- **`auth_interceptor.dart` (신규)**: 앱 사용 중 API 호출 시 401 응답을 감지해 자동으로 토큰 갱신 후 원래 요청 재시도. 갱신 실패 시 Stream 이벤트 push
- **`api_client.dart`**: `AuthInterceptor` 등록을 위한 `storageService`, `authEventController` 파라미터 추가
- **`auth_repository.dart`**: `refreshAccessToken()` 메서드 추가
- **`auth_viewmodel.dart`**: 앱 시작 시 `checkAuthStatus()`에서 accessToken 만료 시 refresh 시도 로직 추가. `StreamController` 소유 및 Stream 구독으로 갱신 실패 이벤트 처리

### 순환 참조 해결

`AuthInterceptor`가 `AuthViewModel`을 직접 참조하면 순환 import 발생.
`AuthViewModel`이 `StreamController<AuthEvent>`를 소유하고 인터셉터에 주입하는 방식으로 해결.
인터셉터는 ViewModel을 전혀 모르고 Stream에 이벤트만 push.

```
AuthInterceptor → Stream<AuthEvent> ← AuthViewModel 구독
```

## 🧪 테스트 방법

1. 로그인 후 accessToken을 강제 만료 (서버 측 만료 또는 SecureStorage에서 토큰 변조)
2. 앱 재시작 → 로그인 화면이 아닌 메인 화면으로 진입되면 정상
3. 앱 사용 중 accessToken 만료 상태에서 API 요청 → 자동 갱신 후 정상 응답 확인

## 📢 논의하고 싶은 내용

- 현재 동시에 여러 요청이 401을 받을 경우 `_isRefreshing` 플래그로 첫 번째 요청만 refresh 시도하고 나머지는 401 에러를 그대로 전달하는 방식으로 처리했습니다. 앱 규모상 허용 가능한 수준으로 판단했는데, 더 엄밀한 큐잉 처리가 필요한지 의견 부탁드립니다.
- 백엔드 refresh API 응답에 새 refreshToken이 포함되지 않아 기존 refreshToken을 계속 사용합니다. 서버 정책 변경 시 별도 대응 필요합니다.

## 🧩 관련 이슈

close #855

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Automatic session renewal: Sessions now remain seamless when authentication expires; the app refreshes credentials in the background to keep you logged in without interruption.

* **Chores**
  - Internal infrastructure improvements for enhanced authentication reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->