### PR TITLE
[BE] 검색어 자동완성 API 구현 #836

### DIFF
--- a/backend/app/src/main/java/com/onair/hearit/app/search/application/HearitSearchService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/search/application/HearitSearchService.java
@@ -3,24 +3,13 @@ package com.onair.hearit.app.search.application;
 import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.search.dto.HearitSearchResponse;
+import com.onair.hearit.app.search.dto.SearchAutocompleteResponse;
 import com.onair.hearit.app.search.dto.SearchSortRequest;
-import com.onair.hearit.core.domain.Hearit;
-import com.onair.hearit.core.domain.HearitKeyword;
-import com.onair.hearit.core.domain.Keyword;
-import com.onair.hearit.core.domain.PlayingHistory;
-import com.onair.hearit.core.domain.UserInfo;
+import com.onair.hearit.core.domain.*;
 import com.onair.hearit.core.infrastructure.elasticsearch.repository.HearitElasticSearchRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -29,6 +18,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -107,5 +100,11 @@ public class HearitSearchService {
                 .filter(Objects::nonNull)
                 .toList();
         return new PageImpl<>(sortedHearits, pageable, searchedHearitIds.getTotalElements());
+    }
+
+    @Transactional(readOnly = true)
+    public SearchAutocompleteResponse getAutocomplete(String searchTerm, int size) {
+        List<String> autocompletes = hearitElasticSearchRepository.autocomplete(searchTerm, size);
+        return new SearchAutocompleteResponse(autocompletes);
     }
 }

--- a/backend/app/src/main/java/com/onair/hearit/app/search/application/HearitSearchService.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/search/application/HearitSearchService.java
@@ -5,11 +5,23 @@ import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.search.dto.HearitSearchResponse;
 import com.onair.hearit.app.search.dto.SearchAutocompleteResponse;
 import com.onair.hearit.app.search.dto.SearchSortRequest;
-import com.onair.hearit.core.domain.*;
+import com.onair.hearit.core.domain.Hearit;
+import com.onair.hearit.core.domain.HearitKeyword;
+import com.onair.hearit.core.domain.Keyword;
+import com.onair.hearit.core.domain.PlayingHistory;
+import com.onair.hearit.core.domain.UserInfo;
 import com.onair.hearit.core.infrastructure.elasticsearch.repository.HearitElasticSearchRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitKeywordRepository;
 import com.onair.hearit.core.infrastructure.jpa.HearitRepository;
 import com.onair.hearit.core.infrastructure.jpa.PlayingHistoryRepository;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,10 +30,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -102,7 +110,6 @@ public class HearitSearchService {
         return new PageImpl<>(sortedHearits, pageable, searchedHearitIds.getTotalElements());
     }
 
-    @Transactional(readOnly = true)
     public SearchAutocompleteResponse getAutocomplete(String searchTerm, int size) {
         List<String> autocompletes = hearitElasticSearchRepository.autocomplete(searchTerm, size);
         return new SearchAutocompleteResponse(autocompletes);

--- a/backend/app/src/main/java/com/onair/hearit/app/search/dto/SearchAutocompleteRequest.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/search/dto/SearchAutocompleteRequest.java
@@ -1,0 +1,16 @@
+package com.onair.hearit.app.search.dto;
+
+import org.hibernate.validator.constraints.Range;
+
+public record SearchAutocompleteRequest(
+        String searchTerm,
+        @Range(min = 1, max = 30, message = "자동완성 요청 사이즈는 1에서 30 사이여야 합니다.")
+        Integer size
+) {
+
+    public SearchAutocompleteRequest {
+        if (size == null) {
+            size = 5;
+        }
+    }
+}

--- a/backend/app/src/main/java/com/onair/hearit/app/search/dto/SearchAutocompleteRequest.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/search/dto/SearchAutocompleteRequest.java
@@ -1,8 +1,12 @@
 package com.onair.hearit.app.search.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.Range;
 
 public record SearchAutocompleteRequest(
+        @NotBlank(message = "검색어는 필수입니다.")
+        @Size(max = 50, message = "검색어는 50자 이하여야 합니다.")
         String searchTerm,
         @Range(min = 1, max = 30, message = "자동완성 요청 사이즈는 1에서 30 사이여야 합니다.")
         Integer size

--- a/backend/app/src/main/java/com/onair/hearit/app/search/dto/SearchAutocompleteResponse.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/search/dto/SearchAutocompleteResponse.java
@@ -1,0 +1,8 @@
+package com.onair.hearit.app.search.dto;
+
+import java.util.List;
+
+public record SearchAutocompleteResponse(
+        List<String> autocompletes
+) {
+}

--- a/backend/app/src/main/java/com/onair/hearit/app/search/presentation/HearitSearchController.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/search/presentation/HearitSearchController.java
@@ -50,7 +50,7 @@ public class HearitSearchController {
     @GetMapping("/api/v1/hearits/search/autocomplete")
     public ResponseEntity<SearchAutocompleteResponse> readSearchedAutocomplete(
             @Valid SearchAutocompleteRequest request) {
-        SearchAutocompleteResponse response = hearitSearchService.getAutocomplete(request.searchTerm(), request.size());
+        SearchAutocompleteResponse response = hearitSearchService.getAutocomplete(request.searchTerm().trim(), request.size());
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/app/src/main/java/com/onair/hearit/app/search/presentation/HearitSearchController.java
+++ b/backend/app/src/main/java/com/onair/hearit/app/search/presentation/HearitSearchController.java
@@ -5,7 +5,10 @@ import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.search.application.HearitSearchService;
 import com.onair.hearit.app.search.dto.HearitSearchResponse;
+import com.onair.hearit.app.search.dto.SearchAutocompleteRequest;
+import com.onair.hearit.app.search.dto.SearchAutocompleteResponse;
 import com.onair.hearit.app.search.dto.SearchSortRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -41,6 +44,13 @@ public class HearitSearchController {
         PagingRequest pagingRequest = new PagingRequest(page, size);
         PagedResponse<HearitSearchResponse> response =
                 hearitSearchService.searchV2(searchTerm, sortRequest, pagingRequest, requestUser.getUserInfo());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/v1/hearits/search/autocomplete")
+    public ResponseEntity<SearchAutocompleteResponse> readSearchedAutocomplete(
+            @Valid SearchAutocompleteRequest request) {
+        SearchAutocompleteResponse response = hearitSearchService.getAutocomplete(request.searchTerm(), request.size());
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/app/src/test/java/com/onair/hearit/app/search/application/HearitSearchServiceTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/search/application/HearitSearchServiceTest.java
@@ -3,6 +3,7 @@ package com.onair.hearit.app.search.application;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -12,6 +13,7 @@ import com.onair.hearit.app.common.dto.request.PagingRequest;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.fixture.DbHelper;
 import com.onair.hearit.app.search.dto.HearitSearchResponse;
+import com.onair.hearit.app.search.dto.SearchAutocompleteResponse;
 import com.onair.hearit.app.search.dto.SearchSortRequest;
 import com.onair.hearit.core.config.DataSourceConfig;
 import com.onair.hearit.core.domain.Category;
@@ -323,6 +325,34 @@ class HearitSearchServiceTest {
                 () -> assertThat(hearitSearchResponse.lastPlayTime()).isEqualTo(playingHistory.getLastPlayTime()),
                 () -> assertThat(hearitSearchResponse.isFinished()).isEqualTo(playingHistory.isFinished())
         );
+    }
+
+    @Test
+    @DisplayName("자동완성 조회 시 ElasticSearch가 반환한 결과를 그대로 반환한다.")
+    void getAutocomplete_returnsResultFromElasticSearch() {
+        // given
+        when(hearitElasticSearchRepository.autocomplete("spring", 5))
+                .thenReturn(List.of("Spring", "Spring Boot"));
+
+        // when
+        SearchAutocompleteResponse result = hearitSearchService.getAutocomplete("spring", 5);
+
+        // then
+        assertThat(result.autocompletes()).containsExactly("Spring", "Spring Boot");
+    }
+
+    @Test
+    @DisplayName("자동완성 조회 시 검색어와 size를 ElasticSearch에 그대로 전달한다.")
+    void getAutocomplete_passesSearchTermAndSizeToRepository() {
+        // given
+        when(hearitElasticSearchRepository.autocomplete(anyString(), anyInt()))
+                .thenReturn(List.of());
+
+        // when
+        hearitSearchService.getAutocomplete("spring", 3);
+
+        // then
+        verify(hearitElasticSearchRepository).autocomplete("spring", 3);
     }
 
     private Hearit saveHearitWithTitleAndKeyword(String title, Keyword keyword) {

--- a/backend/app/src/test/java/com/onair/hearit/app/search/presentation/HearitSearchControllerTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/search/presentation/HearitSearchControllerTest.java
@@ -4,6 +4,7 @@ import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.docume
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -16,6 +17,7 @@ import com.onair.hearit.app.fixture.ControllerTest;
 import com.onair.hearit.app.search.application.HearitSearchService;
 import com.onair.hearit.app.search.dto.HearitSearchResponse;
 import com.onair.hearit.app.search.dto.HearitSearchResponse.KeywordResponse;
+import com.onair.hearit.app.search.dto.SearchAutocompleteResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -173,6 +175,56 @@ public class HearitSearchControllerTest extends ControllerTest {
                                         ).toArray(FieldDescriptor[]::new)
                                 )
                                 .build())));
+    }
+
+    @Test
+    @DisplayName("자동완성 검색 - 200 OK")
+    void readSearchedAutocomplete_OK() throws Exception {
+        // given
+        given(hearitSearchService.getAutocomplete(any(), anyInt()))
+                .willReturn(new SearchAutocompleteResponse(List.of("Spring", "Spring Boot")));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/hearits/search/autocomplete")
+                        .param("searchTerm", "spring")
+                        .param("size", "2"))
+                .andExpect(status().isOk())
+                .andDo(document("v1-get-hearits-search-autocomplete-ok",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Search API")
+                                .summary("자동완성 검색")
+                                .description("검색어에 대한 자동완성 결과를 반환합니다.")
+                                .queryParameters(
+                                        parameterWithName("searchTerm").description("검색어"),
+                                        parameterWithName("size").description("자동완성 결과 수 (1~30, 기본 5)").defaultValue("5")
+                                )
+                                .responseFields(
+                                        fieldWithPath("autocompletes").description("자동완성 결과 목록")
+                                )
+                                .build())));
+    }
+
+    @Test
+    @DisplayName("자동완성 검색 - 400 Bad Request")
+    void readSearchedAutocomplete_BadRequest() throws Exception {
+        // size below min (1)
+        mockMvc.perform(get("/api/v1/hearits/search/autocomplete")
+                        .param("searchTerm", "spring")
+                        .param("size", "0"))
+                .andExpect(status().isBadRequest())
+                .andDo(document("v1-get-hearits-search-autocomplete-bad-request",
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("Search API")
+                                .summary("자동완성 검색")
+                                .responseFields(
+                                        com.onair.hearit.fixture.ApiDocSnippets.getProblemDetailResponseFields())
+                                .build())));
+
+        // size above max (30)
+        mockMvc.perform(get("/api/v1/hearits/search/autocomplete")
+                        .param("searchTerm", "spring")
+                        .param("size", "31"))
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/backend/app/src/test/java/com/onair/hearit/app/search/presentation/HearitSearchIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/search/presentation/HearitSearchIntegrationTest.java
@@ -234,6 +234,46 @@ public class HearitSearchIntegrationTest extends IntegrationTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
+    @Test
+    @DisplayName("자동완성 searchTerm 파라미터가 유효하지 않을 때 400 에러를 반환한다.")
+    void readAutocompleteWithInvalidSearchTerm() {
+        // searchTerm 누락
+        RestAssured.given(this.spec)
+                .queryParam("size", 5)
+                .when()
+                .get("/api/v1/hearits/search/autocomplete")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+
+        // searchTerm 빈 문자열
+        RestAssured.given(this.spec)
+                .queryParam("searchTerm", "")
+                .queryParam("size", 5)
+                .when()
+                .get("/api/v1/hearits/search/autocomplete")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+
+        // searchTerm 공백만 포함
+        RestAssured.given(this.spec)
+                .queryParam("searchTerm", "   ")
+                .queryParam("size", 5)
+                .when()
+                .get("/api/v1/hearits/search/autocomplete")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+
+        // searchTerm 길이 초과 (51자)
+        String tooLong = "a".repeat(51);
+        RestAssured.given(this.spec)
+                .queryParam("searchTerm", tooLong)
+                .queryParam("size", 5)
+                .when()
+                .get("/api/v1/hearits/search/autocomplete")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
     private String generateToken(Member member) {
         return jwtTokenProvider.createAccessToken(member.getUuid());
     }

--- a/backend/app/src/test/java/com/onair/hearit/app/search/presentation/HearitSearchIntegrationTest.java
+++ b/backend/app/src/test/java/com/onair/hearit/app/search/presentation/HearitSearchIntegrationTest.java
@@ -3,12 +3,14 @@ package com.onair.hearit.app.search.presentation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 
 import com.onair.hearit.app.auth.infrastructure.jwt.JwtTokenProvider;
 import com.onair.hearit.app.common.dto.response.PagedResponse;
 import com.onair.hearit.app.fixture.IntegrationTest;
 import com.onair.hearit.app.search.dto.HearitSearchResponse;
+import com.onair.hearit.app.search.dto.SearchAutocompleteResponse;
 import com.onair.hearit.core.domain.Category;
 import com.onair.hearit.core.domain.Hearit;
 import com.onair.hearit.core.domain.HearitKeyword;
@@ -184,6 +186,50 @@ public class HearitSearchIntegrationTest extends IntegrationTest {
                 .queryParam("size", -1)
                 .when()
                 .get("/api/v2/hearits/search")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("자동완성 요청 시 200 OK 및 자동완성 결과를 반환한다.")
+    void readAutocomplete() {
+        // given
+        Mockito.when(hearitElasticSearchRepository.autocomplete(anyString(), anyInt()))
+                .thenReturn(List.of("Spring", "Spring Boot"));
+
+        // when
+        SearchAutocompleteResponse response = RestAssured.given(this.spec)
+                .queryParam("searchTerm", "spring")
+                .queryParam("size", 2)
+                .when()
+                .get("/api/v1/hearits/search/autocomplete")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(SearchAutocompleteResponse.class);
+
+        // then
+        assertThat(response.autocompletes()).containsExactly("Spring", "Spring Boot");
+    }
+
+    @Test
+    @DisplayName("자동완성 size 파라미터가 유효하지 않을 때 400 에러를 반환한다.")
+    void readAutocompleteWithInvalidParams() {
+        // size below min (1)
+        RestAssured.given(this.spec)
+                .queryParam("searchTerm", "spring")
+                .queryParam("size", 0)
+                .when()
+                .get("/api/v1/hearits/search/autocomplete")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+
+        // size above max (30)
+        RestAssured.given(this.spec)
+                .queryParam("searchTerm", "spring")
+                .queryParam("size", 31)
+                .when()
+                .get("/api/v1/hearits/search/autocomplete")
                 .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
     }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepository.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepository.java
@@ -1,13 +1,16 @@
 package com.onair.hearit.core.infrastructure.elasticsearch.repository;
 
 import com.onair.hearit.core.infrastructure.elasticsearch.domain.HearitSearchSortField;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface HearitSearchRepository {
 
     Page<Long> search(String query, HearitSearchSortField sortField, Pageable pageable);
 
     List<Long> findAllIds();
+
+    List<String> autocomplete(String searchTerm, int size);
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepositoryImpl.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepositoryImpl.java
@@ -16,10 +16,7 @@ import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
-import org.springframework.data.elasticsearch.core.query.HighlightQuery;
 import org.springframework.data.elasticsearch.core.query.Query;
-import org.springframework.data.elasticsearch.core.query.highlight.Highlight;
-import org.springframework.data.elasticsearch.core.query.highlight.HighlightField;
 
 import java.util.List;
 import java.util.Objects;
@@ -123,7 +120,7 @@ public class HearitSearchRepositoryImpl implements HearitSearchRepository {
         return operations.search(buildAutocompleteQuery(searchTerm, size), HearitDocument.class)
                 .getSearchHits()
                 .stream()
-                .flatMap(hit -> extractMatches(hit, lowerSearchTerm))
+                .flatMap(hit -> extractMatches(hit.getContent(), lowerSearchTerm))
                 .distinct()
                 .limit(size)
                 .toList();
@@ -149,17 +146,15 @@ public class HearitSearchRepositoryImpl implements HearitSearchRepository {
                         )
                 )
                 .withSourceFilter(new FetchSourceFilter(true, new String[]{"title", "keywords", "category"}, new String[]{}))
-                .withHighlightQuery(new HighlightQuery(new Highlight(List.of(new HighlightField("title"))), HearitDocument.class))
                 .withMaxResults(size)
                 .build();
     }
 
-    private Stream<String> extractMatches(SearchHit<HearitDocument> hit, String lowerSearchTerm) {
-        HearitDocument doc = hit.getContent();
+    private Stream<String> extractMatches(HearitDocument doc, String lowerSearchTerm) {
         return Stream.of(
                 matchCategory(doc, lowerSearchTerm),
-                matchTitle(hit, doc, lowerSearchTerm),
-                matchKeyword(doc, lowerSearchTerm)
+                matchKeyword(doc, lowerSearchTerm),
+                matchTitle(doc, lowerSearchTerm)
         ).filter(Objects::nonNull);
     }
 
@@ -167,15 +162,8 @@ public class HearitSearchRepositoryImpl implements HearitSearchRepository {
         return doc.getCategory().toLowerCase().startsWith(lowerSearchTerm) ? doc.getCategory() : null;
     }
 
-    private String matchTitle(SearchHit<HearitDocument> hit, HearitDocument doc, String lowerSearchTerm) {
-        String titleSource = hit.getHighlightField("title").stream().findFirst().orElse(doc.getTitle());
-        String[] words = titleSource.split(" ");
-        for (int i = 0; i < words.length; i++) {
-            if (words[i].toLowerCase().contains(lowerSearchTerm)) {
-                return i + 1 < words.length ? words[i] + " " + words[i + 1] : words[i];
-            }
-        }
-        return null;
+    private String matchTitle(HearitDocument doc, String lowerSearchTerm) {
+        return doc.getTitle().toLowerCase().contains(lowerSearchTerm) ? doc.getTitle() : null;
     }
 
     private String matchKeyword(HearitDocument doc, String lowerSearchTerm) {

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepositoryImpl.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepositoryImpl.java
@@ -4,8 +4,8 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
 import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
 import com.onair.hearit.core.infrastructure.elasticsearch.domain.HearitDocument;
 import com.onair.hearit.core.infrastructure.elasticsearch.domain.HearitSearchSortField;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -16,7 +16,16 @@ import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
+import org.springframework.data.elasticsearch.core.query.HighlightQuery;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.core.query.highlight.Highlight;
+import org.springframework.data.elasticsearch.core.query.highlight.HighlightField;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+@Slf4j
 @RequiredArgsConstructor
 public class HearitSearchRepositoryImpl implements HearitSearchRepository {
 
@@ -94,7 +103,7 @@ public class HearitSearchRepositoryImpl implements HearitSearchRepository {
                 .toList();
         return new PageImpl<>(ids, pageable, searchResults.getTotalHits());
     }
-    
+
     public List<Long> findAllIds() {
         NativeQuery query = NativeQuery.builder()
                 .withSourceFilter(new FetchSourceFilter(true, new String[]{"id"}, null))
@@ -106,5 +115,73 @@ public class HearitSearchRepositoryImpl implements HearitSearchRepository {
                 .map(SearchHit::getContent)
                 .map(HearitDocument::getId)
                 .toList();
+    }
+
+    @Override
+    public List<String> autocomplete(String searchTerm, int size) {
+        String lowerSearchTerm = searchTerm.toLowerCase();
+        return operations.search(buildAutocompleteQuery(searchTerm, size), HearitDocument.class)
+                .getSearchHits()
+                .stream()
+                .flatMap(hit -> extractMatches(hit, lowerSearchTerm))
+                .distinct()
+                .limit(size)
+                .toList();
+    }
+
+    private Query buildAutocompleteQuery(String searchTerm, int size) {
+        return NativeQuery.builder()
+                .withQuery(q -> q
+                        .multiMatch(m -> m
+                                .query(searchTerm)
+                                .type(TextQueryType.BoolPrefix)
+                                .fields(
+                                        "title.autocomplete",
+                                        "title.autocomplete._2gram",
+                                        "title.autocomplete._3gram",
+                                        "keywords.autocomplete",
+                                        "keywords.autocomplete._2gram",
+                                        "keywords.autocomplete._3gram",
+                                        "category.autocomplete",
+                                        "category.autocomplete._2gram",
+                                        "category.autocomplete._3gram"
+                                )
+                        )
+                )
+                .withSourceFilter(new FetchSourceFilter(true, new String[]{"title", "keywords", "category"}, new String[]{}))
+                .withHighlightQuery(new HighlightQuery(new Highlight(List.of(new HighlightField("title"))), HearitDocument.class))
+                .withMaxResults(size)
+                .build();
+    }
+
+    private Stream<String> extractMatches(SearchHit<HearitDocument> hit, String lowerSearchTerm) {
+        HearitDocument doc = hit.getContent();
+        return Stream.of(
+                matchCategory(doc, lowerSearchTerm),
+                matchTitle(hit, doc, lowerSearchTerm),
+                matchKeyword(doc, lowerSearchTerm)
+        ).filter(Objects::nonNull);
+    }
+
+    private String matchCategory(HearitDocument doc, String lowerSearchTerm) {
+        return doc.getCategory().toLowerCase().startsWith(lowerSearchTerm) ? doc.getCategory() : null;
+    }
+
+    private String matchTitle(SearchHit<HearitDocument> hit, HearitDocument doc, String lowerSearchTerm) {
+        String titleSource = hit.getHighlightField("title").stream().findFirst().orElse(doc.getTitle());
+        String[] words = titleSource.split(" ");
+        for (int i = 0; i < words.length; i++) {
+            if (words[i].toLowerCase().contains(lowerSearchTerm)) {
+                return i + 1 < words.length ? words[i] + " " + words[i + 1] : words[i];
+            }
+        }
+        return null;
+    }
+
+    private String matchKeyword(HearitDocument doc, String lowerSearchTerm) {
+        return doc.getKeywords().stream()
+                .filter(k -> k.toLowerCase().startsWith(lowerSearchTerm))
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/backend/core/src/main/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepositoryImpl.java
+++ b/backend/core/src/main/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepositoryImpl.java
@@ -5,7 +5,6 @@ import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
 import com.onair.hearit.core.infrastructure.elasticsearch.domain.HearitDocument;
 import com.onair.hearit.core.infrastructure.elasticsearch.domain.HearitSearchSortField;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -22,7 +21,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-@Slf4j
 @RequiredArgsConstructor
 public class HearitSearchRepositoryImpl implements HearitSearchRepository {
 

--- a/backend/core/src/main/resources/elasticsearch/hearits-mapping.json
+++ b/backend/core/src/main/resources/elasticsearch/hearits-mapping.json
@@ -11,7 +11,7 @@
         },
         "autocomplete": {
           "type": "search_as_you_type",
-          "analyzer": "korean_index_analyzer",
+          "analyzer": "korean_autocomplete_analyzer",
           "search_analyzer": "korean_autocomplete_analyzer"
         }
       }
@@ -31,7 +31,7 @@
         },
         "autocomplete": {
           "type": "search_as_you_type",
-          "analyzer": "korean_index_analyzer",
+          "analyzer": "korean_autocomplete_analyzer",
           "search_analyzer": "korean_autocomplete_analyzer"
         }
       }

--- a/backend/core/src/main/resources/elasticsearch/hearits-mapping.json
+++ b/backend/core/src/main/resources/elasticsearch/hearits-mapping.json
@@ -8,6 +8,11 @@
         "keyword": {
           "type": "keyword",
           "ignore_above": 256
+        },
+        "autocomplete": {
+          "type": "search_as_you_type",
+          "analyzer": "korean_index_analyzer",
+          "search_analyzer": "korean_autocomplete_analyzer"
         }
       }
     },
@@ -23,6 +28,11 @@
           "type": "text",
           "analyzer": "korean_index_analyzer",
           "search_analyzer": "korean_search_analyzer"
+        },
+        "autocomplete": {
+          "type": "search_as_you_type",
+          "analyzer": "korean_index_analyzer",
+          "search_analyzer": "korean_autocomplete_analyzer"
         }
       }
     },
@@ -31,6 +41,10 @@
       "fields": {
         "text": {
           "type": "text",
+          "analyzer": "standard"
+        },
+        "autocomplete": {
+          "type": "search_as_you_type",
           "analyzer": "standard"
         }
       }

--- a/backend/core/src/main/resources/elasticsearch/hearits-setting.json
+++ b/backend/core/src/main/resources/elasticsearch/hearits-setting.json
@@ -1,4 +1,14 @@
 {
+  "index": {
+    "similarity": {
+      "default": {
+        "type": "BM25",
+        "b": 0.75,
+        "k1": 1.2,
+        "discount_overlaps": false
+      }
+    }
+  },
   "analysis": {
     "tokenizer": {
       "nori_mixed_tokenizer": {
@@ -56,6 +66,15 @@
         "filter": [
           "lowercase",
           "ko_synonym",
+          "nori_pos_filter",
+          "ko_stop"
+        ]
+      },
+      "korean_autocomplete_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_mixed_tokenizer",
+        "filter": [
+          "lowercase",
           "nori_pos_filter",
           "ko_stop"
         ]

--- a/backend/core/src/main/resources/elasticsearch/hearits-setting.json
+++ b/backend/core/src/main/resources/elasticsearch/hearits-setting.json
@@ -15,6 +15,11 @@
         "type": "nori_tokenizer",
         "decompound_mode": "mixed",
         "user_dictionary": "analysis/userdict_ko.txt"
+      },
+      "nori_autocomplete_tokenizer": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "discard",
+        "user_dictionary": "analysis/userdict_ko.txt"
       }
     },
     "filter": {
@@ -72,10 +77,9 @@
       },
       "korean_autocomplete_analyzer": {
         "type": "custom",
-        "tokenizer": "nori_mixed_tokenizer",
+        "tokenizer": "nori_autocomplete_tokenizer",
         "filter": [
           "lowercase",
-          "nori_pos_filter",
           "ko_stop"
         ]
       }

--- a/backend/core/src/test/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepositoryTest.java
+++ b/backend/core/src/test/java/com/onair/hearit/core/infrastructure/elasticsearch/repository/HearitSearchRepositoryTest.java
@@ -648,6 +648,65 @@ class HearitSearchRepositoryTest extends ElasticSearchTestContainer {
         }
     }
 
+    @Nested
+    @DisplayName("자동완성 테스트")
+    class AutocompleteTest {
+
+        @Test
+        @DisplayName("검색어로 시작하는 키워드가 자동완성 결과에 포함된다")
+        void autocomplete_matchesKeyword() {
+            // "스프링" 키워드를 가진 문서(1, 2)에서 "스프"로 시작하는 키워드 반환
+            List<String> result = repository.autocomplete("스프", 10);
+
+            assertThat(result).contains("스프링");
+        }
+
+        @Test
+        @DisplayName("검색어로 시작하는 카테고리가 자동완성 결과에 포함된다")
+        void autocomplete_matchesCategory() {
+            // "개발" 카테고리를 가진 문서(1, 2, 10)에서 "개"로 시작하는 카테고리 반환
+            List<String> result = repository.autocomplete("개", 10);
+
+            assertThat(result).contains("개발");
+        }
+
+        @Test
+        @DisplayName("검색어를 포함하는 제목 단어가 자동완성 결과에 포함된다")
+        void autocomplete_matchesTitle() {
+            // "자바 스프링 입문 가이드"(doc 2) 제목에서 "자바" 단어 매칭
+            List<String> result = repository.autocomplete("자바", 10);
+
+            assertThat(result).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("동일한 자동완성 결과는 중복 없이 한 번만 반환된다")
+        void autocomplete_returnsDistinctResults() {
+            // "스프링" 키워드를 가진 문서(1, 2)가 여러 개이지만 "스프링"은 한 번만 등장
+            List<String> result = repository.autocomplete("스프", 10);
+
+            long count = result.stream().filter("스프링"::equals).count();
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("size 파라미터 이하의 자동완성 결과를 반환한다")
+        void autocomplete_respectsSizeLimit() {
+            // "스프" 검색 시 여러 결과가 매칭되지만 size=1이면 최대 1개만 반환
+            List<String> result = repository.autocomplete("스프", 1);
+
+            assertThat(result).hasSizeLessThanOrEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("매칭되는 문서가 없으면 빈 리스트를 반환한다")
+        void autocomplete_returnsEmptyListWhenNoMatch() {
+            List<String> result = repository.autocomplete("존재하지않는검색어12345", 10);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
     @Test
     @DisplayName("전체 List의 Id만 조회한다.")
     void findAllIds() {


### PR DESCRIPTION
<!-- PR 제목 예시
ex. [BE] 로그인 API 구현
ex. [AN] 페이지 구현 -->

## 📌 변경 내용 & 이유
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

검색어 자동완성 구현
- prefix 기준 일치하는 카테고리, 키워드, 제목 순으로 반환



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 검색 자동완성이 추가되었습니다. 제목·키워드·카테고리를 바탕으로 관련 제안을 실시간 제공하며 중복을 제거하고 최대 30개까지 요청 가능합니다. 기본 요청 크기는 5로 동작합니다.
  * 새 REST 엔드포인트로 쿼리와 크기 파라미터를 전달해 결과를 조회할 수 있습니다.
* **테스트**
  * 서비스·컨트롤러·통합·저장소 레벨의 자동완성 관련 단위 및 통합 테스트가 추가되어 동작과 검증을 보장합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-hEARit/pull/864)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->